### PR TITLE
III-4256 offer image post

### DIFF
--- a/app/Offer/OfferServiceProvider.php
+++ b/app/Offer/OfferServiceProvider.php
@@ -510,7 +510,10 @@ final class OfferServiceProvider extends AbstractServiceProvider
 
         $container->addShared(
             AddImageRequestHandler::class,
-            fn () => new AddImageRequestHandler($container->get('event_command_bus'))
+            fn () => new AddImageRequestHandler(
+                $container->get('event_command_bus'),
+                $container->get('media_object_repository'),
+            )
         );
 
         $container->addShared(

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-uitdatabank/III-4256-offer-image-post",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/III-4256-offer-image-post",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "883995971da3586e2840a47c771dec17",
+    "content-hash": "a07a771e5952458ff73b41d866dcaad2",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5576,18 +5576,19 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-uitdatabank/III-4256-offer-image-post",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "d52139160854e1e24794d1c6cd8b551c18243e5a"
+                "reference": "a94123c359daf38446da779583b5442d99d1be77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/d52139160854e1e24794d1c6cd8b551c18243e5a",
-                "reference": "d52139160854e1e24794d1c6cd8b551c18243e5a",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/a94123c359daf38446da779583b5442d99d1be77",
+                "reference": "a94123c359daf38446da779583b5442d99d1be77",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5602,9 +5603,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-4256-offer-image-post"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
-            "time": "2022-10-26T09:43:02+00:00"
+            "time": "2022-10-27T11:05:07+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a07a771e5952458ff73b41d866dcaad2",
+    "content-hash": "883995971da3586e2840a47c771dec17",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5576,19 +5576,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/III-4256-offer-image-post",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "a4d38c813a24b48acd0b83ce5d3828dd306d0c57"
+                "reference": "d52139160854e1e24794d1c6cd8b551c18243e5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/a4d38c813a24b48acd0b83ce5d3828dd306d0c57",
-                "reference": "a4d38c813a24b48acd0b83ce5d3828dd306d0c57",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/d52139160854e1e24794d1c6cd8b551c18243e5a",
+                "reference": "d52139160854e1e24794d1c6cd8b551c18243e5a",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5603,9 +5602,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-4256-offer-image-post"
             },
