### PR TITLE
III-5042 Fix impersonator service name in getProvidedServiceNames()

### DIFF
--- a/app/Authentication/AuthServiceProvider.php
+++ b/app/Authentication/AuthServiceProvider.php
@@ -32,7 +32,7 @@ final class AuthServiceProvider extends AbstractServiceProvider
             ApiKey::class,
             ConsumerReadRepository::class,
             Consumer::class,
-            Impersonator::class,
+            'impersonator',
         ];
     }
 


### PR DESCRIPTION
### Fixed

- Fixed `PHP Fatal error:  Uncaught League\Container\Exception\NotFoundException: Alias (impersonator) is not being managed by the container or delegates in /var/www/udb-silex/vendor/league/container/src/Container.php:194`

---
Ticket: https://jira.uitdatabank.be/browse/III-5042
