### PR TITLE
III-5031 Update phpunit to v9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ external_id_mapping_place.yml
 term_mapping_*.yml
 .php_cs.cache
 .env
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
     "icanhazstring/composer-unused": "^0.7.7",
     "mikey179/vfsstream": "~1.6.2",
     "phpstan/phpstan": "^1.8",
-    "phpunit/phpunit": "^8.5",
+    "phpunit/phpunit": "^9.5",
     "publiq/php-cs-fixer-config": "^1.3",
     "rector/rector": "^0.14.5"
   },

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
     "icanhazstring/composer-unused": "^0.7.7",
     "mikey179/vfsstream": "~1.6.2",
     "phpstan/phpstan": "^1.8",
-    "phpunit/phpunit": "^7.5",
+    "phpunit/phpunit": "^8.5",
     "publiq/php-cs-fixer-config": "^1.3",
     "rector/rector": "^0.14.5"
   },

--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,8 @@
       "composer cs"
     ],
     "cs": "php-cs-fixer fix -v --diff --dry-run",
-    "cs-fix": "php-cs-fixer fix -v --diff"
+    "cs-fix": "php-cs-fixer fix -v --diff",
+    "rector": "vendor/bin/rector process --dry-run",
+    "rector-fix": "vendor/bin/rector process"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,8 @@
     "mikey179/vfsstream": "~1.6.2",
     "phpstan/phpstan": "^1.8",
     "phpunit/phpunit": "^7.5",
-    "publiq/php-cs-fixer-config": "^1.3"
+    "publiq/php-cs-fixer-config": "^1.3",
+    "rector/rector": "^0.14.5"
   },
   "prefer-stable": true,
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3d92ce07458e2d2a49b7dcab25a78c7",
+    "content-hash": "e4f4d1a9f6dc12eb47c06875ee1dde75",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -9030,40 +9030,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.4",
+            "version": "7.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+                "reference": "bb7c9a210c72e4709cdde67f8b7362f672f2225c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bb7c9a210c72e4709cdde67f8b7362f672f2225c",
+                "reference": "bb7c9a210c72e4709cdde67f8b7362f672f2225c",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^2.0",
+                "php": ">=7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
+                "phpunit/php-token-stream": "^3.1.1 || ^4.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -9089,7 +9089,17 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-31T16:06:48+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.14"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-02T13:39:03+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -9301,45 +9311,44 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.20",
+            "version": "8.5.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+                "reference": "3123601e3b29339b20129acc3f989cfec3274566"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3123601e3b29339b20129acc3f989cfec3274566",
+                "reference": "3123601e3b29339b20129acc3f989cfec3274566",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.1",
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.7",
-                "phar-io/manifest": "^1.0.2",
-                "phar-io/version": "^2.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.7",
-                "phpunit/php-file-iterator": "^2.0.1",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.0",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.10.3",
+                "phpunit/php-code-coverage": "^7.0.12",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1",
-                "sebastian/comparator": "^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^4.0",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.3",
+                "sebastian/exporter": "^3.1.2",
+                "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
                 "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
@@ -9347,7 +9356,7 @@
             "suggest": {
                 "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -9355,7 +9364,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.5-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -9381,7 +9390,21 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-01-08T08:45:45+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.11"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-27T12:46:45+00:00"
         },
         {
             "name": "publiq/php-cs-fixer-config",
@@ -9799,23 +9822,26 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/de036ec91d55d2a9e0db2ba975b512cdb1c23921",
+                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -9823,7 +9849,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -9846,7 +9872,17 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-10T06:55:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -10058,6 +10094,62 @@
                 }
             ],
             "time": "2020-11-30T07:30:19+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/1.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:25:11+00:00"
         },
         {
             "name": "sebastian/version",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4f4d1a9f6dc12eb47c06875ee1dde75",
+    "content-hash": "3293a2249fff2eaced04178fd3865c24",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -7473,30 +7473,35 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.1",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
+                "ext-ctype": "*",
+                "php": "^7.2 || ^8.0"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -7518,7 +7523,11 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-07-08T17:02:28+00:00"
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
+            },
+            "time": "2022-06-03T18:03:27+00:00"
         },
         {
             "name": "willdurand/geocoder",
@@ -8147,29 +8156,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -8194,6 +8204,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -8208,7 +8222,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -8522,12 +8536,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -8541,6 +8555,10 @@
                 "object",
                 "object graph"
             ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
@@ -8551,16 +8569,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.1",
+            "version": "v4.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd"
+                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/63a79e8daa781cac14e5195e63ed8ae231dd10fd",
-                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
+                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
                 "shasum": ""
             },
             "require": {
@@ -8601,34 +8619,35 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.1"
             },
-            "time": "2021-11-03T20:52:16+00:00"
+            "time": "2022-09-04T07:30:47+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.3",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^2.0",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -8658,24 +8677,28 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2018-07-08T19:23:20+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "2.0.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -8705,7 +8728,11 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2018-07-08T19:19:57+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -8757,217 +8784,6 @@
                 "diff"
             ],
             "time": "2020-10-14T08:39:05+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
-                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2020-04-27T09:25:28+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
-                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "doctrine/instantiator": "^1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpdocumentor/type-resolver": "0.4.*",
-                "phpunit/phpunit": "^6.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-12-28T18:55:12+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1",
-                "phpdocumentor/reflection-common": "^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "^7.1",
-                "mockery/mockery": "~1",
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2019-08-22T18:11:29+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "v1.10.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^2.5 || ^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -9030,40 +8846,44 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.14",
+            "version": "9.2.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "bb7c9a210c72e4709cdde67f8b7362f672f2225c"
+                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bb7c9a210c72e4709cdde67f8b7362f672f2225c",
-                "reference": "bb7c9a210c72e4709cdde67f8b7362f672f2225c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa94dc41e8661fe90c7316849907cba3007b10d8",
+                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=7.2",
-                "phpunit/php-file-iterator": "^2.0.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.1.1 || ^4.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^4.2.2",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1.3"
+                "nikic/php-parser": "^4.14",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2.2"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-xdebug": "^2.7.2"
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.0-dev"
+                    "dev-master": "9.2-dev"
                 }
             },
             "autoload": {
@@ -9091,7 +8911,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.14"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.17"
             },
             "funding": [
                 {
@@ -9099,32 +8919,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-12-02T13:39:03+00:00"
+            "time": "2022-08-30T12:24:04+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.3",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -9149,32 +8969,107 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:25:21+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -9196,32 +9091,42 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.3",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
-                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -9245,82 +9150,30 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:20:02+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "3.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "abandoned": true,
-            "time": "2020-11-30T08:38:46+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.11",
+            "version": "9.5.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3123601e3b29339b20129acc3f989cfec3274566"
+                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3123601e3b29339b20129acc3f989cfec3274566",
-                "reference": "3123601e3b29339b20129acc3f989cfec3274566",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
                 "shasum": ""
             },
             "require": {
@@ -9331,32 +9184,30 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.0",
-                "phar-io/manifest": "^1.0.3",
-                "phar-io/version": "^2.0.1",
-                "php": "^7.2",
-                "phpspec/prophecy": "^1.10.3",
-                "phpunit/php-code-coverage": "^7.0.12",
-                "phpunit/php-file-iterator": "^2.0.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1.2",
-                "sebastian/comparator": "^3.0.2",
-                "sebastian/diff": "^3.0.2",
-                "sebastian/environment": "^4.2.3",
-                "sebastian/exporter": "^3.1.2",
-                "sebastian/global-state": "^3.0.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0.1",
-                "sebastian/type": "^1.1.3",
-                "sebastian/version": "^2.0.1"
-            },
-            "require-dev": {
-                "ext-pdo": "*"
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.8",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.5",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^3.2",
+                "sebastian/version": "^3.0.2"
             },
             "suggest": {
                 "ext-soap": "*",
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0.0"
+                "ext-xdebug": "*"
             },
             "bin": [
                 "phpunit"
@@ -9364,10 +9215,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.5-dev"
+                    "dev-master": "9.5-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -9392,19 +9246,23 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.11"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/donate.html",
+                    "url": "https://phpunit.de/sponsors.html",
                     "type": "custom"
                 },
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2020-11-27T12:46:45+00:00"
+            "time": "2022-09-25T03:44:45+00:00"
         },
         {
             "name": "publiq/php-cs-fixer-config",
@@ -9506,29 +9364,141 @@
             "time": "2022-09-29T11:05:42+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.2",
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
-                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -9548,40 +9518,44 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:15:22+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.3",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -9618,39 +9592,100 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:04:30+00:00"
+            "time": "2022-09-14T12:41:17+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "3.0.3",
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -9680,33 +9715,37 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:59:04+00:00"
+            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.4",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
-                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -9714,7 +9753,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -9739,40 +9778,44 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:53:42+00:00"
+            "time": "2022-04-03T09:37:03+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.3",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -9807,41 +9850,45 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:47:53+00:00"
+            "time": "2022-09-14T06:03:37+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "3.0.2",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921"
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/de036ec91d55d2a9e0db2ba975b512cdb1c23921",
-                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -9849,7 +9896,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -9874,7 +9921,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
             },
             "funding": [
                 {
@@ -9882,34 +9929,91 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-10T06:55:38+00:00"
+            "time": "2022-02-14T08:28:10+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.4",
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
-                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -9929,38 +10033,42 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:40:27+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.2",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
-                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -9980,38 +10088,42 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:37:18+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
-                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -10039,35 +10151,42 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:34:24+00:00"
+            "time": "2020-10-26T13:17:30+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "2.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
-                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -10087,38 +10206,42 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:30:19+00:00"
+            "time": "2020-09-28T06:45:17+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "1.1.4",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4"
+                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/0150cfbc4495ed2df3872fb31b26781e4e077eb4",
-                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -10141,7 +10264,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/1.1.4"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
             },
             "funding": [
                 {
@@ -10149,29 +10272,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:25:11+00:00"
+            "time": "2022-09-12T14:47:03+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -10192,7 +10315,17 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -10575,23 +10708,23 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.3",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -10611,7 +10744,17 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-06-13T22:48:21+00:00"
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-28T10:34:58+00:00"
         }
     ],
     "aliases": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae653f9481daa19c9a9db20e672536a6",
+    "content-hash": "d3d92ce07458e2d2a49b7dcab25a78c7",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -9423,6 +9423,64 @@
                 "source": "https://github.com/cultuurnet/php-cs-fixer-config/tree/v1.3.1"
             },
             "time": "2021-02-26T12:16:58+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "0.14.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "f7fd87b2435835f481e6a94ee28e09af412bd3cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/f7fd87b2435835f481e6a94ee28e09af412bd3cc",
+                "reference": "f7fd87b2435835f481e6a94ee28e09af412bd3cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.8.6"
+            },
+            "conflict": {
+                "rector/rector-cakephp": "*",
+                "rector/rector-doctrine": "*",
+                "rector/rector-laravel": "*",
+                "rector/rector-php-parser": "*",
+                "rector/rector-phpoffice": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.14-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/0.14.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-29T11:05:42+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,6 @@ parameters:
 		- tests/bootstrap.php
 	scanFiles:
 		- vendor/gridonic/princexml-php/lib/prince.php
+	excludePaths:
+		- tests/Event/Productions/SimilarEventsRepositoryTest.php
+		- tests/Http/Productions/SuggestProductionRequestHandlerTest.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,11 @@
-<phpunit
-    bootstrap="tests/bootstrap.php">
-    <testsuite name="all">
-        <directory>tests</directory>
-    </testsuite>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuite name="all">
+    <directory>tests</directory>
+  </testsuite>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -16,6 +16,6 @@ return static function (RectorConfig $rectorConfig): void {
     );
 
     $rectorConfig->sets([
-        PHPUnitSetList::PHPUNIT_80,
+        PHPUnitSetList::PHPUNIT_90,
     ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        PHPUnitSetList::PHPUNIT_80,
+    ]);
+};