-            "time": "2022-10-26T06:29:39+00:00"
+            "time": "2022-10-26T09:43:02+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Http/Offer/AddImageRequestHandler.php
+++ b/src/Http/Offer/AddImageRequestHandler.php
@@ -30,6 +30,8 @@ final class AddImageRequestHandler implements RequestHandlerInterface
     {
         $routeParameters = new RouteParameters($request);
         $offerId = $routeParameters->getOfferId();
+        $offerType = $routeParameters->getOfferType();
+
         $bodyContent = Json::decode($request->getBody()->getContents());
 
         if (empty($bodyContent->mediaObjectId)) {
@@ -39,7 +41,7 @@ final class AddImageRequestHandler implements RequestHandlerInterface
         // @todo Validate that this id exists and is in fact an image and not a different type of media object
         $imageId = new UUID($bodyContent->mediaObjectId);
 
-        if ($routeParameters->getOfferType()->sameAs(OfferType::event())) {
+        if ($offerType->sameAs(OfferType::event())) {
             $addImage = new EventAddImage(
                 $offerId,
                 $imageId

--- a/src/Http/Organizer/AddMediaObjectPropertiesRequestBodyParser.php
+++ b/src/Http/Organizer/AddMediaObjectPropertiesRequestBodyParser.php
@@ -15,16 +15,19 @@ final class AddMediaObjectPropertiesRequestBodyParser implements RequestBodyPars
 {
     private Repository $mediaRepository;
 
-    public function __construct(Repository $mediaRepository)
+    private string $idField;
+
+    public function __construct(Repository $mediaRepository, string $idField = 'id')
     {
         $this->mediaRepository = $mediaRepository;
+        $this->idField = $idField;
     }
 
     public function parse(ServerRequestInterface $request): ServerRequestInterface
     {
         $data = (array) $request->getParsedBody();
 
-        $imageId = $data['id'];
+        $imageId = $data[$this->idField];
 
         try {
             /** @var MediaObject $mediaObject */
@@ -34,7 +37,7 @@ final class AddMediaObjectPropertiesRequestBodyParser implements RequestBodyPars
         }
 
         $convertedData = [];
-        $convertedData['id'] = $imageId;
+        $convertedData[$this->idField] = $imageId;
         $convertedData['language'] = $data['language'] ?? $mediaObject->getLanguage()->getCode();
         $convertedData['description'] = $data['description'] ?? $mediaObject->getDescription()->toNative();
         $convertedData['copyrightHolder'] = $data['copyrightHolder'] ?? $mediaObject->getCopyrightHolder()->toString();

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -26,6 +26,7 @@ final class JsonSchemaLocator
     public const EVENT_CALENDAR_PUT = 'event-calendar-put.json';
     public const EVENT_DESCRIPTION_PUT = 'event-description-put.json';
     public const EVENT_FACILITIES_PUT = 'event-facilities-put.json';
+    public const EVENT_IMAGE_POST = 'event-image-post.json';
     public const EVENT_PRICE_INFO_PUT = 'event-priceInfo.json';
     public const EVENT_STATUS = 'event-status.json';
     public const EVENT_SUB_EVENT_PATCH = 'event-subEvent-patch.json';
@@ -40,6 +41,7 @@ final class JsonSchemaLocator
     public const PLACE_CALENDAR_PUT = 'place-calendar-put.json';
     public const PLACE_DESCRIPTION_PUT = 'place-description-put.json';
     public const PLACE_FACILITIES_PUT = 'place-facilities-put.json';
+    public const PLACE_IMAGE_POST = 'place-image-post.json';
     public const PLACE_PRICE_INFO_PUT = 'place-priceInfo.json';
     public const PLACE_STATUS = 'place-status.json';
     public const PLACE_VIDEOS_PATCH = 'place-videos-patch.json';

--- a/src/Offer/Serializers/AddImageDenormalizer.php
+++ b/src/Offer/Serializers/AddImageDenormalizer.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\Serializers;
+
+use CultuurNet\UDB3\Event\Commands\AddImage as EventAddImage;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Offer\Commands\Image\AbstractAddImage;
+use CultuurNet\UDB3\Offer\OfferType;
+use CultuurNet\UDB3\Place\Commands\AddImage as PlaceAddImage;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class AddImageDenormalizer implements DenormalizerInterface
+{
+    private OfferType $offerType;
+
+    private string $offerId;
+
+    public function __construct(OfferType $offerType, string $offerId)
+    {
+        $this->offerType = $offerType;
+        $this->offerId = $offerId;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = []): AbstractAddImage
+    {
+        if ($this->offerType->sameAs(OfferType::event())) {
+            return new EventAddImage(
+                $this->offerId,
+                new UUID($data['mediaObjectId'])
+            );
+        } else {
+            return new PlaceAddImage(
+                $this->offerId,
+                new UUID($data['mediaObjectId'])
+            );
+        }
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === AbstractAddImage::class;
+    }
+}

--- a/tests/Http/Offer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Offer/AddImageRequestHandlerTest.php
@@ -8,6 +8,7 @@ use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use CultuurNet\UDB3\Event\Commands\AddImage as EventAddImage;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
@@ -89,7 +90,9 @@ final class AddImageRequestHandlerTest extends TestCase
             ->build('POST');
 
         $this->assertCallableThrowsApiProblem(
-            ApiProblem::bodyInvalidDataWithDetail('media object id required'),
+            ApiProblem::bodyInvalidData(
+                new SchemaError('/', 'The required properties (mediaObjectId) are missing')
+            ),
             fn () => $this->addImageRequestHandler->handle($addImageRequest)
         );
     }

--- a/tests/Http/Offer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Offer/AddImageRequestHandlerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use Broadway\Repository\AggregateNotFoundException;
+use Broadway\Repository\Repository;
 use CultuurNet\UDB3\Event\Commands\AddImage as EventAddImage;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
@@ -12,9 +14,16 @@ use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Language as LegacyLanguage;
+use CultuurNet\UDB3\Media\MediaObject;
+use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\Commands\Image\AbstractAddImage;
 use CultuurNet\UDB3\Place\Commands\AddImage as PlaceAddImage;
+use CultuurNet\UDB3\StringLiteral;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class AddImageRequestHandlerTest extends TestCase
@@ -31,12 +40,18 @@ final class AddImageRequestHandlerTest extends TestCase
 
     private Psr7RequestBuilder $psr7RequestBuilder;
 
+    /** @var Repository|MockObject */
+    private $imageRepository;
+
     protected function setUp(): void
     {
         $this->commandBus = new TraceableCommandBus();
 
+        $this->imageRepository = $this->createMock(Repository::class);
+
         $this->addImageRequestHandler = new AddImageRequestHandler(
-            $this->commandBus
+            $this->commandBus,
+            $this->imageRepository,
         );
 
         $this->psr7RequestBuilder = new Psr7RequestBuilder();
@@ -59,6 +74,19 @@ final class AddImageRequestHandlerTest extends TestCase
                 '{ "mediaObjectId": "' . self::MEDIA_ID . '" }'
             )
             ->build('POST');
+
+        $this->imageRepository->method('load')
+            ->with(self::MEDIA_ID)
+            ->willReturn(
+                MediaObject::create(
+                    new UUID(self::MEDIA_ID),
+                    MIMEType::fromSubtype('jpeg'),
+                    new StringLiteral('Uploaded image'),
+                    new CopyrightHolder('madewithlove'),
+                    new Url('https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg'),
+                    new LegacyLanguage('nl')
+                )
+            );
 
         $response = $this->addImageRequestHandler->handle($addImageRequest);
 
@@ -94,6 +122,29 @@ final class AddImageRequestHandlerTest extends TestCase
                 new SchemaError('/', 'The required properties (mediaObjectId) are missing')
             ),
             fn () => $this->addImageRequestHandler->handle($addImageRequest)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider offerTypeDataProvider
+     */
+    public function it_throws_an_api_problem_when_image_not_found(string $offerType): void
+    {
+        $unknownImageId = '08805a3c-ffe0-4c94-a1bc-453a6dd9d01f';
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('offerType', $offerType)
+            ->withRouteParameter('offerId', self::OFFER_ID)
+            ->withJsonBodyFromArray(['mediaObjectId' => $unknownImageId])
+            ->build('POST');
+
+        $this->imageRepository->method('load')
+            ->with($unknownImageId)
+            ->willThrowException(new AggregateNotFoundException());
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::imageNotFound($unknownImageId),
+            fn () => $this->addImageRequestHandler->handle($request)
         );
     }
 


### PR DESCRIPTION
### Changed
- use JSON schema validation in `Offer\AddImageRequestHandler`.
- `AddImageRequestHandler` will throw an `ApiProblem` when the image could not be found.

### Fixed
- `AddImageRequestHandler` would crash when the `mediaObjectId` wasn't a UUID.

---
Ticket: https://jira.uitdatabank.be/browse/III-4256
