### PR TITLE
III-4272 Endpoint to update `workflowStatus`

### DIFF
--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -62,6 +62,7 @@ use CultuurNet\UDB3\Http\Offer\UpdateTitleRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateTypeRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateTypicalAgeRangeRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateVideosRequestHandler;
+use CultuurNet\UDB3\Http\Offer\UpdateWorkflowStatusRequestHandler;
 use CultuurNet\UDB3\Http\Place\GetEventsRequestHandler;
 use CultuurNet\UDB3\Http\Place\UpdateAddressRequestHandler as UpdatePlaceAddressRequestHandler;
 use CultuurNet\UDB3\Http\Place\UpdateMajorInfoRequestHandler as UpdatePlaceMajorInfoRequestHandler;
@@ -397,6 +398,8 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
 
         $router->put('/{offerType:events|places}/{offerId}/organizer/{organizerId}/', UpdateOrganizerRequestHandler::class);
         $router->delete('/{offerType:events|places}/{offerId}/organizer/{organizerId}/', DeleteOfferOrganizerRequestHandler::class);
+
+        $router->put('/{offerType:events|places}/{offerId}/workflow-status/', UpdateWorkflowStatusRequestHandler::class);
 
         $router->patch('/{offerType:events|places}/{offerId}/', PatchOfferRequestHandler::class);
 

--- a/app/Offer/OfferServiceProvider.php
+++ b/app/Offer/OfferServiceProvider.php
@@ -45,6 +45,7 @@ use CultuurNet\UDB3\Http\Offer\UpdateTitleRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateTypeRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateTypicalAgeRangeRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateVideosRequestHandler;
+use CultuurNet\UDB3\Http\Offer\UpdateWorkflowStatusRequestHandler;
 use CultuurNet\UDB3\Label\LabelImportPreProcessor;
 use CultuurNet\UDB3\LabelJSONDeserializer;
 use CultuurNet\UDB3\Offer\CommandHandlers\AddLabelHandler;
@@ -150,6 +151,7 @@ final class OfferServiceProvider extends AbstractServiceProvider
             AddVideoRequestHandler::class,
             UpdateVideosRequestHandler::class,
             DeleteVideoRequestHandler::class,
+            UpdateWorkflowStatusRequestHandler::class,
             PatchOfferRequestHandler::class,
         ];
     }
@@ -553,6 +555,11 @@ final class OfferServiceProvider extends AbstractServiceProvider
         $container->addShared(
             DeleteVideoRequestHandler::class,
             fn () => new DeleteVideoRequestHandler($container->get('event_command_bus'))
+        );
+
+        $container->addShared(
+            UpdateWorkflowStatusRequestHandler::class,
+            fn () => new UpdateWorkflowStatusRequestHandler($container->get('event_command_bus'))
         );
 
         $container->addShared(

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/III-4272-update-workflow-status-endpoint",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-uitdatabank/III-4272-update-workflow-status-endpoint",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a07a771e5952458ff73b41d866dcaad2",
+    "content-hash": "b2dfc7816ecea17265c31d2149e42169",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5576,19 +5576,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/III-4272-update-workflow-status-endpoint",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "a91349027cbe7c5bf86ee973c36e05347aad6dc6"
+                "reference": "dcffa7abecd2defc0196382bda0de33d780b2c02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/a91349027cbe7c5bf86ee973c36e05347aad6dc6",
-                "reference": "a91349027cbe7c5bf86ee973c36e05347aad6dc6",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/dcffa7abecd2defc0196382bda0de33d780b2c02",
+                "reference": "dcffa7abecd2defc0196382bda0de33d780b2c02",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5603,9 +5602,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/III-4272-update-workflow-status-endpoint"
             },
-            "time": "2022-11-07T05:58:15+00:00"
+            "time": "2022-11-18T13:03:33+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -10383,5 +10382,5 @@
         "ext-fileinfo": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -5580,12 +5580,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "dcffa7abecd2defc0196382bda0de33d780b2c02"