--- a/rector.php
+++ b/rector.php
@@ -6,6 +6,15 @@ use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths(
+        [
+            __DIR__ . '/app',
+            __DIR__ . '/src',
+            __DIR__ . '/tests',
+            __DIR__ . '/web',
+        ]
+    );
+
     $rectorConfig->sets([
         PHPUnitSetList::PHPUNIT_80,
     ]);

--- a/tests/Address/CultureFeedAddressFactoryTest.php
+++ b/tests/Address/CultureFeedAddressFactoryTest.php
@@ -14,7 +14,7 @@ class CultureFeedAddressFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->factory = new CultureFeedAddressFactory();
     }

--- a/tests/Broadway/AMQP/AMQPPublisherTest.php
+++ b/tests/Broadway/AMQP/AMQPPublisherTest.php
@@ -50,7 +50,7 @@ class AMQPPublisherTest extends TestCase
      */
     private $messageFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->amqpChannel = $this->createMock(AMQPChannel::class);
 

--- a/tests/Broadway/AMQP/CommandBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/CommandBusForwardingConsumerTest.php
@@ -75,7 +75,7 @@ class CommandBusForwardingConsumerTest extends TestCase
     private $deserializer;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connection = $this->createMock(AMQPStreamConnection::class);
 

--- a/tests/Broadway/AMQP/DomainMessage/AnyOfTest.php
+++ b/tests/Broadway/AMQP/DomainMessage/AnyOfTest.php
@@ -18,7 +18,7 @@ class AnyOfTest extends TestCase
      */
     private $anyOf;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $specifications = new SpecificationCollection();
 

--- a/tests/Broadway/AMQP/DomainMessage/PayloadInNamespaceTest.php
+++ b/tests/Broadway/AMQP/DomainMessage/PayloadInNamespaceTest.php
@@ -17,7 +17,7 @@ class PayloadInNamespaceTest extends TestCase
      */
     private $domainMessage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->domainMessage = new DomainMessage(
             'F68E71A1-DBB0-4542-AEE5-BD937E095F74',

--- a/tests/Broadway/AMQP/DomainMessage/PayloadIsInstanceOfTest.php
+++ b/tests/Broadway/AMQP/DomainMessage/PayloadIsInstanceOfTest.php
@@ -19,7 +19,7 @@ class PayloadIsInstanceOfTest extends TestCase
      */
     private $domainMessage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->domainMessage = new DomainMessage(
             'F68E71A1-DBB0-4542-AEE5-BD937E095F74',

--- a/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
@@ -79,7 +79,7 @@ class EventBusForwardingConsumerTest extends TestCase
     private $deserializer;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connection = $this->createMock(AMQPStreamConnection::class);
 

--- a/tests/Broadway/AMQP/Message/Body/EntireDomainMessageBodyFactoryTest.php
+++ b/tests/Broadway/AMQP/Message/Body/EntireDomainMessageBodyFactoryTest.php
@@ -19,7 +19,7 @@ class EntireDomainMessageBodyFactoryTest extends TestCase
      */
     private $entireDomainMessageBodyFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->entireDomainMessageBodyFactory = new EntireDomainMessageBodyFactory();
     }

--- a/tests/Broadway/AMQP/Message/DelegatingAMQPMessageFactoryTest.php
+++ b/tests/Broadway/AMQP/Message/DelegatingAMQPMessageFactoryTest.php
@@ -31,7 +31,7 @@ class DelegatingAMQPMessageFactoryTest extends TestCase
      */
     private $messageFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->bodyFactory = $this->createMock(BodyFactoryInterface::class);
         $this->propertiesFactory = $this->createMock(PropertiesFactoryInterface::class);

--- a/tests/Broadway/AMQP/Message/Properties/CompositePropertiesFactoryTest.php
+++ b/tests/Broadway/AMQP/Message/Properties/CompositePropertiesFactoryTest.php
@@ -27,7 +27,7 @@ class CompositePropertiesFactoryTest extends TestCase
      */
     private $compositeFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->mockFactory1 = $this->createMock(PropertiesFactoryInterface::class);
         $this->mockFactory2 = $this->createMock(PropertiesFactoryInterface::class);

--- a/tests/Broadway/AMQP/Message/Properties/ContentTypeLookupTest.php
+++ b/tests/Broadway/AMQP/Message/Properties/ContentTypeLookupTest.php
@@ -14,7 +14,7 @@ class ContentTypeLookupTest extends TestCase
      */
     protected $contentTypeLookup;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->contentTypeLookup = new ContentTypeLookup();
     }

--- a/tests/Broadway/AMQP/Message/Properties/ContentTypePropertiesFactoryTest.php
+++ b/tests/Broadway/AMQP/Message/Properties/ContentTypePropertiesFactoryTest.php
@@ -23,7 +23,7 @@ class ContentTypePropertiesFactoryTest extends TestCase
      */
     private $contentTypePropertiesFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->contentTypeLookup = (new ContentTypeLookup())
             ->withContentType(

--- a/tests/Broadway/AMQP/Message/Properties/CorrelationIdPropertiesFactoryTest.php
+++ b/tests/Broadway/AMQP/Message/Properties/CorrelationIdPropertiesFactoryTest.php
@@ -16,7 +16,7 @@ class CorrelationIdPropertiesFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->factory = new CorrelationIdPropertiesFactory();
     }

--- a/tests/Broadway/CommandHandling/RetryingCommandBusTest.php
+++ b/tests/Broadway/CommandHandling/RetryingCommandBusTest.php
@@ -24,7 +24,7 @@ class RetryingCommandBusTest extends TestCase
      */
     private $commandBus;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->decoratee = $this->createMock(CommandBus::class);
         $this->commandBus = new RetryingCommandBus($this->decoratee);

