### PR TITLE
III-4258 update offer image

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-uitdatabank/III-4258-offer-image-update ",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/III-4258-offer-image-update ",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a07a771e5952458ff73b41d866dcaad2",
+    "content-hash": "c6a7d880448b4cf237b74d070f3e2ad5",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5576,19 +5576,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/III-4258-offer-image-update",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "a4d38c813a24b48acd0b83ce5d3828dd306d0c57"
+                "reference": "6455c2a7a11ec58a3826679c28e8e803bf78968c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/a4d38c813a24b48acd0b83ce5d3828dd306d0c57",
-                "reference": "a4d38c813a24b48acd0b83ce5d3828dd306d0c57",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/6455c2a7a11ec58a3826679c28e8e803bf78968c",
+                "reference": "6455c2a7a11ec58a3826679c28e8e803bf78968c",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5603,9 +5602,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-4258-offer-image-update"
             },
-            "time": "2022-10-26T06:29:39+00:00"
+            "time": "2022-10-27T13:45:50+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -5580,12 +5580,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "a94123c359daf38446da779583b5442d99d1be77"
+                "reference": "7549bd316f628fd00f5df849521b014800cbd04d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/a94123c359daf38446da779583b5442d99d1be77",
-                "reference": "a94123c359daf38446da779583b5442d99d1be77",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/7549bd316f628fd00f5df849521b014800cbd04d",
+                "reference": "7549bd316f628fd00f5df849521b014800cbd04d",
                 "shasum": ""
             },
             "default-branch": true,
@@ -5605,7 +5605,7 @@
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
                 "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
-            "time": "2022-10-27T11:05:07+00:00"
+            "time": "2022-11-02T12:27:19+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -5580,12 +5580,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "6455c2a7a11ec58a3826679c28e8e803bf78968c"
+                "reference": "7549bd316f628fd00f5df849521b014800cbd04d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/6455c2a7a11ec58a3826679c28e8e803bf78968c",
-                "reference": "6455c2a7a11ec58a3826679c28e8e803bf78968c",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/7549bd316f628fd00f5df849521b014800cbd04d",
+                "reference": "7549bd316f628fd00f5df849521b014800cbd04d",
                 "shasum": ""
             },
             "type": "library",
@@ -5604,7 +5604,7 @@
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
                 "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-4258-offer-image-update"
             },
-            "time": "2022-10-27T13:45:50+00:00"
+            "time": "2022-11-02T12:27:19+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6a7d880448b4cf237b74d070f3e2ad5",
+    "content-hash": "a07a771e5952458ff73b41d866dcaad2",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5576,18 +5576,19 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-uitdatabank/III-4258-offer-image-update",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "7549bd316f628fd00f5df849521b014800cbd04d"
+                "reference": "a94123c359daf38446da779583b5442d99d1be77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/7549bd316f628fd00f5df849521b014800cbd04d",
-                "reference": "7549bd316f628fd00f5df849521b014800cbd04d",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/a94123c359daf38446da779583b5442d99d1be77",
+                "reference": "a94123c359daf38446da779583b5442d99d1be77",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5602,9 +5603,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-4258-offer-image-update"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
-            "time": "2022-11-02T12:27:19+00:00"
+            "time": "2022-10-27T11:05:07+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Http/Offer/UpdateImageRequestHandler.php
+++ b/src/Http/Offer/UpdateImageRequestHandler.php
@@ -5,20 +5,16 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\CommandBus;
-use CultuurNet\UDB3\Event\Commands\UpdateImage as EventUpdateImage;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
-use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
-use CultuurNet\UDB3\Offer\OfferType;
-use CultuurNet\UDB3\Place\Commands\UpdateImage as PlaceUpdateImage;
-use CultuurNet\UDB3\StringLiteral;
-use Psr\Http\Message\ResponseInterface;
+use CultuurNet\UDB3\Offer\Commands\Image\AbstractUpdateImage;
+use CultuurNet\UDB3\Offer\Serializers\UpdateImageDenormalizer;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
@@ -32,13 +28,11 @@ final class UpdateImageRequestHandler implements RequestHandlerInterface
         $this->commandBus = $commandBus;
     }
 