+                "reference": "7a364cbee96da8b05a862c863a34f1fc9f3b84be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/dcffa7abecd2defc0196382bda0de33d780b2c02",
-                "reference": "dcffa7abecd2defc0196382bda0de33d780b2c02",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/7a364cbee96da8b05a862c863a34f1fc9f3b84be",
+                "reference": "7a364cbee96da8b05a862c863a34f1fc9f3b84be",
                 "shasum": ""
             },
             "type": "library",
@@ -5602,9 +5602,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/III-4272-update-workflow-status-endpoint"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-4272-update-workflow-status-endpoint"
             },
-            "time": "2022-11-18T13:03:33+00:00"
+            "time": "2022-11-18T13:48:23+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2dfc7816ecea17265c31d2149e42169",
+    "content-hash": "a07a771e5952458ff73b41d866dcaad2",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5576,18 +5576,19 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-uitdatabank/III-4272-update-workflow-status-endpoint",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "7a364cbee96da8b05a862c863a34f1fc9f3b84be"
+                "reference": "569fc875f7882ccfeefb20013a9fa8e339f56d99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/7a364cbee96da8b05a862c863a34f1fc9f3b84be",
-                "reference": "7a364cbee96da8b05a862c863a34f1fc9f3b84be",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/569fc875f7882ccfeefb20013a9fa8e339f56d99",
+                "reference": "569fc875f7882ccfeefb20013a9fa8e339f56d99",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5602,9 +5603,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-4272-update-workflow-status-endpoint"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
-            "time": "2022-11-18T13:48:23+00:00"
+            "time": "2022-11-22T13:26:45+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Http/Offer/PatchOfferRequestHandler.php
+++ b/src/Http/Offer/PatchOfferRequestHandler.php
@@ -14,6 +14,11 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Note: Currently this request handler can only change the workflowStatus of an Offer, based on a specific custom
+ * mime-type being included in the content-type header.
+ * This functionality has been superseded by UpdateWorkflowStatusRequestHandler.
+ */
 final class PatchOfferRequestHandler implements RequestHandlerInterface
 {
     public const DOMAIN_MODEL_REGEX = '/.*domain-model=([a-zA-Z]*)/';

--- a/src/Http/Offer/UpdateWorkflowStatusRequestHandler.php
+++ b/src/Http/Offer/UpdateWorkflowStatusRequestHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Offer;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
+use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Offer\Commands\AbstractCommand;
+use CultuurNet\UDB3\Offer\Serializers\UpdateWorkflowStatusDenormalizer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class UpdateWorkflowStatusRequestHandler implements RequestHandlerInterface
+{
+    private CommandBus $commandBus;
+
+    public function __construct(CommandBus $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+        $offerType = $routeParameters->getOfferType();
+        $offerId = $routeParameters->getOfferId();
+
+        $requestBodyParser = RequestBodyParserFactory::createBaseParser(
+            new JsonSchemaValidatingRequestBodyParser(
+                JsonSchemaLocator::getSchemaFileByOfferType(
+                    $offerType,
+                    JsonSchemaLocator::EVENT_WORKFLOW_STATUS_PUT,
+                    JsonSchemaLocator::PLACE_WORKFLOW_STATUS_PUT,
+                )
+            ),
+            new DenormalizingRequestBodyParser(
+                new UpdateWorkflowStatusDenormalizer($offerType, $offerId),
+                AbstractCommand::class
+            )
+        );
+
+        $command = $requestBodyParser->parse($request)->getParsedBody();
+        if ($command) {
+            $this->commandBus->dispatch($command);
+        }
+
+        return new NoContentResponse();
+    }
+}

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -34,6 +34,7 @@ final class JsonSchemaLocator
     public const EVENT_SUB_EVENT_PATCH = 'event-subEvent-patch.json';
     public const EVENT_VIDEOS_PATCH = 'event-videos-patch.json';
     public const EVENT_VIDEOS_POST = 'event-videos-post.json';
+    public const EVENT_WORKFLOW_STATUS_PUT = 'event-workflowStatus-put.json';
 
     public const PLACE = 'place.json';
     public const PLACE_NAME_PUT = 'place-name-put.json';
@@ -50,6 +51,7 @@ final class JsonSchemaLocator
     public const PLACE_STATUS = 'place-status.json';
     public const PLACE_VIDEOS_PATCH = 'place-videos-patch.json';
     public const PLACE_VIDEOS_POST = 'place-videos-post.json';
+    public const PLACE_WORKFLOW_STATUS_PUT = 'place-workflowStatus-put.json';
 
     public const ORGANIZER = 'organizer.json';
     public const ORGANIZER_NAME_PUT = 'organizer-name-put.json';

--- a/src/Offer/Serializers/UpdateWorkflowStatusDenormalizer.php
+++ b/src/Offer/Serializers/UpdateWorkflowStatusDenormalizer.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\Serializers;
+
+use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Event\Commands\Moderation\Approve as ApproveEvent;
+use CultuurNet\UDB3\Event\Commands\Moderation\Publish as PublishEvent;
+use CultuurNet\UDB3\Event\Commands\Moderation\Reject as RejectEvent;
+use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
+use CultuurNet\UDB3\Offer\Commands\AbstractCommand;
+use CultuurNet\UDB3\Offer\Commands\DeleteOffer;
+use CultuurNet\UDB3\Offer\OfferType;
+use CultuurNet\UDB3\Place\Commands\Moderation\Approve as ApprovePlace;
+use CultuurNet\UDB3\Place\Commands\Moderation\Publish as PublishPlace;
+use CultuurNet\UDB3\Place\Commands\Moderation\Reject as RejectPlace;
+use CultuurNet\UDB3\StringLiteral;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class UpdateWorkflowStatusDenormalizer implements DenormalizerInterface
+{
+    private OfferType $offerType;
+    private string $offerId;
+
+    public function __construct(OfferType $offerType, string $offerId)
+    {
+        $this->offerType = $offerType;
+        $this->offerId = $offerId;
+    }
+
+    public function denormalize($data, $type, $format = null, array $context = []): ?AbstractCommand
+    {
+        $workflowStatus = new WorkflowStatus($data['workflowStatus']);
+
+        if ($workflowStatus->sameAs(WorkflowStatus::READY_FOR_VALIDATION())) {
+            $availableFrom = isset($data['availableFrom']) ? DateTimeFactory::fromISO8601($data['availableFrom']) : null;
+            return $this->offerType->sameAs(OfferType::event())
+                ? new PublishEvent($this->offerId, $availableFrom)
+                : new PublishPlace($this->offerId, $availableFrom);
+        }
+
+        if ($workflowStatus->sameAs(WorkflowStatus::APPROVED())) {
+            return $this->offerType->sameAs(OfferType::event())
+                ? new ApproveEvent($this->offerId)
+                : new ApprovePlace($this->offerId);
+        }
+
+        if ($workflowStatus->sameAs(WorkflowStatus::REJECTED())) {
+            $reason = new StringLiteral($data['reason']);
+            return $this->offerType->sameAs(OfferType::event())
+                ? new RejectEvent($this->offerId, $reason)
+                : new RejectPlace($this->offerId, $reason);
+        }
+
+        if ($workflowStatus->sameAs(WorkflowStatus::DELETED())) {
+            return new DeleteOffer($this->offerId);
+        }
+
+        // If the workflowStatus property is set to DRAFT return nothing. Either the offer is already a draft and we
+        // don't need to do anything, or the offer is not a draft anymore but you cannot move an offer back to the draft
+        // status.
+        return null;
+    }
+
+    public function supportsDenormalization($data, $type, $format = null): bool
+    {
+        return $type === AbstractCommand::class;
+    }
+}

--- a/tests/Http/Offer/UpdateWorkflowStatusRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateWorkflowStatusRequestHandlerTest.php
@@ -60,8 +60,7 @@ final class UpdateWorkflowStatusRequestHandlerTest extends TestCase
     public function it_dispatches_a_publish_command_for_workflow_status_ready_for_validation(
         string $offerType,
         string $publishCommandClassName
-    ): void
-    {
+    ): void {
         $request = (new Psr7RequestBuilder())
             ->withRouteParameter('offerType', $offerType)
             ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
@@ -87,8 +86,7 @@ final class UpdateWorkflowStatusRequestHandlerTest extends TestCase
     public function it_dispatches_a_publish_command_for_workflow_status_ready_for_validation_with_an_available_from(
         string $offerType,
         string $publishCommandClassName
-    ): void
-    {
+    ): void {
         $request = (new Psr7RequestBuilder())
             ->withRouteParameter('offerType', $offerType)
             ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
@@ -123,8 +121,7 @@ final class UpdateWorkflowStatusRequestHandlerTest extends TestCase
     public function it_dispatches_an_approve_command_for_workflow_status_approved(
         string $offerType,
         string $approveCommandClassName
-    ): void
-    {
+    ): void {
         $request = (new Psr7RequestBuilder())
             ->withRouteParameter('offerType', $offerType)
             ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')

--- a/tests/Http/Offer/UpdateWorkflowStatusRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateWorkflowStatusRequestHandlerTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Offer;
+
+use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Event\Commands\Moderation\Approve;
+use CultuurNet\UDB3\Event\Commands\Moderation\Publish;
+use CultuurNet\UDB3\Event\Commands\Moderation\Reject;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\Offer\Commands\DeleteOffer;
+use CultuurNet\UDB3\StringLiteral;
+use \Iterator;
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use PHPUnit\Framework\TestCase;
+
+final class UpdateWorkflowStatusRequestHandlerTest extends TestCase
+{
+    use AssertApiProblemTrait;
+
+    private TraceableCommandBus $commandBus;
+    private UpdateWorkflowStatusRequestHandler $updateWorkflowStatusRequestHandler;
+
+    protected function setUp(): void
+    {
+        $this->commandBus = new TraceableCommandBus();
+        $this->commandBus->record();
+        $this->updateWorkflowStatusRequestHandler = new UpdateWorkflowStatusRequestHandler($this->commandBus);
+    }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_no_command_for_workflow_status_draft(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('offerType', 'events')
+            ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
+            ->withJsonBodyFromArray(['workflowStatus' => 'DRAFT'])
+            ->build('PUT');
+
+        $this->updateWorkflowStatusRequestHandler->handle($request);
+
+        $commands = $this->commandBus->getRecordedCommands();
+        $this->assertEmpty($commands);
+    }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_a_publish_command_for_workflow_status_ready_for_validation(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('offerType', 'events')
+            ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
+            ->withJsonBodyFromArray(['workflowStatus' => 'READY_FOR_VALIDATION'])
+            ->build('PUT');
+
+        $this->updateWorkflowStatusRequestHandler->handle($request);
+
+        $commands = $this->commandBus->getRecordedCommands();
+        $this->assertCount(1, $commands);
+
+        // Note that we cannot assert the complete Publish command because the publicationDate (set to now) is always
+        // slightly different from the one that we would generate.
+        $command = $commands[0];
+        $this->assertInstanceOf(Publish::class, $command);
+        $this->assertEquals('d1422721-f226-48fd-a26d-cb21599ee533', $command->getItemId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_a_publish_command_for_workflow_status_ready_for_validation_with_an_available_from(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('offerType', 'events')
+            ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
+            ->withJsonBodyFromArray(
+                [
+                    'workflowStatus' => 'READY_FOR_VALIDATION',
+                    'availableFrom' => '2222-03-04T12:32:10+01:00',
+                ]
+            )
+            ->build('PUT');
+
+        $this->updateWorkflowStatusRequestHandler->handle($request);
+
+        $commands = $this->commandBus->getRecordedCommands();
+        $this->assertCount(1, $commands);
+
+        // Note that we cannot assert the complete Publish command because the publicationDates will have slightly
+        // different milli/microseconds in the internal state of DateTimeImmutable.
+        // (But they will be dropped when persisted / encoded as JSON)
+        // Also note that the publication date MUST be in the future, otherwise the current date will be used. That is
+        // why we use a date in 2222 to avoid the test failing at some point in the foreseeable future.
+        $command = $commands[0];
+        $this->assertInstanceOf(Publish::class, $command);
+        $this->assertEquals('d1422721-f226-48fd-a26d-cb21599ee533', $command->getItemId());
+        $this->assertEquals('2222-03-04T12:32:10+01:00', $command->getPublicationDate()->format(DATE_RFC3339));
+    }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_an_approve_command_for_workflow_status_approved(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('offerType', 'events')
+            ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
+            ->withJsonBodyFromArray(['workflowStatus' => 'APPROVED'])
+            ->build('PUT');
+
+        $this->updateWorkflowStatusRequestHandler->handle($request);
+
+        $expected = new Approve('d1422721-f226-48fd-a26d-cb21599ee533');
+
+        $commands = $this->commandBus->getRecordedCommands();
+        $this->assertEquals([$expected], $commands);
+    }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_a_reject_command_for_workflow_status_rejected(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('offerType', 'events')
+            ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
+            ->withJsonBodyFromArray(
+                [
+                    'workflowStatus' => 'REJECTED',
+                    'reason' => 'Events that focus primarily on religion are not allowed in UiTdatabank.',
+                ]
+            )
+            ->build('PUT');
+
+        $this->updateWorkflowStatusRequestHandler->handle($request);
+
+        $expected = new Reject(
+            'd1422721-f226-48fd-a26d-cb21599ee533',
+            new StringLiteral('Events that focus primarily on religion are not allowed in UiTdatabank.')
+        );
+
+        $commands = $this->commandBus->getRecordedCommands();
+        $this->assertEquals([$expected], $commands);
+    }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_a_delete_command_for_workflow_status_deleted(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('offerType', 'events')
+            ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
+            ->withJsonBodyFromArray(['workflowStatus' => 'DELETED'])
+            ->build('PUT');
+
+        $this->updateWorkflowStatusRequestHandler->handle($request);
+
+        $expected = new DeleteOffer('d1422721-f226-48fd-a26d-cb21599ee533');
+
+        $commands = $this->commandBus->getRecordedCommands();
+        $this->assertEquals([$expected], $commands);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_on_empty_body(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('offerType', 'events')
+            ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
+            ->build('PUT');
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyMissing(),
+            fn () => $this->updateWorkflowStatusRequestHandler->handle($request)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_on_invalid_json_syntax_in_body(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('offerType', 'events')
+            ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
+            ->withBodyFromString('{}}')
+            ->build('PUT');
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidSyntax('JSON'),
+            fn () => $this->updateWorkflowStatusRequestHandler->handle($request)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidBodyDataProvider
+     */
+    public function it_throws_on_invalid_body_data($bodyData, SchemaError ...$expectedSchemaErrors): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('offerType', 'events')
+            ->withRouteParameter('offerId', 'd1422721-f226-48fd-a26d-cb21599ee533')
+            ->withBodyFromString(Json::encode($bodyData))
+            ->build('PUT');
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidData(...$expectedSchemaErrors),
+            fn () => $this->updateWorkflowStatusRequestHandler->handle($request)
+        );
+    }
+
+    public function invalidBodyDataProvider(): Iterator
+    {
+        yield 'string_instead_of_object' => [
+            'READY_FOR_VALIDATION',
+            new SchemaError('/', 'Root element must be an array or object')
+        ];
+
+        yield 'array_instead_of_object' => [
+            [],
+            new SchemaError('/', 'The data (array) must match the type: object')
+        ];
+
+        yield 'missing_workflowStatus_property' => [
+            (object) [],
+            new SchemaError('/', 'The required properties (workflowStatus) are missing')
+        ];
+
+        yield 'invalid_workflowStatus_value' => [
+            (object) ['workflowStatus' => 'NOT_VALID'],
+            new SchemaError('/workflowStatus', 'The data should match one item from enum')
+        ];
+
+        yield 'missing_reason_for_workflowStatus_rejected' => [
+            (object) ['workflowStatus' => 'REJECTED'],
+            new SchemaError('/', 'The required properties (reason) are missing')
+        ];
+
+        yield 'invalid_availableFrom' => [
+            (object) ['workflowStatus' => 'READY_FOR_VALIDATION', 'availableFrom' => 'invalid'],
+            new SchemaError('/availableFrom', 'The data must match the \'date-time\' format')
+        ];
+    }
+}

--- a/tests/Http/Offer/UpdateWorkflowStatusRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateWorkflowStatusRequestHandlerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Offer;
 
-use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\Commands\Moderation\Approve;
 use CultuurNet\UDB3\Event\Commands\Moderation\Publish;
 use CultuurNet\UDB3\Event\Commands\Moderation\Reject;
@@ -14,7 +13,7 @@ use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Offer\Commands\DeleteOffer;
 use CultuurNet\UDB3\StringLiteral;
-use \Iterator;
+use Iterator;
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use PHPUnit\Framework\TestCase;
@@ -225,32 +224,32 @@ final class UpdateWorkflowStatusRequestHandlerTest extends TestCase
     {
         yield 'string_instead_of_object' => [
             'READY_FOR_VALIDATION',
-            new SchemaError('/', 'Root element must be an array or object')
+            new SchemaError('/', 'Root element must be an array or object'),
         ];
 
         yield 'array_instead_of_object' => [
             [],
-            new SchemaError('/', 'The data (array) must match the type: object')
+            new SchemaError('/', 'The data (array) must match the type: object'),
         ];
 
         yield 'missing_workflowStatus_property' => [
             (object) [],
-            new SchemaError('/', 'The required properties (workflowStatus) are missing')
+            new SchemaError('/', 'The required properties (workflowStatus) are missing'),
         ];
 
         yield 'invalid_workflowStatus_value' => [
             (object) ['workflowStatus' => 'NOT_VALID'],
-            new SchemaError('/workflowStatus', 'The data should match one item from enum')
+            new SchemaError('/workflowStatus', 'The data should match one item from enum'),
         ];
 
         yield 'missing_reason_for_workflowStatus_rejected' => [
             (object) ['workflowStatus' => 'REJECTED'],
-            new SchemaError('/', 'The required properties (reason) are missing')
+            new SchemaError('/', 'The required properties (reason) are missing'),
         ];
 
         yield 'invalid_availableFrom' => [
             (object) ['workflowStatus' => 'READY_FOR_VALIDATION', 'availableFrom' => 'invalid'],
-            new SchemaError('/availableFrom', 'The data must match the \'date-time\' format')
+            new SchemaError('/availableFrom', 'The data must match the \'date-time\' format'),
         ];
     }
 }


### PR DESCRIPTION
### Added

- Added a new route & request handler to update the `workflowStatus` of an event or place, to replace the quirky PATCH endpoint that uses custom content-types to determine the intended state transition.

---
Ticket: https://jira.uitdatabank.be/browse/III-4272

I will add some acceptance tests as well, but in the meantime this can already be reviewed if someone has the time (as well as the schema in https://github.com/cultuurnet/apidocs/pull/115)
Edit: Done, see https://github.com/cultuurnet/udb3-acceptance-tests/pull/169

I'll also fix the merge conflict in `composer.lock` once the schema is merged, because I'll have to update the `publiq/udb3-json-schemas` dependency then again anyway
Edit: Done