--- a/tests/Broadway/CommandHandling/Validation/CompositeCommandValidatorTest.php
+++ b/tests/Broadway/CommandHandling/Validation/CompositeCommandValidatorTest.php
@@ -15,13 +15,13 @@ class CompositeCommandValidatorTest extends TestCase
     {
         $command = (object) ['do' => 'something'];
 
-        /** @var CommandValidatorInterface|\PHPUnit_Framework_MockObject_MockObject $validator1 */
+        /** @var CommandValidatorInterface|\PHPUnit\Framework\MockObject\MockObject $validator1 */
         $validator1 = $this->createMock(CommandValidatorInterface::class);
         $validator1->expects($this->once())
             ->method('validate')
             ->with($command);
 
-        /** @var CommandValidatorInterface|\PHPUnit_Framework_MockObject_MockObject $validator2 */
+        /** @var CommandValidatorInterface|\PHPUnit\Framework\MockObject\MockObject $validator2 */
         $validator2 = $this->createMock(CommandValidatorInterface::class);
         $validator2->expects($this->once())
             ->method('validate')
@@ -39,19 +39,19 @@ class CompositeCommandValidatorTest extends TestCase
     {
         $command = (object) ['do' => 'something'];
 
-        /** @var CommandValidatorInterface|\PHPUnit_Framework_MockObject_MockObject $validator1 */
+        /** @var CommandValidatorInterface|\PHPUnit\Framework\MockObject\MockObject $validator1 */
         $validator1 = $this->createMock(CommandValidatorInterface::class);
         $validator1->expects($this->once())
             ->method('validate')
             ->with($command);
 
-        /** @var CommandValidatorInterface|\PHPUnit_Framework_MockObject_MockObject $validator2 */
+        /** @var CommandValidatorInterface|\PHPUnit\Framework\MockObject\MockObject $validator2 */
         $validator2 = $this->createMock(CommandValidatorInterface::class);
         $validator2->expects($this->once())
             ->method('validate')
             ->with($command);
 
-        /** @var CommandValidatorInterface|\PHPUnit_Framework_MockObject_MockObject $validator3 */
+        /** @var CommandValidatorInterface|\PHPUnit\Framework\MockObject\MockObject $validator3 */
         $validator3 = $this->createMock(CommandValidatorInterface::class);
         $validator3->expects($this->once())
             ->method('validate')

--- a/tests/Broadway/CommandHandling/Validation/ValidatingCommandBusDecoratorTest.php
+++ b/tests/Broadway/CommandHandling/Validation/ValidatingCommandBusDecoratorTest.php
@@ -11,12 +11,12 @@ use PHPUnit\Framework\TestCase;
 class ValidatingCommandBusDecoratorTest extends TestCase
 {
     /**
-     * @var CommandBus|\PHPUnit_Framework_MockObject_MockObject
+     * @var CommandBus|\PHPUnit\Framework\MockObject\MockObject
      */
     private $decoratee;
 
     /**
-     * @var CommandValidatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var CommandValidatorInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $validator;
 

--- a/tests/Broadway/CommandHandling/Validation/ValidatingCommandBusDecoratorTest.php
+++ b/tests/Broadway/CommandHandling/Validation/ValidatingCommandBusDecoratorTest.php
@@ -25,7 +25,7 @@ class ValidatingCommandBusDecoratorTest extends TestCase
      */
     private $decorator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->decoratee = $this->createMock(CommandBus::class);
         $this->validator = $this->createMock(CommandValidatorInterface::class);

--- a/tests/Broadway/EventHandling/ReplayFilteringEventListenerTest.php
+++ b/tests/Broadway/EventHandling/ReplayFilteringEventListenerTest.php
@@ -22,7 +22,7 @@ class ReplayFilteringEventListenerTest extends TestCase
      */
     private $filteringEventListener;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->eventListener = $this->createMock(EventListener::class);
 

--- a/tests/Broadway/EventHandling/ReplayFilteringEventListenerTest.php
+++ b/tests/Broadway/EventHandling/ReplayFilteringEventListenerTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 class ReplayFilteringEventListenerTest extends TestCase
 {
     /**
-     * @var EventListener|\PHPUnit_Framework_MockObject_MockObject
+     * @var EventListener|\PHPUnit\Framework\MockObject\MockObject
      */
     private $eventListener;
 

--- a/tests/Calendar/CalendarConverterTest.php
+++ b/tests/Calendar/CalendarConverterTest.php
@@ -23,7 +23,7 @@ class CalendarConverterTest extends TestCase
      */
     private $converter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->converter = new CalendarConverter();
     }

--- a/tests/Calendar/DayOfWeekCollectionTest.php
+++ b/tests/Calendar/DayOfWeekCollectionTest.php
@@ -13,7 +13,7 @@ class DayOfWeekCollectionTest extends TestCase
      */
     private $dayOfWeekCollection;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dayOfWeekCollection = new DayOfWeekCollection(
             DayOfWeek::WEDNESDAY()

--- a/tests/Calendar/OpeningHourTest.php
+++ b/tests/Calendar/OpeningHourTest.php
@@ -35,7 +35,7 @@ class OpeningHourTest extends TestCase
      */
     private $openingHour;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->opens = new OpeningTime(new Hour(9), new Minute(30));
 

--- a/tests/Calendar/OpeningTimeTest.php
+++ b/tests/Calendar/OpeningTimeTest.php
@@ -25,7 +25,7 @@ class OpeningTimeTest extends TestCase
      */
     private $openingTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->hour = new Hour(9);
         $this->minute = new Minute(30);

--- a/tests/CalendarFactoryTest.php
+++ b/tests/CalendarFactoryTest.php
@@ -23,7 +23,7 @@ class CalendarFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->factory = new CalendarFactory();
     }

--- a/tests/Cdb/ActorItemFactoryTest.php
+++ b/tests/Cdb/ActorItemFactoryTest.php
@@ -13,7 +13,7 @@ class ActorItemFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->factory = new ActorItemFactory(
             \CultureFeed_Cdb_Xml::namespaceUriForVersion('3.3')

--- a/tests/Cdb/CdbId/EventCdbIdExtractorTest.php
+++ b/tests/Cdb/CdbId/EventCdbIdExtractorTest.php
@@ -24,7 +24,7 @@ class EventCdbIdExtractorTest extends TestCase
      */
     private $cdbIdExtractor;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->placeExternalIdMappingService = new ArrayMappingService(
             [

--- a/tests/Cdb/EventItemFactoryTest.php
+++ b/tests/Cdb/EventItemFactoryTest.php
@@ -13,7 +13,7 @@ class EventItemFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->factory = new EventItemFactory(
             \CultureFeed_Cdb_Xml::namespaceUriForVersion('3.3')

--- a/tests/Cdb/ExternalId/ArrayMappingServiceTest.php
+++ b/tests/Cdb/ExternalId/ArrayMappingServiceTest.php
@@ -18,7 +18,7 @@ class ArrayMappingServiceTest extends TestCase
      */
     private $mappingService;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->array = [
             'SKB Import:Organisation_6666' => 'b91a72d0-7d69-4fe2-81f4-5c0f29001089',

--- a/tests/Cdb/PriceDescriptionParserTest.php
+++ b/tests/Cdb/PriceDescriptionParserTest.php
@@ -15,7 +15,7 @@ class PriceDescriptionParserTest extends TestCase
      */
     private $parser;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->parser = new PriceDescriptionParser(
             new NumberFormatRepository(),

--- a/tests/CommandHandling/AbstractContextAwareCommandBus.php
+++ b/tests/CommandHandling/AbstractContextAwareCommandBus.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\CommandHandling;
+
+use Broadway\CommandHandling\CommandBus;
+
+abstract class AbstractContextAwareCommandBus implements CommandBus, ContextAwareInterface
+{
+}

--- a/tests/CommandHandling/AuthorizedCommandBusTest.php
+++ b/tests/CommandHandling/AuthorizedCommandBusTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\CommandHandling;
 
-use Broadway\CommandHandling\CommandBus;
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Security\AuthorizableCommand;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
@@ -16,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 class AuthorizedCommandBusTest extends TestCase
 {
     /**
-     * @var CommandBus|ContextAwareInterface|MockObject
+     * @var AbstractContextAwareCommandBus|MockObject
      */
     private $decoratee;
 
@@ -36,7 +35,7 @@ class AuthorizedCommandBusTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->decoratee = $this->createMock([CommandBus::class, ContextAwareInterface::class]);
+        $this->decoratee = $this->createMock(AbstractContextAwareCommandBus::class);
 
         $this->userId = '9bd817a3-670e-4720-affa-7636e29073ce';
 

--- a/tests/CommandHandling/SimpleContextAwareCommandBusTest.php
+++ b/tests/CommandHandling/SimpleContextAwareCommandBusTest.php
@@ -21,7 +21,7 @@ class SimpleContextAwareCommandBusTest extends TestCase
      */
     protected $commandHandler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->commandBus = new SimpleContextAwareCommandBus();
 

--- a/tests/ContactPointTest.php
+++ b/tests/ContactPointTest.php
@@ -34,7 +34,7 @@ class ContactPointTest extends TestCase
      */
     private $contactPoint;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->phones = ['012 34 56 78', '987 65 43 21'];
 

--- a/tests/CulturefeedSluggerTest.php
+++ b/tests/CulturefeedSluggerTest.php
@@ -13,7 +13,7 @@ class CulturefeedSluggerTest extends TestCase
      */
     protected $slugger;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->slugger = new CulturefeedSlugger();
     }

--- a/tests/DescriptionJSONDeserializerTest.php
+++ b/tests/DescriptionJSONDeserializerTest.php
@@ -14,7 +14,7 @@ class DescriptionJSONDeserializerTest extends TestCase
      */
     private $deserializer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->deserializer = new DescriptionJSONDeserializer();
     }

--- a/tests/Deserializer/JSONDeserializerTest.php
+++ b/tests/Deserializer/JSONDeserializerTest.php
@@ -19,7 +19,7 @@ class JSONDeserializerTest extends TestCase
      */
     private $assocDeserializer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->deserializer = new JSONDeserializer();
 

--- a/tests/Deserializer/SimpleDeserializerLocatorTest.php
+++ b/tests/Deserializer/SimpleDeserializerLocatorTest.php
@@ -14,7 +14,7 @@ class SimpleDeserializerLocatorTest extends TestCase
      */
     protected $deserializerLocator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->deserializerLocator = new SimpleDeserializerLocator();
     }

--- a/tests/Event/Commands/DeleteTypicalAgeRangeTest.php
+++ b/tests/Event/Commands/DeleteTypicalAgeRangeTest.php
@@ -13,7 +13,7 @@ class DeleteTypicalAgeRangeTest extends TestCase
      */
     protected $deleteTypicalAgeRange;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->deleteTypicalAgeRange = new DeleteTypicalAgeRange('id');
     }

--- a/tests/Event/Commands/UpdateBookingInfoTest.php
+++ b/tests/Event/Commands/UpdateBookingInfoTest.php
@@ -17,7 +17,7 @@ class UpdateBookingInfoTest extends TestCase
      */
     protected $updateBookingInfo;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->updateBookingInfo = new UpdateBookingInfo(
             'id',

--- a/tests/Event/Commands/UpdateContactPointTest.php
+++ b/tests/Event/Commands/UpdateContactPointTest.php
@@ -14,7 +14,7 @@ class UpdateContactPointTest extends TestCase
      */
     protected $updateContactPoint;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->updateContactPoint = new UpdateContactPoint(
             'id',

--- a/tests/Event/Commands/UpdateDescriptionTest.php
+++ b/tests/Event/Commands/UpdateDescriptionTest.php
@@ -15,7 +15,7 @@ class UpdateDescriptionTest extends TestCase
      */
     protected $updateDescription;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->updateDescription = new UpdateDescription(
             'id',

--- a/tests/Event/Commands/UpdateLocationTest.php
+++ b/tests/Event/Commands/UpdateLocationTest.php
@@ -25,7 +25,7 @@ class UpdateLocationTest extends TestCase
      */
     private $updateLocation;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventId = '3ed90f18-93a3-4340-981d-12e57efa0211';
 

--- a/tests/Event/Commands/UpdateMajorInfoTest.php
+++ b/tests/Event/Commands/UpdateMajorInfoTest.php
@@ -19,7 +19,7 @@ class UpdateMajorInfoTest extends TestCase
      */
     protected $updateMajorInfo;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->updateMajorInfo = new UpdateMajorInfo(
             'id',

--- a/tests/Event/Commands/UpdateTypicalAgeRangeTest.php
+++ b/tests/Event/Commands/UpdateTypicalAgeRangeTest.php
@@ -13,7 +13,7 @@ class UpdateTypicalAgeRangeTest extends TestCase
      */
     protected $updateTypicalAgeRange;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->updateTypicalAgeRange = new UpdateTypicalAgeRange('id', '1-14');
     }

--- a/tests/Event/EventThemeResolverTest.php
+++ b/tests/Event/EventThemeResolverTest.php
@@ -15,7 +15,7 @@ class EventThemeResolverTest extends TestCase
      */
     private $themeResolver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->themeResolver = new EventThemeResolver();
     }

--- a/tests/Event/Events/CalendarUpdatedTest.php
+++ b/tests/Event/Events/CalendarUpdatedTest.php
@@ -31,7 +31,7 @@ class CalendarUpdatedTest extends TestCase
      */
     private $calendarUpdated;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 

--- a/tests/Event/Events/EventCreatedTest.php
+++ b/tests/Event/Events/EventCreatedTest.php
@@ -33,7 +33,7 @@ class EventCreatedTest extends TestCase
      */
     private $eventCreated;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->location = new LocationId('335be568-aaf0-4147-80b6-9267daafe23b');
 

--- a/tests/Event/Events/LocationUpdatedTest.php
+++ b/tests/Event/Events/LocationUpdatedTest.php
@@ -29,7 +29,7 @@ class LocationUpdatedTest extends TestCase
      */
     private $locationUpdated;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventId = '3ed90f18-93a3-4340-981d-12e57efa0211';
 

--- a/tests/Event/Events/Moderation/PublishedTest.php
+++ b/tests/Event/Events/Moderation/PublishedTest.php
@@ -24,7 +24,7 @@ class PublishedTest extends TestCase
      */
     private $published;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->itemId = '75d90bc2-9b64-11e6-9f33-a24fc0d9649c';
 

--- a/tests/Event/GeoCoordinatesProcessManagerTest.php
+++ b/tests/Event/GeoCoordinatesProcessManagerTest.php
@@ -38,7 +38,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
      */
     private $processManager;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->commandBus = $this->createMock(CommandBus::class);
         $this->addressFactory = new CultureFeedAddressFactory();

--- a/tests/Event/ReadModel/Calendar/CacheCalendarRepositoryTest.php
+++ b/tests/Event/ReadModel/Calendar/CacheCalendarRepositoryTest.php
@@ -22,7 +22,7 @@ class CacheCalendarRepositoryTest extends TestCase
      */
     protected $calendar;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->eventId = '24b1e348-f27d-4f70-ae1a-871074267c2e';
 

--- a/tests/Event/ReadModel/Calendar/EventCalendarProjectorTest.php
+++ b/tests/Event/ReadModel/Calendar/EventCalendarProjectorTest.php
@@ -36,7 +36,7 @@ class EventCalendarProjectorTest extends TestCase
      */
     protected $cdbXMLEventFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cdbXMLEventFactory = new CdbXMLEventFactory();
 

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -213,8 +213,8 @@ class HistoryProjectorTest extends TestCase
             self::EVENT_ID_1,
             [
                 (object) [
-                    'description' => 'Event aangepast via UDB2',
                     'date' => '2015-03-25T10:17:19+02:00',
+                    'description' => 'Event aangepast via UDB2',
                 ],
                 (object) [
                     'date' => '2015-03-04T10:17:19+02:00',
@@ -334,8 +334,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => $now->format('c'),
-                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
                     'description' => 'Event gekopieerd van ' . $originalEventId,
+                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
                 ],
             ]
         );
@@ -369,8 +369,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-26T10:17:19+02:00',
-                    'author' => '3d4a9602-44ee-45c9-809e-621e2671e0c8',
                     'description' => 'Titel vertaald (fr)',
+                    'author' => '3d4a9602-44ee-45c9-809e-621e2671e0c8',
                 ],
             ]
         );
@@ -404,8 +404,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Beschrijving vertaald (fr)',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -438,8 +438,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
                     'description' => "Label 'foo' toegepast",
+                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
                 ],
             ]
         );
@@ -472,8 +472,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
                     'description' => "Label 'foo' verwijderd",
+                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
                 ],
             ]
         );