-    public function handle(ServerRequestInterface $request): ResponseInterface
+    public function handle(ServerRequestInterface $request): NoContentResponse
     {
         $routeParameters = new RouteParameters($request);
         $offerType = $routeParameters->getOfferType();
         $offerId = $routeParameters->getOfferId();
-
-        $bodyContent = Json::decode($request->getBody()->getContents());
 
         try {
             $mediaId = new UUID($routeParameters->getMediaId());
@@ -53,29 +47,17 @@ final class UpdateImageRequestHandler implements RequestHandlerInterface
                     JsonSchemaLocator::EVENT_IMAGE_PUT,
                     JsonSchemaLocator::PLACE_IMAGE_PUT,
                 )
-            )
+            ),
+            new DenormalizingRequestBodyParser(
+                new UpdateImageDenormalizer($offerType, $offerId, $mediaId),
+                AbstractUpdateImage::class,
+            ),
         );
 
-        $requestBodyParser->parse($request);
+        $request = $requestBodyParser->parse($request);
 
-        $description = new StringLiteral($bodyContent->description);
-        $copyrightHolder = new CopyrightHolder($bodyContent->copyrightHolder);
-
-        if ($offerType->sameAs(OfferType::event())) {
-            $updateImage = new EventUpdateImage(
-                $offerId,
-                $mediaId,
-                $description,
-                $copyrightHolder
-            );
-        } else {
-            $updateImage = new PlaceUpdateImage(
-                $offerId,
-                $mediaId,
-                $description,
-                $copyrightHolder
-            );
-        }
+        /** @var AbstractUpdateImage $updateImage */
+        $updateImage = $request->getParsedBody();
 
         $this->commandBus->dispatch($updateImage);
 