@@ -501,8 +501,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Goedgekeurd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -530,8 +530,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Toegang aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -559,8 +559,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Deelnamevorm (fysiek / online) aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -588,8 +588,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Online url aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -617,8 +617,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Online url verwijderd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -646,8 +646,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Reservatie-info aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -675,8 +675,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Kalender-info aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -704,8 +704,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Contact-info aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -733,8 +733,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Beschrijving aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -762,8 +762,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Event verwijderd uit UiTdatabank',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -791,8 +791,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Voorzieningen aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -820,8 +820,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Afgekeurd als duplicaat',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -849,8 +849,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Afgekeurd als ongepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -884,8 +884,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Geocoördinaten automatisch aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -922,8 +922,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Afbeelding \'0aa8d12d-26d6-409f-aa68-e8200e5c91a0\' toegevoegd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -960,8 +960,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Afbeelding \'0aa8d12d-26d6-409f-aa68-e8200e5c91a0\' verwijderd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -994,8 +994,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Afbeelding \'0aa8d12d-26d6-409f-aa68-e8200e5c91a0\' aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1046,13 +1046,13 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Afbeelding \'0aa8d12d-26d6-409f-aa68-e8200e5c91a0\' geïmporteerd uit UDB2',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Afbeelding \'f1926870-136c-4b06-b2a1-1fab01590847\' geïmporteerd uit UDB2',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1103,13 +1103,13 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Afbeelding \'0aa8d12d-26d6-409f-aa68-e8200e5c91a0\' aangepast via UDB2',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Afbeelding \'f1926870-136c-4b06-b2a1-1fab01590847\' aangepast via UDB2',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1144,8 +1144,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' toegevoegd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1176,8 +1176,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' verwijderd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1212,8 +1212,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1241,8 +1241,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Labels geïmporteerd uit JSON-LD',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1270,8 +1270,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => "Locatie aangepast naar '827b7d8d-8821-4870-a48b-bea9d44f557c'",
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1308,8 +1308,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Hoofdafbeelding geselecteerd: \'0aa8d12d-26d6-409f-aa68-e8200e5c91a0\'',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1343,8 +1343,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'MajorInfo aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1375,8 +1375,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Organisatie \'0d7d2247-ebaa-4ff0-baf9-8ea274579cc3\' verwijderd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1407,8 +1407,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Organisatie \'0d7d2247-ebaa-4ff0-baf9-8ea274579cc3\' toegevoegd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1443,8 +1443,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Prijs-info aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1478,8 +1478,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Gepubliceerd (publicatiedatum: \'2015-04-30T02:00:00+02:00\')',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1507,8 +1507,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => "Afgekeurd, reden: 'not good enough'",
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1539,8 +1539,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Publicatiedatum aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1568,8 +1568,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Thema aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1597,8 +1597,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Thema verwijderd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1626,8 +1626,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Titel aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1655,8 +1655,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Type aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1684,8 +1684,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Leeftijds-info verwijderd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1713,8 +1713,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Leeftijds-info aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );

--- a/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -42,7 +42,7 @@ class CdbXMLImporterTest extends TestCase
      */
     protected $slugger;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->importer = new CdbXMLImporter(
             new CdbXMLItemBaseImporter(

--- a/tests/Event/ReadModel/JSONLD/EventFactoryTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventFactoryTest.php
@@ -21,7 +21,7 @@ class EventFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->iriGenerator = $this->createMock(IriGeneratorInterface::class);
 

--- a/tests/Event/ReadModel/JSONLD/EventJsonDocumentLanguageAnalyzerTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventJsonDocumentLanguageAnalyzerTest.php
@@ -15,7 +15,7 @@ class EventJsonDocumentLanguageAnalyzerTest extends TestCase
      */
     private $analyzer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->analyzer = new EventJsonDocumentLanguageAnalyzer();
     }

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -95,7 +95,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
      */
     protected $cdbXMLImporter;
 
-    public function __construct(string $name = null, array $data = [], string $dataName = '')
+    public function __construct(string $name = null, array $data = [], $dataName = '')
     {
         parent::__construct($name, $data, $dataName, 'CultuurNet\\UDB3\\Event');
     }

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -827,7 +827,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $expectedBookingInfo->price = 9.99;
         $expectedBookingInfo->description = 'Iedereen aan dezelfde prijs';
 
-        $this->assertInternalType('object', $bookingInfo);
+        $this->assertIsObject($bookingInfo);
         $this->assertEquals($expectedBookingInfo, $bookingInfo);
     }
 
@@ -849,7 +849,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $expectedBookingInfo->price = 9.99;
         $expectedBookingInfo->description = 'Iedereen aan dezelfde prijs';
 
-        $this->assertInternalType('object', $bookingInfo);
+        $this->assertIsObject($bookingInfo);
         $this->assertEquals($expectedBookingInfo, $bookingInfo);
     }
 
@@ -869,7 +869,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $expectedBookingInfo = new stdClass();
         $expectedBookingInfo->description = 'Gratis voor iedereen!';
 
-        $this->assertInternalType('object', $bookingInfo);
+        $this->assertIsObject($bookingInfo);
         $this->assertEquals($expectedBookingInfo, $bookingInfo);
     }
 

--- a/tests/Event/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Event/ReadModel/Permission/ProjectorTest.php
@@ -39,7 +39,7 @@ class ProjectorTest extends TestCase
      */
     private $userIdResolver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->repository = $this->createMock(ResourceOwnerRepository::class);
         $this->userIdResolver = $this->createMock(CreatedByToUserIdResolverInterface::class);

--- a/tests/Event/ReadModel/Relations/Doctrine/DBALRepositoryTest.php
+++ b/tests/Event/ReadModel/Relations/Doctrine/DBALRepositoryTest.php
@@ -22,7 +22,7 @@ class DBALRepositoryTest extends TestCase
      */
     private $tableName;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->repository = new DBALEventRelationsRepository(
             $this->getConnection()

--- a/tests/Event/ReadModel/Relations/EventRelationsProjectorTest.php
+++ b/tests/Event/ReadModel/Relations/EventRelationsProjectorTest.php
@@ -37,7 +37,7 @@ class EventRelationsProjectorTest extends TestCase
      */
     private $projector;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->repository = $this->createMock(EventRelationsRepository::class);
 

--- a/tests/Event/RelocateEventToCanonicalPlaceTest.php
+++ b/tests/Event/RelocateEventToCanonicalPlaceTest.php
@@ -38,7 +38,7 @@ class RelocateEventToCanonicalPlaceTest extends TestCase
      */
     private $canonicalPlaceRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->commandBus = new TraceableCommandBus();
         $this->canonicalPlaceRepository = $this->createMock(CanonicalPlaceRepository::class);

--- a/tests/EventExport/Command/ExportEventsJSONDeserializerTest.php
+++ b/tests/EventExport/Command/ExportEventsJSONDeserializerTest.php
@@ -19,7 +19,7 @@ class ExportEventsJSONDeserializerTest extends TestCase
      */
     private $deserializer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->deserializer = $this->getMockForAbstractClass(ExportEventsJSONDeserializer::class);
     }

--- a/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
+++ b/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
@@ -13,7 +13,7 @@ class HTMLFileWriterTest extends TestCase
      */
     protected $filePath;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->filePath = $this->getFilePath();
@@ -524,7 +524,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->filePath && file_exists($this->filePath)) {
             unlink($this->filePath);

--- a/tests/EventExport/Format/HTML/Uitpas/DistributionKey/KansentariefDiscountSpecificationTest.php
+++ b/tests/EventExport/Format/HTML/Uitpas/DistributionKey/KansentariefDiscountSpecificationTest.php
@@ -30,7 +30,7 @@ class KansentariefDiscountSpecificationTest extends TestCase
      */
     protected $cardSystems;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->specification = new KansentariefDiscountSpecification();
     }

--- a/tests/EventExport/Format/HTML/Uitpas/DistributionKey/KansentariefForCurrentCardSystemSpecificationTest.php
+++ b/tests/EventExport/Format/HTML/Uitpas/DistributionKey/KansentariefForCurrentCardSystemSpecificationTest.php
@@ -20,7 +20,7 @@ class KansentariefForCurrentCardSystemSpecificationTest extends TestCase
      */
     private $specification;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->specification =
             new KansentariefForCurrentCardSystemSpecification();

--- a/tests/EventExport/Format/HTML/Uitpas/DistributionKey/KansentariefForOtherCardSystemsSpecificationTest.php
+++ b/tests/EventExport/Format/HTML/Uitpas/DistributionKey/KansentariefForOtherCardSystemsSpecificationTest.php
@@ -15,7 +15,7 @@ class KansentariefForOtherCardSystemsSpecificationTest extends TestCase
      */
     protected $specification;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->specification = new KansentariefForOtherCardSystemsSpecification();
     }

--- a/tests/EventExport/Format/HTML/Uitpas/Event/PointCollectingSpecificationTest.php
+++ b/tests/EventExport/Format/HTML/Uitpas/Event/PointCollectingSpecificationTest.php
@@ -14,7 +14,7 @@ class PointCollectingSpecificationTest extends TestCase
      */
     protected $specification;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->specification = new PointCollectingSpecification();
     }

--- a/tests/EventExport/Format/HTML/Uitpas/Promotion/EventOrganizerPromotionQueryFactoryTest.php
+++ b/tests/EventExport/Format/HTML/Uitpas/Promotion/EventOrganizerPromotionQueryFactoryTest.php
@@ -24,7 +24,7 @@ class EventOrganizerPromotionQueryFactoryTest extends TestCase
      */
     protected $unixTime = 435052800;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->queryFactory = new EventOrganizerPromotionQueryFactory(
             new FrozenClock(

--- a/tests/EventExport/Format/Twig/GoogleMapUrlGeneratorTest.php
+++ b/tests/EventExport/Format/Twig/GoogleMapUrlGeneratorTest.php
@@ -16,7 +16,7 @@ class GoogleMapUrlGeneratorTest extends TestCase
      */
     private $generator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->generator = new GoogleMapUrlGenerator(
             self::TEST_API_KEY

--- a/tests/EventHandling/DelegateEventHandlingToSpecificMethodTraitTest.php
+++ b/tests/EventHandling/DelegateEventHandlingToSpecificMethodTraitTest.php
@@ -27,7 +27,7 @@ class DelegateEventHandlingToSpecificMethodTraitTest extends TestCase
      */
     private $mockLDProjector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockedMockLDProjector = $this
             ->getMockBuilder(MockLDProjector::class)

--- a/tests/EventListener/ClassNameEventSpecificationTest.php
+++ b/tests/EventListener/ClassNameEventSpecificationTest.php
@@ -16,7 +16,7 @@ class ClassNameEventSpecificationTest extends TestCase
      */
     private $labelAdded;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->labelAdded = new LabelAdded(
             '26e36905-64d0-4cac-ba41-6d6dcd997ca0',

--- a/tests/EventSourcing/AbstractEventStoreDecoratorTest.php
+++ b/tests/EventSourcing/AbstractEventStoreDecoratorTest.php
@@ -21,7 +21,7 @@ class AbstractEventStoreDecoratorTest extends TestCase
      */
     private $abstractEventStoreDecorator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventStore = $this->createMock(EventStore::class);
 

--- a/tests/EventSourcing/CopyAwareEventStoreDecoratorTest.php
+++ b/tests/EventSourcing/CopyAwareEventStoreDecoratorTest.php
@@ -24,7 +24,7 @@ class CopyAwareEventStoreDecoratorTest extends TestCase
      */
     protected $copyAwareEventStore;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventStore = $this->createMock(EventStore::class);
         $this->copyAwareEventStore = new CopyAwareEventStoreDecorator($this->eventStore);

--- a/tests/Geocoding/CachedGeocodingServiceTest.php
+++ b/tests/Geocoding/CachedGeocodingServiceTest.php
@@ -28,7 +28,7 @@ class CachedGeocodingServiceTest extends TestCase
      */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cache = new ArrayCache();
         $this->decoratee = $this->createMock(GeocodingService::class);

--- a/tests/Geocoding/DefaultGeocodingServiceTest.php
+++ b/tests/Geocoding/DefaultGeocodingServiceTest.php
@@ -34,7 +34,7 @@ class DefaultGeocodingServiceTest extends TestCase
      */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->geocoder = $this->createMock(Geocoder::class);
         $this->logger = $this->createMock(LoggerInterface::class);

--- a/tests/Http/Deserializer/Address/AddressJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Address/AddressJSONDeserializerTest.php
@@ -20,7 +20,7 @@ class AddressJSONDeserializerTest extends TestCase
      */
     private $deserializer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->deserializer = new AddressJSONDeserializer();
     }

--- a/tests/Http/Deserializer/BookingInfo/BookingInfoDataValidatorTest.php
+++ b/tests/Http/Deserializer/BookingInfo/BookingInfoDataValidatorTest.php
@@ -15,7 +15,7 @@ class BookingInfoDataValidatorTest extends TestCase
      */
     private $validator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->validator = new BookingInfoDataValidator();
     }

--- a/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
@@ -31,7 +31,7 @@ class CalendarJSONParserTest extends TestCase
      */
     private $calendarJSONParser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $updateCalendar = file_get_contents(__DIR__ . '/samples/calendar_all_fields.json');
         $this->updateCalendarAsArray = json_decode($updateCalendar, true);

--- a/tests/Http/Deserializer/ContactPoint/ContactPointDataValidatorTest.php
+++ b/tests/Http/Deserializer/ContactPoint/ContactPointDataValidatorTest.php
@@ -14,7 +14,7 @@ class ContactPointDataValidatorTest extends TestCase
      */
     private $validator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->validator = new ContactPointDataValidator();
     }

--- a/tests/Http/Deserializer/ContactPoint/ContactPointJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/ContactPoint/ContactPointJSONDeserializerTest.php
@@ -16,7 +16,7 @@ class ContactPointJSONDeserializerTest extends TestCase
      */
     private $contactPointJSONDeserializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->contactPointJSONDeserializer = new ContactPointJSONDeserializer();
     }

--- a/tests/Http/Deserializer/Organizer/OrganizerCreationPayloadDataValidatorTest.php
+++ b/tests/Http/Deserializer/Organizer/OrganizerCreationPayloadDataValidatorTest.php
@@ -14,7 +14,7 @@ class OrganizerCreationPayloadDataValidatorTest extends TestCase
      */
     private $validator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->validator = new OrganizerCreationPayloadDataValidator();
     }

--- a/tests/Http/Deserializer/Organizer/OrganizerCreationPayloadTest.php
+++ b/tests/Http/Deserializer/Organizer/OrganizerCreationPayloadTest.php
@@ -47,7 +47,7 @@ class OrganizerCreationPayloadTest extends TestCase
      */
     private $organizerCreationPayload;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mainLanguage = new Language('en');
 

--- a/tests/Http/Deserializer/Organizer/UrlJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Organizer/UrlJSONDeserializerTest.php
@@ -16,7 +16,7 @@ class UrlJSONDeserializerTest extends TestCase
      */
     private $urlJSONDeserializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->urlJSONDeserializer = new UrlJSONDeserializer();
     }

--- a/tests/Http/Deserializer/TitleJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/TitleJSONDeserializerTest.php
@@ -16,7 +16,7 @@ class TitleJSONDeserializerTest extends TestCase
      */
     private $deserializer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->deserializer = new TitleJSONDeserializer();
     }

--- a/tests/Http/Place/FacilitiesJSONDeserializerTest.php
+++ b/tests/Http/Place/FacilitiesJSONDeserializerTest.php
@@ -19,7 +19,7 @@ class FacilitiesJSONDeserializerTest extends TestCase
      */
     private $facilityResolver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->facilityResolver = $this->createMock(OfferFacilityResolverInterface::class);
     }

--- a/tests/Http/Role/QueryValidatingRequestBodyParserTest.php
+++ b/tests/Http/Role/QueryValidatingRequestBodyParserTest.php
@@ -19,7 +19,7 @@ class QueryValidatingRequestBodyParserTest extends TestCase
 
     private JsonRequestBodyParser $jsonParser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parser = new QueryValidatingRequestBodyParser();
         $this->jsonParser = new JsonRequestBodyParser();