--- a/src/Http/Offer/UpdateImageRequestHandler.php
+++ b/src/Http/Offer/UpdateImageRequestHandler.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Event\Commands\UpdateImage as EventUpdateImage;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Json;
@@ -32,7 +33,11 @@ final class UpdateImageRequestHandler implements RequestHandlerInterface
     {
         $routeParameters = new RouteParameters($request);
         $offerId = $routeParameters->getOfferId();
-        $mediaId = new UUID($routeParameters->getMediaId());
+        try {
+            $mediaId = new UUID($routeParameters->getMediaId());
+        } catch (\InvalidArgumentException $exception) {
+            throw ApiProblem::imageNotFound($routeParameters->getMediaId());
+        }
         $bodyContent = Json::decode($request->getBody()->getContents());
 
         $description = new StringLiteral($bodyContent->description);

--- a/src/Http/Offer/UpdateImageRequestHandler.php
+++ b/src/Http/Offer/UpdateImageRequestHandler.php
@@ -32,7 +32,9 @@ final class UpdateImageRequestHandler implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $routeParameters = new RouteParameters($request);
+        $offerType = $routeParameters->getOfferType();
         $offerId = $routeParameters->getOfferId();
+
         try {
             $mediaId = new UUID($routeParameters->getMediaId());
         } catch (\InvalidArgumentException $exception) {
@@ -43,7 +45,7 @@ final class UpdateImageRequestHandler implements RequestHandlerInterface
         $description = new StringLiteral($bodyContent->description);
         $copyrightHolder = new CopyrightHolder($bodyContent->copyrightHolder);
 
-        if ($routeParameters->getOfferType()->sameAs(OfferType::event())) {
+        if ($offerType->sameAs(OfferType::event())) {
             $updateImage = new EventUpdateImage(
                 $offerId,
                 $mediaId,

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -26,6 +26,7 @@ final class JsonSchemaLocator
     public const EVENT_CALENDAR_PUT = 'event-calendar-put.json';
     public const EVENT_DESCRIPTION_PUT = 'event-description-put.json';
     public const EVENT_FACILITIES_PUT = 'event-facilities-put.json';
+    public const EVENT_IMAGE_PUT = 'event-image-put.json';
     public const EVENT_PRICE_INFO_PUT = 'event-priceInfo.json';
     public const EVENT_STATUS = 'event-status.json';
     public const EVENT_SUB_EVENT_PATCH = 'event-subEvent-patch.json';
@@ -40,6 +41,7 @@ final class JsonSchemaLocator
     public const PLACE_CALENDAR_PUT = 'place-calendar-put.json';
     public const PLACE_DESCRIPTION_PUT = 'place-description-put.json';
     public const PLACE_FACILITIES_PUT = 'place-facilities-put.json';
+    public const PLACE_IMAGE_PUT = 'place-image-put.json';
     public const PLACE_PRICE_INFO_PUT = 'place-priceInfo.json';
     public const PLACE_STATUS = 'place-status.json';
     public const PLACE_VIDEOS_PATCH = 'place-videos-patch.json';

--- a/src/Offer/Commands/Image/AbstractUpdateImage.php
+++ b/src/Offer/Commands/Image/AbstractUpdateImage.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Offer\Commands\Image;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Offer\Commands\AbstractCommand;
-use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractUpdateImage extends AbstractCommand
 {
@@ -34,9 +33,9 @@ abstract class AbstractUpdateImage extends AbstractCommand
         return $this->mediaObjectId;
     }
 
-    public function getDescription(): StringLiteral
+    public function getDescription(): string
     {
-        return new StringLiteral($this->description);
+        return $this->description;
     }
 
     public function getCopyrightHolder(): CopyrightHolder

--- a/src/Offer/Commands/Image/AbstractUpdateImage.php
+++ b/src/Offer/Commands/Image/AbstractUpdateImage.php
@@ -13,20 +13,14 @@ abstract class AbstractUpdateImage extends AbstractCommand
 {
     protected UUID $mediaObjectId;
 
-    /**
-     * @var StringLiteral
-     */
-    protected $description;
+    protected string $description;
 
-    /**
-     * @var CopyrightHolder
-     */
-    protected $copyrightHolder;
+    protected CopyrightHolder $copyrightHolder;
 
     public function __construct(
         string $itemId,
         UUID $mediaObjectId,
-        StringLiteral $description,
+        string $description,
         CopyrightHolder $copyrightHolder
     ) {
         parent::__construct($itemId);
@@ -42,7 +36,7 @@ abstract class AbstractUpdateImage extends AbstractCommand
 
     public function getDescription(): StringLiteral
     {
-        return $this->description;
+        return new StringLiteral($this->description);
     }
 
     public function getCopyrightHolder(): CopyrightHolder

--- a/src/Offer/OfferCommandHandler.php
+++ b/src/Offer/OfferCommandHandler.php
@@ -25,6 +25,7 @@ use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractFlagAsInappropriate;
 use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractPublish;
 use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractReject;
 use CultuurNet\UDB3\Organizer\Organizer;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class OfferCommandHandler extends Udb3CommandHandler
 {
@@ -200,7 +201,7 @@ abstract class OfferCommandHandler extends Udb3CommandHandler
         $offer = $this->load($updateImage->getItemId());
         $offer->updateImage(
             $updateImage->getMediaObjectId(),
-            $updateImage->getDescription(),
+            new StringLiteral($updateImage->getDescription()),
             $updateImage->getCopyrightHolder()
         );
         $this->offerRepository->save($offer);

--- a/src/Offer/Serializers/UpdateImageDenormalizer.php
+++ b/src/Offer/Serializers/UpdateImageDenormalizer.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\Serializers;
+
+use CultuurNet\UDB3\Event\Commands\UpdateImage as EventUpdateImage;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Offer\Commands\Image\AbstractUpdateImage;
+use CultuurNet\UDB3\Offer\OfferType;
+use CultuurNet\UDB3\Place\Commands\UpdateImage as PlaceUpdateImage;
+use CultuurNet\UDB3\StringLiteral;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class UpdateImageDenormalizer implements DenormalizerInterface
+{
+    private OfferType $offerType;
+
+    private string $offerId;
+
+    private UUID $mediaObjectId;
+
+    public function __construct(OfferType $offerType, string $offerId, UUID $mediaObjectId)
+    {
+        $this->offerType = $offerType;
+        $this->offerId = $offerId;
+        $this->mediaObjectId = $mediaObjectId;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = []): AbstractUpdateImage
+    {
+        if ($this->offerType->sameAs(OfferType::event())) {
+            return new EventUpdateImage(
+                $this->offerId,
+                $this->mediaObjectId,
+                new StringLiteral($data['description']),
+                new CopyrightHolder($data['copyrightHolder'])
+            );
+        } else {
+            return new PlaceUpdateImage(
+                $this->offerId,
+                $this->mediaObjectId,
+                new StringLiteral($data['description']),
+                new CopyrightHolder($data['copyrightHolder'])
+            );
+        }
+    }
+
+    public function supportsDenormalization($data, $type, $format = null): bool
+    {
+        return $type === AbstractUpdateImage::class;
+    }
+}

--- a/src/Offer/Serializers/UpdateImageDenormalizer.php
+++ b/src/Offer/Serializers/UpdateImageDenormalizer.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Offer\Commands\Image\AbstractUpdateImage;
 use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Place\Commands\UpdateImage as PlaceUpdateImage;
-use CultuurNet\UDB3\StringLiteral;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class UpdateImageDenormalizer implements DenormalizerInterface
@@ -34,14 +33,14 @@ final class UpdateImageDenormalizer implements DenormalizerInterface
             return new EventUpdateImage(
                 $this->offerId,
                 $this->mediaObjectId,
-                new StringLiteral($data['description']),
+                $data['description'],
                 new CopyrightHolder($data['copyrightHolder'])
             );
         } else {
             return new PlaceUpdateImage(
                 $this->offerId,
                 $this->mediaObjectId,
-                new StringLiteral($data['description']),
+                $data['description'],
                 new CopyrightHolder($data['copyrightHolder'])
             );
         }

--- a/tests/Http/Offer/UpdateImageRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateImageRequestHandlerTest.php
@@ -185,9 +185,9 @@ class UpdateImageRequestHandlerTest extends TestCase
                 ),
             ],
             [
-                '{"description": "An image", "copyrightHolder": "ma"}',
+                '{"description": "An image", "copyrightHolder": "m"}',
                 ApiProblem::bodyInvalidData(
-                    new SchemaError('/copyrightHolder', 'Minimum string length is 3, found 2')
+                    new SchemaError('/copyrightHolder', 'Minimum string length is 2, found 1')
                 ),
             ],
         ];

--- a/tests/Http/Offer/UpdateImageRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateImageRequestHandlerTest.php
@@ -16,7 +16,6 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Offer\Commands\Image\AbstractUpdateImage;
 use CultuurNet\UDB3\Place\Commands\UpdateImage as PlaceUpdateImage;
-use CultuurNet\UDB3\StringLiteral;
 use PHPUnit\Framework\TestCase;
 
 class UpdateImageRequestHandlerTest extends TestCase
@@ -117,7 +116,7 @@ class UpdateImageRequestHandlerTest extends TestCase
                 'updateImage' => new EventUpdateImage(
                     self::OFFER_ID,
                     new UUID(self::MEDIA_ID),
-                    new StringLiteral('A new picture of a picture'),
+                    'A new picture of a picture',
                     new CopyrightHolder('Public Domain')
                 ),
             ],
@@ -126,7 +125,7 @@ class UpdateImageRequestHandlerTest extends TestCase
                 'updateImage' => new PlaceUpdateImage(
                     self::OFFER_ID,
                     new UUID(self::MEDIA_ID),
-                    new StringLiteral('A new picture of a picture'),
+                    'A new picture of a picture',
                     new CopyrightHolder('Public Domain')
                 ),
             ],

--- a/tests/Http/Organizer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/AddImageRequestHandlerTest.php
@@ -246,10 +246,10 @@ final class AddImageRequestHandlerTest extends TestCase
                     "id":"08805a3c-ffe0-4c94-a1bc-453a6dd9d01f",
                     "language":"en",
                     "description":"A nice image",
-                    "copyrightHolder":""
+                    "copyrightHolder":"a"
                 }',
                 ApiProblem::bodyInvalidData(
-                    new SchemaError('/copyrightHolder', 'Minimum string length is 3, found 0')
+                    new SchemaError('/copyrightHolder', 'Minimum string length is 2, found 1')
                 ),
             ],
             [

--- a/tests/OfferCommandHandlerTestTrait.php
+++ b/tests/OfferCommandHandlerTestTrait.php
@@ -196,7 +196,7 @@ trait OfferCommandHandlerTestTrait
     {
         $itemId = '1';
         $mediaObjectId = new UUID('de305d54-75b4-431b-adb2-eb6b9e546014');
-        $description = new StringLiteral('A description.');
+        $description = 'A description.';
         $copyrightHolder = new CopyrightHolder('Dirk');
         $imageAdded = $this->getEventClass('ImageAdded');
         $commandClass = $this->getCommandClass('UpdateImage');
@@ -232,7 +232,7 @@ trait OfferCommandHandlerTestTrait
                 new $eventClass(
                     $itemId,
                     $mediaObjectId->toString(),
-                    $description->toNative(),
+                    $description,
                     $copyrightHolder->toString()
                 ),
             ]);


### PR DESCRIPTION
### Changed
- A request to `UpdateImageRequestHandler` is now validated with JSON schema.
- `UpdateImage` command expects string iso `StringLiteral` for a description in its constructor. It returns a string now as well.

### Fixed
- An `ApiProblem` is thrown when mediaId is not a valid UUID iso throwing an exception.

---
Ticket: https://jira.uitdatabank.be/browse/III-4258