--- a/tests/Label/ReadModels/Doctrine/AbstractDBALRepositoryTest.php
+++ b/tests/Label/ReadModels/Doctrine/AbstractDBALRepositoryTest.php
@@ -27,7 +27,7 @@ class AbstractDBALRepositoryTest extends TestCase
      */
     private $abstractDBALRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->connection = DriverManager::getConnection(
             [

--- a/tests/Label/ReadModels/JSON/Repository/BroadcastingWriteRepositoryDecoratorTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/BroadcastingWriteRepositoryDecoratorTest.php
@@ -29,7 +29,7 @@ class BroadcastingWriteRepositoryDecoratorTest extends TestCase
      */
     private $writeRepository;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->writeRepository = $this->createMock(WriteRepositoryInterface::class);
         $this->eventBus = $this->createMock(EventBus::class);

--- a/tests/Label/ReadModels/JSON/Repository/Doctrine/BaseDBALRepositoryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/Doctrine/BaseDBALRepositoryTest.php
@@ -21,7 +21,7 @@ abstract class BaseDBALRepositoryTest extends TestCase
      */
     private $tableName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tableName = new StringLiteral('test_places_json');
 

--- a/tests/Label/ReadModels/JSON/Repository/EntityTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/EntityTest.php
@@ -52,7 +52,7 @@ class EntityTest extends TestCase
      */
     private $entityWithDefaults;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('17d17095-a628-4cfe-98c2-3306bb6af450');
 

--- a/tests/Label/ReadModels/Roles/Doctrine/LabelRolesWriteRepositoryTest.php
+++ b/tests/Label/ReadModels/Roles/Doctrine/LabelRolesWriteRepositoryTest.php
@@ -24,7 +24,7 @@ class LabelRolesWriteRepositoryTest extends TestCase
      */
     private $labelRolesWriteRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->labelRolesTableName = new StringLiteral('label_roles');
 

--- a/tests/Label/ReadModels/Roles/LabelRolesProjectorTest.php
+++ b/tests/Label/ReadModels/Roles/LabelRolesProjectorTest.php
@@ -27,7 +27,7 @@ class LabelRolesProjectorTest extends TestCase
      */
     private $labelRolesProjector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->labelRolesWriteRepository = $this->createMock(
             LabelRolesWriteRepositoryInterface::class

--- a/tests/LabelJSONDeserializerTest.php
+++ b/tests/LabelJSONDeserializerTest.php
@@ -15,7 +15,7 @@ class LabelJSONDeserializerTest extends TestCase
 
     private LabelJSONDeserializer $deserializer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->label = new Label(new LabelName('test-label'));
         $this->deserializer = new LabelJSONDeserializer();

--- a/tests/Log/SocketIOEmitterHandlerTest.php
+++ b/tests/Log/SocketIOEmitterHandlerTest.php
@@ -21,7 +21,7 @@ class SocketIOEmitterHandlerTest extends TestCase
      */
     protected $emitter;
 
-    public function setUp()
+    public function setUp(): void
     {
         // SocketIO\Emitter unfortunately does not adhere to an interface, so
         // we need to use the implementation and ensure all required

--- a/tests/Media/Commands/UploadImageTest.php
+++ b/tests/Media/Commands/UploadImageTest.php
@@ -18,7 +18,7 @@ class UploadImageTest extends TestCase
      */
     private $uploadImage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uploadImage = new UploadImage(
             new UUID('de305d54-75b4-431b-adb2-eb6b9e546014'),

--- a/tests/Media/Serialization/MediaObjectSerializerTest.php
+++ b/tests/Media/Serialization/MediaObjectSerializerTest.php
@@ -29,7 +29,7 @@ class MediaObjectSerializerTest extends TestCase
      */
     protected $iriGenerator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->iriGenerator = $this->createMock(IriGeneratorInterface::class);
         $this->serializer = new MediaObjectSerializer($this->iriGenerator);

--- a/tests/Model/Event/EventIDParserTest.php
+++ b/tests/Model/Event/EventIDParserTest.php
@@ -15,7 +15,7 @@ class EventIDParserTest extends TestCase
      */
     private $parser;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->parser = new EventIDParser();
     }

--- a/tests/Model/Import/MediaObject/MediaManagerImageCollectionFactoryTest.php
+++ b/tests/Model/Import/MediaObject/MediaManagerImageCollectionFactoryTest.php
@@ -36,7 +36,7 @@ class MediaManagerImageCollectionFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->mediaManager = $this->createMock(MediaManagerInterface::class);
         $this->factory = new MediaManagerImageCollectionFactory($this->mediaManager);

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -74,7 +74,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
      */
     private $completeAdapter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->offer = new ImmutableEvent(
             new UUID('91060c19-a860-4a47-8591-8a779bfa520a'),

--- a/tests/Model/Import/Place/Udb3ModelToLegacyPlaceAdapterTest.php
+++ b/tests/Model/Import/Place/Udb3ModelToLegacyPlaceAdapterTest.php
@@ -31,7 +31,7 @@ class Udb3ModelToLegacyPlaceAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $place = new ImmutablePlace(
             new UUID('6ba87a6b-efea-4467-9e87-458d145384d9'),

--- a/tests/Model/Organizer/OrganizerIDParserTest.php
+++ b/tests/Model/Organizer/OrganizerIDParserTest.php
@@ -15,7 +15,7 @@ class OrganizerIDParserTest extends TestCase
      */
     private $parser;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->parser = new OrganizerIDParser();
     }

--- a/tests/Model/Place/PlaceIDParserTest.php
+++ b/tests/Model/Place/PlaceIDParserTest.php
@@ -15,7 +15,7 @@ class PlaceIDParserTest extends TestCase
      */
     private $parser;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->parser = new PlaceIDParser();
     }

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -91,7 +91,7 @@ class EventDenormalizerTest extends TestCase
      */
     private $uuidFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->uuidFactory = $this->createMock(UuidFactoryInterface::class);
 

--- a/tests/Model/Serializer/Organizer/OrganizerDenormalizerTest.php
+++ b/tests/Model/Serializer/Organizer/OrganizerDenormalizerTest.php
@@ -39,7 +39,7 @@ class OrganizerDenormalizerTest extends TestCase
      */
     private $denormalizer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->denormalizer = new OrganizerDenormalizer();
     }

--- a/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
+++ b/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
@@ -83,7 +83,7 @@ class PlaceDenormalizerTest extends TestCase
      */
     private $denormalizer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->denormalizer = new PlaceDenormalizer();
     }

--- a/tests/Model/ValueObject/MediaObject/MediaObjectIDParserTest.php
+++ b/tests/Model/ValueObject/MediaObject/MediaObjectIDParserTest.php
@@ -15,7 +15,7 @@ class MediaObjectIDParserTest extends TestCase
      */
     private $parser;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->parser = new MediaObjectIDParser();
     }

--- a/tests/Offer/Commands/AbstractOrganizerCommandTest.php
+++ b/tests/Offer/Commands/AbstractOrganizerCommandTest.php
@@ -24,7 +24,7 @@ class AbstractOrganizerCommandTest extends TestCase
      */
     protected $organizerId;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->organizerId = 'organizer-456';

--- a/tests/Offer/Commands/AbstractTranslatePropertyCommandTest.php
+++ b/tests/Offer/Commands/AbstractTranslatePropertyCommandTest.php
@@ -25,7 +25,7 @@ class AbstractTranslatePropertyCommandTest extends TestCase
      */
     protected $language;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->language = new Language('en');

--- a/tests/Offer/Commands/AbstractUpdateBookingInfoTest.php
+++ b/tests/Offer/Commands/AbstractUpdateBookingInfoTest.php
@@ -28,7 +28,7 @@ class AbstractUpdateBookingInfoTest extends TestCase
      */
     protected $bookingInfo;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->bookingInfo = new BookingInfo(

--- a/tests/Offer/Commands/AbstractUpdateContactPointTest.php
+++ b/tests/Offer/Commands/AbstractUpdateContactPointTest.php
@@ -25,7 +25,7 @@ class AbstractUpdateContactPointTest extends TestCase
      */
     protected $contactPoint;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->contactPoint = new ContactPoint(

--- a/tests/Offer/Commands/AbstractUpdateDescriptionTest.php
+++ b/tests/Offer/Commands/AbstractUpdateDescriptionTest.php
@@ -31,7 +31,7 @@ class AbstractUpdateDescriptionTest extends TestCase
      */
     protected $language;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->description = new Description('This is the event description update.');

--- a/tests/Offer/Commands/AbstractUpdateTitleTest.php
+++ b/tests/Offer/Commands/AbstractUpdateTitleTest.php
@@ -31,7 +31,7 @@ class AbstractUpdateTitleTest extends TestCase
      */
     protected $language;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->title = new Title('This is the event title update.');

--- a/tests/Offer/Commands/AbstractUpdateTypicalAgeRangeTest.php
+++ b/tests/Offer/Commands/AbstractUpdateTypicalAgeRangeTest.php
@@ -24,7 +24,7 @@ class AbstractUpdateTypicalAgeRangeTest extends TestCase
      */
     protected $typicalAgeRange;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->typicalAgeRange = '3-12';

--- a/tests/Offer/Commands/AddLabelToMultipleTest.php
+++ b/tests/Offer/Commands/AddLabelToMultipleTest.php
@@ -26,7 +26,7 @@ class AddLabelToMultipleTest extends TestCase
 
     protected Label $label;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->offerIdentifiers = OfferIdentifierCollection::fromArray(
             [

--- a/tests/Offer/Commands/AddLabelToQueryJSONDeserializerTest.php
+++ b/tests/Offer/Commands/AddLabelToQueryJSONDeserializerTest.php
@@ -17,7 +17,7 @@ class AddLabelToQueryJSONDeserializerTest extends TestCase
      */
     private $deserializer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->deserializer = new AddLabelToQueryJSONDeserializer();
     }

--- a/tests/Offer/Commands/AddLabelToQueryTest.php
+++ b/tests/Offer/Commands/AddLabelToQueryTest.php
@@ -15,7 +15,7 @@ class AddLabelToQueryTest extends TestCase
      */
     protected $labelQuery;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->labelQuery = new AddLabelToQuery(
             'query',

--- a/tests/Offer/Events/AbstractBookingInfoEventTest.php
+++ b/tests/Offer/Events/AbstractBookingInfoEventTest.php
@@ -27,7 +27,7 @@ class AbstractBookingInfoEventTest extends TestCase
      */
     protected $bookingInfo;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->bookingInfo = new BookingInfo(

--- a/tests/Offer/Events/AbstractContactPointUpdatedTest.php
+++ b/tests/Offer/Events/AbstractContactPointUpdatedTest.php
@@ -25,7 +25,7 @@ class AbstractContactPointUpdatedTest extends TestCase
      */
     protected $contactPoint;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->contactPoint = new ContactPoint(

--- a/tests/Offer/Events/AbstractDescriptionTranslatedTest.php
+++ b/tests/Offer/Events/AbstractDescriptionTranslatedTest.php
@@ -31,7 +31,7 @@ class AbstractDescriptionTranslatedTest extends TestCase
      */
     protected $description;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->language = new Language('en');

--- a/tests/Offer/Events/AbstractDescriptionUpdatedTest.php
+++ b/tests/Offer/Events/AbstractDescriptionUpdatedTest.php
@@ -25,7 +25,7 @@ class AbstractDescriptionUpdatedTest extends TestCase
      */
     protected $description;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->description = new Description('Description');

--- a/tests/Offer/Events/AbstractEventTest.php
+++ b/tests/Offer/Events/AbstractEventTest.php
@@ -19,7 +19,7 @@ class AbstractEventTest extends TestCase
      */
     protected $itemId;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->event = new MockAbstractEvent($this->itemId);

--- a/tests/Offer/Events/AbstractEventWithIriTest.php
+++ b/tests/Offer/Events/AbstractEventWithIriTest.php
@@ -23,7 +23,7 @@ class AbstractEventWithIriTest extends TestCase
      */
     protected $iri;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id = '1';
         $this->iri = 'event/1';

--- a/tests/Offer/Events/AbstractOrganizerEventTest.php
+++ b/tests/Offer/Events/AbstractOrganizerEventTest.php
@@ -23,7 +23,7 @@ class AbstractOrganizerEventTest extends TestCase
      */
     protected $organizerId;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->organizerId = 'my-organizer-123';

--- a/tests/Offer/Events/AbstractPropertyTranslatedEventTest.php
+++ b/tests/Offer/Events/AbstractPropertyTranslatedEventTest.php
@@ -30,7 +30,7 @@ class AbstractPropertyTranslatedEventTest extends TestCase
      */
     protected $title;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->language = new Language('en');

--- a/tests/Offer/Events/AbstractTitleTranslatedTest.php
+++ b/tests/Offer/Events/AbstractTitleTranslatedTest.php
@@ -31,7 +31,7 @@ class AbstractTitleTranslatedTest extends TestCase
      */
     protected $title;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->language = new Language('en');

--- a/tests/Offer/Events/AbstractTypicalAgeRangeUpdatedTest.php
+++ b/tests/Offer/Events/AbstractTypicalAgeRangeUpdatedTest.php
@@ -26,7 +26,7 @@ class AbstractTypicalAgeRangeUpdatedTest extends TestCase
      */
     protected $typicalAgeRange;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->itemId = 'Foo';
         $this->typicalAgeRange = new AgeRange(new Age(3), new Age(12));

--- a/tests/Offer/Events/Moderation/AbstractPublishedTest.php
+++ b/tests/Offer/Events/Moderation/AbstractPublishedTest.php
@@ -26,7 +26,7 @@ class AbstractPublishedTest extends TestCase
      */
     private $abstractPublished;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->itemId = '3dc2b894-9a80-11e6-9f33-a24fc0d9649c';
 

--- a/tests/Offer/Events/Moderation/AbstractRejectedTest.php
+++ b/tests/Offer/Events/Moderation/AbstractRejectedTest.php
@@ -25,7 +25,7 @@ class AbstractRejectedTest extends TestCase
      */
     private $abstractRejected;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->itemId = 'e1d026e2-d158-40e9-b82a-dfcd62de2a77';
         $this->reason = new StringLiteral('Het aanbod is hetzelfde als...');

--- a/tests/Offer/IriOfferIdentifierFactoryTest.php
+++ b/tests/Offer/IriOfferIdentifierFactoryTest.php
@@ -21,7 +21,7 @@ class IriOfferIdentifierFactoryTest extends TestCase
      */
     private $iriOfferIdentifierFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->regex = 'https?://foo\.bar/(?<offertype>[event|place]+)/(?<offerid>[a-zA-Z0-9\-]+)';
         $this->iriOfferIdentifierFactory = new IriOfferIdentifierFactory(

--- a/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
+++ b/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
@@ -23,7 +23,7 @@ class IriOfferIdentifierJSONDeserializerTest extends TestCase
      */
     private $iriOfferIdentifierFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->iriOfferIdentifierFactory = $this->createMock(IriOfferIdentifierFactoryInterface::class);
         $this->deserializer = new IriOfferIdentifierJSONDeserializer(

--- a/tests/Offer/IriOfferIdentifierTest.php
+++ b/tests/Offer/IriOfferIdentifierTest.php
@@ -14,7 +14,7 @@ class IriOfferIdentifierTest extends TestCase
      */
     private $identifier;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->identifier = new IriOfferIdentifier(
             new Url('http://du.de/place/1'),

--- a/tests/Offer/OfferLocatorTest.php
+++ b/tests/Offer/OfferLocatorTest.php
@@ -18,7 +18,7 @@ class OfferLocatorTest extends TestCase
      */
     protected $iriGenerator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->iriGenerator = $this->createMock(IriGeneratorInterface::class);
     }

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -440,10 +440,10 @@ class OfferTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
-     * @expectedException     Exception
      */
     public function it_should_throw_an_exception_when_selecting_an_unknown_main_image(): void
     {
+        $this->expectException(\Exception::class);
         $this->offer->selectMainImage($this->image);
     }
 
@@ -1381,11 +1381,11 @@ class OfferTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
-     * @expectedException        Exception
-     * @expectedExceptionMessage You can not approve an offer that is not ready for validation
      */
     public function it_should_not_approve_an_offer_after_it_was_rejected(): void
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('You can not approve an offer that is not ready for validation');
         $itemId = '4b5f30bf-a612-4cb9-bba0-4a77a4385a73';
         $reason = new StringLiteral('There are spelling mistakes in the description.');
 
@@ -1437,11 +1437,11 @@ class OfferTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
-     * @expectedException        Exception
-     * @expectedExceptionMessage The offer has already been rejected for another reason: The title is misleading.
      */
     public function it_should_not_reject_an_offer_that_is_already_rejected_for_a_different_reason(): void
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The offer has already been rejected for another reason: The title is misleading.');
         $itemId = '1cb18f8c-5be4-4301-9761-dea2bbfa9a1f';
         $reason = new StringLiteral('The title is misleading.');
         $differentReason = new StringLiteral('I\'m afraid I can\'t let you do that.');
@@ -1521,11 +1521,11 @@ class OfferTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
-     * @expectedException        Exception
-     * @expectedExceptionMessage The offer has already been rejected for another reason: duplicate
      */
     public function it_should_reject_an_offer_when_it_is_flagged_as_duplicate(): void
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The offer has already been rejected for another reason: duplicate');
         $itemId = '0e3a13ec-a88d-4cd5-9565-d7b00690c52f';
         $reason = new StringLiteral('The theme does not match the description.');
 
@@ -1575,11 +1575,11 @@ class OfferTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
-     * @expectedException        Exception
-     * @expectedExceptionMessage The offer has already been rejected for another reason: inappropriate
      */
     public function it_should_not_reject_an_offer_when_it_is_flagged_as_inappropriate(): void
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The offer has already been rejected for another reason: inappropriate');
         $itemId = '05f4b7f7-a0ed-4530-8b25-2a573fe7f305';
         $reason = new StringLiteral('The theme does not match the description.');
 
@@ -1601,11 +1601,11 @@ class OfferTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
-     * @expectedException        Exception
-     * @expectedExceptionMessage You can not reject an offer that is not ready for validation
      */
     public function it_should_not_reject_an_offer_that_is_flagged_as_approved(): void
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('You can not reject an offer that is not ready for validation');
         $itemId = '5988798b-c211-4c04-a9f4-ceb2568d93b3';
         $reason = new StringLiteral('Yeah, but no, but yeah...');
 

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -56,7 +56,6 @@ use CultuurNet\UDB3\Offer\Item\Events\VideoUpdated;
 use CultuurNet\UDB3\Offer\Item\Item;
 use CultuurNet\UDB3\Title;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
-use Exception;
 use CultuurNet\UDB3\StringLiteral;
 
 class OfferTest extends AggregateRootScenarioTestCase

--- a/tests/Offer/Popularity/PopularityEnrichedOfferRepositoryTest.php
+++ b/tests/Offer/Popularity/PopularityEnrichedOfferRepositoryTest.php
@@ -26,7 +26,7 @@ class PopularityEnrichedOfferRepositoryTest extends TestCase
      */
     private $popularityEnrichedOfferRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->popularityRepository = new InMemoryPopularityRepository();
         $this->decoratedRepository = new InMemoryDocumentRepository();

--- a/tests/Offer/ReadModel/JSONLD/CdbXmlContactInfoImporterTest.php
+++ b/tests/Offer/ReadModel/JSONLD/CdbXmlContactInfoImporterTest.php
@@ -18,7 +18,7 @@ class CdbXmlContactInfoImporterTest extends TestCase
      */
     private $cdbContactInfo;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cdbXmlContactInfoImporter = new CdbXmlContactInfoImporter();
 

--- a/tests/Offer/ReadModel/MainLanguage/JSONLDMainLanguageQueryTest.php
+++ b/tests/Offer/ReadModel/MainLanguage/JSONLDMainLanguageQueryTest.php
@@ -24,7 +24,7 @@ class JSONLDMainLanguageQueryTest extends TestCase
      */
     private $query;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->documentRepository = $this->createMock(DocumentRepository::class);
         $this->query = new JSONLDMainLanguageQuery($this->documentRepository, new Language('nl'));

--- a/tests/Offer/ReadModel/Metadata/OfferMetadataEnrichedOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/Metadata/OfferMetadataEnrichedOfferRepositoryTest.php
@@ -27,7 +27,7 @@ class OfferMetadataEnrichedOfferRepositoryTest extends TestCase
      */
     private $offerMetadataEnrichedOfferRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->offerMetadataRepository = $this->createMock(OfferMetadataRepository::class);
         $this->decoratedRepository = new InMemoryDocumentRepository();

--- a/tests/Organizer/Events/TitleTranslatedTest.php
+++ b/tests/Organizer/Events/TitleTranslatedTest.php
@@ -27,7 +27,7 @@ class TitleTranslatedTest extends TestCase
      */
     private $titleTranslatedAsArray;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->organizerId = '3ad6c135-9b2d-4360-8886-3a58aaf66039';
 

--- a/tests/Organizer/ReadModel/JSONLD/EventFactoryTest.php
+++ b/tests/Organizer/ReadModel/JSONLD/EventFactoryTest.php
@@ -20,7 +20,7 @@ class EventFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->iriGenerator = new CallableIriGenerator(
             function ($id) {

--- a/tests/Organizer/ReadModel/JSONLD/OrganizerJsonDocumentLanguageAnalyzerTest.php
+++ b/tests/Organizer/ReadModel/JSONLD/OrganizerJsonDocumentLanguageAnalyzerTest.php
@@ -15,7 +15,7 @@ class OrganizerJsonDocumentLanguageAnalyzerTest extends TestCase
      */
     private $analyzer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->analyzer = new OrganizerJsonDocumentLanguageAnalyzer();
     }

--- a/tests/Place/CanonicalPlaceRepositoryTest.php
+++ b/tests/Place/CanonicalPlaceRepositoryTest.php
@@ -19,7 +19,7 @@ class CanonicalPlaceRepositoryTest extends TestCase
      */
     private $placeRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->placeRepository = $this->createMock(PlaceRepository::class);
         $this->canonicalPlaceRepository = new CanonicalPlaceRepository($this->placeRepository);

--- a/tests/Place/Commands/UpdateMajorInfoTest.php
+++ b/tests/Place/Commands/UpdateMajorInfoTest.php
@@ -22,7 +22,7 @@ class UpdateMajorInfoTest extends TestCase
      */
     protected $updateMajorInfo;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->updateMajorInfo = new UpdateMajorInfo(
             'id',

--- a/tests/Place/DummyPlaceProjectionEnricherTest.php
+++ b/tests/Place/DummyPlaceProjectionEnricherTest.php
@@ -27,7 +27,7 @@ class DummyPlaceProjectionEnricherTest extends TestCase
      */
     private $dummyPlaceId;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dummyPlaceId = Uuid::uuid4()->toString();
         $this->repository = $this->createMock(DocumentRepository::class);

--- a/tests/Place/Events/CalendarUpdatedTest.php
+++ b/tests/Place/Events/CalendarUpdatedTest.php
@@ -31,7 +31,7 @@ class CalendarUpdatedTest extends TestCase
      */
     private $calendarUpdated;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->placeId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 

--- a/tests/Place/Events/PlaceCreatedTest.php
+++ b/tests/Place/Events/PlaceCreatedTest.php
@@ -36,7 +36,7 @@ class PlaceCreatedTest extends TestCase
      */
     private $placeCreated;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->address = new Address(
             new Street('Blubstraat 69'),

--- a/tests/Place/GeoCoordinatesProcessManagerTest.php
+++ b/tests/Place/GeoCoordinatesProcessManagerTest.php
@@ -52,7 +52,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
      */
     private $processManager;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->commandBus = $this->createMock(CommandBus::class);
         $this->addressFactory = new CultureFeedAddressFactory();

--- a/tests/Place/LocalPlaceServiceTest.php
+++ b/tests/Place/LocalPlaceServiceTest.php
@@ -38,7 +38,7 @@ class LocalPlaceServiceTest extends TestCase
      */
     private $localPlaceService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->documentRepository = $this->createMock(
             DocumentRepository::class

--- a/tests/Place/PlaceRepositoryTest.php
+++ b/tests/Place/PlaceRepositoryTest.php
@@ -43,7 +43,7 @@ class PlaceRepositoryTest extends TestCase
      */
     private $eventBus;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -623,8 +623,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' toegevoegd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -655,8 +655,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' verwijderd',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -691,8 +691,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -893,8 +893,8 @@ class HistoryProjectorTest extends TestCase
             [
                 (object) [
                     'date' => '2015-03-27T10:17:19+02:00',
-                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Publicatiedatum aangepast',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                 ],
             ]
         );
@@ -1112,8 +1112,8 @@ class HistoryProjectorTest extends TestCase
             [
                 [
                     'date' => self::OCCURRED_ON_FORMATTED,
-                    'author' => self::META_USER_ID,
                     'description' => $eventDescription,
+                    'author' => self::META_USER_ID,
                     'apiKey' => self::META_AUTH_API_KEY,
                     'api' => self::META_API,
                     'consumerName' => self::META_CONSUMER,

--- a/tests/Place/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Place/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -24,7 +24,7 @@ class CdbXMLImporterTest extends TestCase
      */
     protected $importer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->importer = new CdbXMLImporter(
             new CdbXMLItemBaseImporter(

--- a/tests/Place/ReadModel/JSONLD/EventFactoryTest.php
+++ b/tests/Place/ReadModel/JSONLD/EventFactoryTest.php
@@ -21,7 +21,7 @@ class EventFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->iriGenerator = $this->createMock(IriGeneratorInterface::class);
 

--- a/tests/Place/ReadModel/JSONLD/PlaceJsonDocumentLanguageAnalyzerTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceJsonDocumentLanguageAnalyzerTest.php
@@ -15,7 +15,7 @@ class PlaceJsonDocumentLanguageAnalyzerTest extends TestCase
      */
     private $analyzer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->analyzer = new PlaceJsonDocumentLanguageAnalyzer();
     }

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -53,7 +53,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
 {
     private Address $address;
 
-    public function __construct(string $name = null, array $data = [], string $dataName = '')
+    public function __construct(string $name = null, array $data = [], $dataName = '')
     {
         parent::__construct($name, $data, $dataName, 'CultuurNet\\UDB3\\Place');
     }

--- a/tests/Place/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Place/ReadModel/Permission/ProjectorTest.php
@@ -42,7 +42,7 @@ class ProjectorTest extends TestCase
      */
     private $userIdResolver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->repository = $this->createMock(ResourceOwnerRepository::class);
         $this->userIdResolver = $this->createMock(CreatedByToUserIdResolverInterface::class);

--- a/tests/Place/ReadModel/Relations/Doctrine/DBALRepositoryTest.php
+++ b/tests/Place/ReadModel/Relations/Doctrine/DBALRepositoryTest.php
@@ -23,7 +23,7 @@ class DBALRepositoryTest extends TestCase
      */
     private $tableName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->repository = new DBALPlaceRelationsRepository($this->getConnection());
 

--- a/tests/Place/ReadModel/Relations/PlaceRelationsProjectorTest.php
+++ b/tests/Place/ReadModel/Relations/PlaceRelationsProjectorTest.php
@@ -33,7 +33,7 @@ final class PlaceRelationsProjectorTest extends TestCase
      */
     private $projector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->repository = $this->createMock(PlaceRelationsRepository::class);
 

--- a/tests/ReadModel/BroadcastingDocumentRepositoryDecoratorTest.php
+++ b/tests/ReadModel/BroadcastingDocumentRepositoryDecoratorTest.php
@@ -30,7 +30,7 @@ class BroadcastingDocumentRepositoryDecoratorTest extends TestCase
      */
     protected $eventFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->decoratedRepository = $this->createMock(DocumentRepository::class);
         $this->eventBus = $this->createMock(EventBus::class);

--- a/tests/ReadModel/ConfigurableJsonDocumentLanguageAnalyzerTest.php
+++ b/tests/ReadModel/ConfigurableJsonDocumentLanguageAnalyzerTest.php
@@ -14,7 +14,7 @@ class ConfigurableJsonDocumentLanguageAnalyzerTest extends TestCase
      */
     private $analyzer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->analyzer = new ConfigurableJsonDocumentLanguageAnalyzer(
             [

--- a/tests/ReadModel/JsonDocumentLanguageEnricherTest.php
+++ b/tests/ReadModel/JsonDocumentLanguageEnricherTest.php
@@ -19,7 +19,7 @@ class JsonDocumentLanguageEnricherTest extends TestCase
      */
     private $enricher;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->languageAnalyzer = new ConfigurableJsonDocumentLanguageAnalyzer(
             [

--- a/tests/ReadModel/JsonDocumentNullEnricherTest.php
+++ b/tests/ReadModel/JsonDocumentNullEnricherTest.php
@@ -14,7 +14,7 @@ class JsonDocumentNullEnricherTest extends TestCase
      */
     private $enricher;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->enricher = new JsonDocumentNullEnricher();
     }

--- a/tests/RecordedOnTest.php
+++ b/tests/RecordedOnTest.php
@@ -16,7 +16,7 @@ class RecordedOnTest extends TestCase
      */
     private $recordedOn;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->recordedOn = RecordedOn::fromBroadwayDateTime(
             DateTime::fromString('2018-01-16T12:13:33Z')

--- a/tests/Role/Commands/AbstractUserCommandTest.php
+++ b/tests/Role/Commands/AbstractUserCommandTest.php
@@ -26,7 +26,7 @@ class AbstractUserCommandTest extends TestCase
      */
     private $userId;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('ebb777b2-6735-4636-8f60-f7bde4576036');
 

--- a/tests/Role/Commands/AddConstraintTest.php
+++ b/tests/Role/Commands/AddConstraintTest.php
@@ -25,7 +25,7 @@ class AddConstraintTest extends TestCase
      */
     protected $addConstraint;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('7ec197c5-b816-43e1-b057-ba1d25a04567');
         $this->query = new Query('city:3000');

--- a/tests/Role/Commands/AddUserTest.php
+++ b/tests/Role/Commands/AddUserTest.php
@@ -21,7 +21,7 @@ class AddUserTest extends TestCase
 
     private string $userId;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('7ce4cb7e-af7c-4724-bfbe-d943ac2b949a');
 

--- a/tests/Role/Commands/CreateRoleTest.php
+++ b/tests/Role/Commands/CreateRoleTest.php
@@ -21,7 +21,7 @@ class CreateRoleTest extends TestCase
      */
     protected $createRole;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('da3d5569-9d0b-4f52-b61e-1f81b4deeb01');
 

--- a/tests/Role/Commands/RemoveConstraintTest.php
+++ b/tests/Role/Commands/RemoveConstraintTest.php
@@ -13,7 +13,7 @@ class RemoveConstraintTest extends TestCase
 
     private RemoveConstraint $removeConstraint;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('45e61f58-e11b-4045-91a0-540e51c3a98d');
 

--- a/tests/Role/Commands/RemoveUserTest.php
+++ b/tests/Role/Commands/RemoveUserTest.php
@@ -15,7 +15,7 @@ class RemoveUserTest extends TestCase
 
     private string $userId;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('67780d64-b401-4040-af1f-5f424e0b7306');
 

--- a/tests/Role/Commands/RenameRoleTest.php
+++ b/tests/Role/Commands/RenameRoleTest.php
@@ -21,7 +21,7 @@ class RenameRoleTest extends TestCase
      */
     protected $renameRole;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('45264080-03ba-4ae7-87ee-0865a1ed0ae2');
 

--- a/tests/Role/Commands/UpdateConstraintTest.php
+++ b/tests/Role/Commands/UpdateConstraintTest.php
@@ -25,7 +25,7 @@ class UpdateConstraintTest extends TestCase
      */
     protected $updateConstraint;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('f311378a-a34a-4d5f-ad49-a861f022ccb1');
         $this->query = new Query('city:3000');

--- a/tests/Role/Events/AbstractLabelEventTest.php
+++ b/tests/Role/Events/AbstractLabelEventTest.php
@@ -25,7 +25,7 @@ class AbstractLabelEventTest extends TestCase
      */
     protected $event;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('1e99c6ab-6ff2-4611-96fa-eda8b8a78ae9');
         $this->labelId = new UUID('d50852d1-5351-46bc-8221-238c2d47e3cf');

--- a/tests/Role/Events/AbstractUserEventTest.php
+++ b/tests/Role/Events/AbstractUserEventTest.php
@@ -26,7 +26,7 @@ class AbstractUserEventTest extends TestCase
      */
     private $userId;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('7c296342-d72b-4444-9f8b-2a0c99763c9a');
 

--- a/tests/Role/Events/PermissionAddedTest.php
+++ b/tests/Role/Events/PermissionAddedTest.php
@@ -25,7 +25,7 @@ class PermissionAddedTest extends TestCase
      */
     protected $event;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('abb75a3f-92b3-4dbf-ba9a-d7e98e4f3655');
 

--- a/tests/Role/Events/RoleCreatedTest.php
+++ b/tests/Role/Events/RoleCreatedTest.php
@@ -25,7 +25,7 @@ class RoleCreatedTest extends TestCase
      */
     protected $roleCreated;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('12c98a43-978b-4a6f-a7da-67a4350a6fa1');
 

--- a/tests/Role/Events/RoleRenamedTest.php
+++ b/tests/Role/Events/RoleRenamedTest.php
@@ -25,7 +25,7 @@ class RoleRenamedTest extends TestCase
      */
     protected $roleRenamed;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('e97ed374-ca50-4d07-a893-637729341ab3');
 

--- a/tests/Role/Events/UserAddedTest.php
+++ b/tests/Role/Events/UserAddedTest.php
@@ -25,7 +25,7 @@ class UserAddedTest extends TestCase
      */
     private $userId;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('510610a1-ffe0-4e10-a396-7d0cb28e0619');
 

--- a/tests/Role/Events/UserRemovedTest.php
+++ b/tests/Role/Events/UserRemovedTest.php
@@ -25,7 +25,7 @@ class UserRemovedTest extends TestCase
      */
     private $userId;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('510610a1-ffe0-4e10-a396-7d0cb28e0619');
 

--- a/tests/Role/ReadModel/Constraints/Doctrine/UserConstraintsReadRepositoryTest.php
+++ b/tests/Role/ReadModel/Constraints/Doctrine/UserConstraintsReadRepositoryTest.php
@@ -85,14 +85,7 @@ class UserConstraintsReadRepositoryTest extends TestCase
             new StringLiteral('zipCode:3000'),
         ];
 
-        $this->assertEquals(
-            $expectedConstraints,
-            $constraints,
-            'Constraints do not match expected!',
-            0.0,
-            0,
-            true
-        );
+        $this->assertEqualsCanonicalizing($expectedConstraints, $constraints, 'Constraints do not match expected!');
     }
 
     /**

--- a/tests/Role/ReadModel/Labels/RoleLabelsProjectorTest.php
+++ b/tests/Role/ReadModel/Labels/RoleLabelsProjectorTest.php
@@ -46,7 +46,7 @@ class RoleLabelsProjectorTest extends TestCase
      */
     private $roleLabelsRepository;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->roleLabelsRepository = $this->createMock(DocumentRepository::class);
         $this->labelJsonRepository = $this->createMock(ReadRepositoryInterface::class);

--- a/tests/Role/ReadModel/Permissions/Doctrine/UserPermissionsReadRepositoryTest.php
+++ b/tests/Role/ReadModel/Permissions/Doctrine/UserPermissionsReadRepositoryTest.php
@@ -107,14 +107,7 @@ class UserPermissionsReadRepositoryTest extends TestCase
             Permission::gebruikersBeheren(),
             Permission::aanbodModereren(),
         ];
-        $this->assertEquals(
-            $expectedPermissions,
-            $permissions,
-            'User permissions do not match expected!',
-            0.0,
-            10,
-            true
-        );
+        $this->assertEqualsCanonicalizing($expectedPermissions, $permissions, 'User permissions do not match expected!');
 
         $otherUserPermissions = $this->repository->getPermissions('otherUserId');
         $this->assertEmpty($otherUserPermissions);

--- a/tests/Role/ReadModel/Search/Doctrine/DBALRepositoryTest.php
+++ b/tests/Role/ReadModel/Search/Doctrine/DBALRepositoryTest.php
@@ -27,7 +27,7 @@ class DBALRepositoryTest extends TestCase
      */
     private $tableName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tableName = new StringLiteral('test_roles_search');
 

--- a/tests/Role/ReadModel/Users/RoleUsersProjectorTest.php
+++ b/tests/Role/ReadModel/Users/RoleUsersProjectorTest.php
@@ -44,7 +44,7 @@ class RoleUsersProjectorTest extends TestCase
      */
     private $userIdentityDetail;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->repository = $this->createMock(DocumentRepository::class);
 

--- a/tests/Role/ReadModel/Users/UserRolesProjectorTest.php
+++ b/tests/Role/ReadModel/Users/UserRolesProjectorTest.php
@@ -42,7 +42,7 @@ class UserRolesProjectorTest extends TestCase
      */
     private $userRolesProjector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->userRolesDocumentRepository = $this->createMock(
             DocumentRepository::class

--- a/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
+++ b/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
@@ -21,7 +21,7 @@ class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
      */
     protected $deserializer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->userId = new StringLiteral('xyx');
 

--- a/tests/Security/LabelCommandBusSecurityTest.php
+++ b/tests/Security/LabelCommandBusSecurityTest.php
@@ -41,7 +41,7 @@ class LabelCommandBusSecurityTest extends TestCase
      */
     private $addLabel;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->securityDecoratee = $this->createMock(CommandBusSecurity::class);
 

--- a/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
+++ b/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
@@ -20,7 +20,7 @@ class CombinedResourceOwnerQueryTest extends TestCase
      */
     private $combinedPermissionQuery;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->permissionQueries[] = $this->createPermissionQuery([
             new StringLiteral('offerId1'),

--- a/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
+++ b/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
@@ -17,7 +17,7 @@ class DBALResourceOwnerRepositoryTest extends TestCase
      */
     private $repository;
 
-    public function setUp()
+    public function setUp(): void
     {
         $table = new StringLiteral('event_permission');
         $idField = new StringLiteral('event_id');

--- a/tests/StringFilter/StringFilterTest.php
+++ b/tests/StringFilter/StringFilterTest.php
@@ -29,7 +29,7 @@ abstract class StringFilterTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->filter = $this->getFilter();

--- a/tests/UiTID/CdbXmlCreatedByToUserIdResolverTest.php
+++ b/tests/UiTID/CdbXmlCreatedByToUserIdResolverTest.php
@@ -29,7 +29,7 @@ class CdbXmlCreatedByToUserIdResolverTest extends TestCase
      */
     private $resolver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->users = $this->createMock(UserIdentityResolver::class);
         $this->resolver = new CdbXmlCreatedByToUserIdResolver($this->users);

--- a/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
+++ b/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
@@ -15,7 +15,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
      */
     private $deserializer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->deserializer = new EventCardSystemsUpdatedDeserializer();
     }

--- a/tests/ValueObject/MultilingualStringTest.php
+++ b/tests/ValueObject/MultilingualStringTest.php
@@ -38,7 +38,7 @@ class MultilingualStringTest extends TestCase
      */
     private $multilingualString;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->originalLanguage = new Language('nl');
         $this->originalString = new StringLiteral(


### PR DESCRIPTION
### Added

- Added `rector/rector` to help refactor PHPUnit TestCase classes so they're compatible with never PHPUnit versions

### Changed

- Updated `phpunit/phpunit` to v9

---
Ticket: https://jira.uitdatabank.be/browse/III-5031

Note: Some tests now report deprecation warnings, mostly due to the `at()` method being deprecated and being removed in PHPUnit 10. I decided not to fix those in this PR because we still have time to refactor those before PHPUnit v10 is released, and the tests will still fail if something is actually broken so they're still useful. And refactoring them to not use `at()` would increase the scope of this PR a lot.
