### PR TITLE
III-5111 Refactor Unit to avoid deprecated methods

### DIFF
--- a/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
@@ -204,28 +204,21 @@ class EventBusForwardingConsumerTest extends TestCase
         $context = [];
         $context['correlation_id'] = new StringLiteral('my-correlation-id-123');
 
-        $this->logger
-            ->expects($this->at(0))
+        $this->logger->expects($this->exactly(3))
             ->method('info')
-            ->with(
-                'received message with content-type application/vnd.cultuurnet.udb3-events.dummy-event+json',
-                $context
-            );
-
-        $this->logger
-            ->expects($this->at(1))
-            ->method('info')
-            ->with(
-                'passing on message to event bus',
-                $context
-            );
-
-        $this->logger
-            ->expects($this->at(2))
-            ->method('info')
-            ->with(
-                'message acknowledged',
-                $context
+            ->withConsecutive(
+                [
+                    'received message with content-type application/vnd.cultuurnet.udb3-events.dummy-event+json',
+                    $context,
+                ],
+                [
+                    'passing on message to event bus',
+                    $context,
+                ],
+                [
+                    'message acknowledged',
+                    $context,
+                ]
             );
 
         $this->deserializerLocator->expects($this->once())

--- a/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
@@ -270,9 +270,9 @@ final class EventBusForwardingConsumerTest extends TestCase
             ->method('info')
             ->withConsecutive(
                 [
-                'received message with content-type application/vnd.cultuurnet.udb3-events.dummy-event+json',
-                $context,
-                    ],
+                    'received message with content-type application/vnd.cultuurnet.udb3-events.dummy-event+json',
+                    $context,
+                ],
                 [
                     'message rejected',
                     $context,

--- a/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
@@ -280,27 +280,25 @@ class EventBusForwardingConsumerTest extends TestCase
         $context['correlation_id'] = new StringLiteral('my-correlation-id-123');
 
         $this->logger
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('info')
-            ->with(
+            ->withConsecutive(
+                [
                 'received message with content-type application/vnd.cultuurnet.udb3-events.dummy-event+json',
-                $context
+                $context,
+                    ],
+                [
+                    'message rejected',
+                    $context,
+                ]
             );
 
         $this->logger
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('error')
             ->with(
                 'Deserializerlocator error',
                 $context + ['exception' => new \InvalidArgumentException('Deserializerlocator error')]
-            );
-
-        $this->logger
-            ->expects($this->at(2))
-            ->method('info')
-            ->with(
-                'message rejected',
-                $context
             );
 
         $this->deserializerLocator->expects($this->once())

--- a/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
@@ -19,27 +19,18 @@ use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidFactory;
 use CultuurNet\UDB3\StringLiteral;
 
-class EventBusForwardingConsumerTest extends TestCase
+final class EventBusForwardingConsumerTest extends TestCase
 {
     /**
      * @var AMQPStreamConnection|MockObject
      */
     private $connection;
 
-    /**
-     * @var StringLiteral
-     */
-    private $queueName;
+    private StringLiteral $queueName;
 
-    /**
-     * @var StringLiteral
-     */
-    private $exchangeName;
+    private StringLiteral $exchangeName;
 
-    /**
-     * @var StringLiteral
-     */
-    private $consumerTag;
+    private StringLiteral $consumerTag;
 
     /**
      * @var EventBus|MockObject
@@ -58,15 +49,10 @@ class EventBusForwardingConsumerTest extends TestCase
 
     /**
      * Seconds to delay the actual consumption of the message after it arrived.
-     *
-     * @var int
      */
-    private $delay;
+    private int $delay;
 
-    /**
-     * @var EventBusForwardingConsumer
-     */
-    private $eventBusForwardingConsumer;
+    private EventBusForwardingConsumer $eventBusForwardingConsumer;
 
     /**
      * @var LoggerInterface|MockObject
@@ -119,7 +105,7 @@ class EventBusForwardingConsumerTest extends TestCase
     /**
      * @test
      */
-    public function it_can_get_the_connection()
+    public function it_can_get_the_connection(): void
     {
         $this->channel->expects($this->once())
             ->method('basic_qos')
@@ -143,7 +129,7 @@ class EventBusForwardingConsumerTest extends TestCase
     /**
      * @test
      */
-    public function it_can_publish_the_message_on_the_event_bus()
+    public function it_can_publish_the_message_on_the_event_bus(): void
     {
         $context = [];
         $context['correlation_id'] = 'my-correlation-id-123';
@@ -199,7 +185,7 @@ class EventBusForwardingConsumerTest extends TestCase
     /**
      * @test
      */
-    public function it_logs_messages_when_consuming()
+    public function it_logs_messages_when_consuming(): void
     {
         $context = [];
         $context['correlation_id'] = new StringLiteral('my-correlation-id-123');
@@ -243,7 +229,7 @@ class EventBusForwardingConsumerTest extends TestCase
     /**
      * @test
      */
-    public function it_rejects_the_massage_when_an_error_occurs()
+    public function it_rejects_the_massage_when_an_error_occurs(): void
     {
         $context = [];
         $context['correlation_id'] = new StringLiteral('my-correlation-id-123');
@@ -274,7 +260,7 @@ class EventBusForwardingConsumerTest extends TestCase
     /**
      * @test
      */
-    public function it_logs_messages_when_rejecting_a_message()
+    public function it_logs_messages_when_rejecting_a_message(): void
     {
         $context = [];
         $context['correlation_id'] = new StringLiteral('my-correlation-id-123');
@@ -329,9 +315,6 @@ class EventBusForwardingConsumerTest extends TestCase
      */
     public function it_automatically_acknowledges_when_no_deserializer_was_found(): void
     {
-        $context = [];
-        $context['correlation_id'] = new StringLiteral('my-correlation-id-123');
-
         $this->deserializerLocator->expects($this->once())
             ->method('getDeserializerForContentType')
             ->with(new StringLiteral('application/vnd.cultuurnet.udb3-events.dummy-event+json'))

--- a/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
+++ b/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
@@ -6,12 +6,9 @@ namespace CultuurNet\UDB3\EventExport\Format\HTML;
 
 use PHPUnit\Framework\TestCase;
 
-class HTMLFileWriterTest extends TestCase
+final class HTMLFileWriterTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    protected $filePath;
+    protected string $filePath;
 
     public function setUp(): void
     {
@@ -22,7 +19,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_writes_a_file()
+    public function it_writes_a_file(): void
     {
         $events = [];
 
@@ -48,7 +45,7 @@ class HTMLFileWriterTest extends TestCase
         $template,
         $variables,
         $fileWithExpectedContent
-    ) {
+    ): void {
         $events = [];
 
         $twig = new \Twig_Environment(
@@ -67,7 +64,7 @@ class HTMLFileWriterTest extends TestCase
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
-    public function twigCustomTemplateProvider()
+    public function twigCustomTemplateProvider(): array
     {
         return [
             [
@@ -104,7 +101,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_inserts_variables()
+    public function it_inserts_variables(): void
     {
         $fileWriter = $this->createHTMLFileWriter(
             [
@@ -125,7 +122,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_inserts_events()
+    public function it_inserts_events(): void
     {
         $events = [
             [
@@ -190,7 +187,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_can_handle_events_without_an_image()
+    public function it_can_handle_events_without_an_image(): void
     {
         $events = [
             [
@@ -224,7 +221,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_shows_taaliconen()
+    public function it_shows_taaliconen(): void
     {
         $events = [
             [
@@ -260,7 +257,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_can_handle_four_taaliconen()
+    public function it_can_handle_four_taaliconen(): void
     {
         $events = [
             [
@@ -296,7 +293,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_adds_event_brands_to_activities()
+    public function it_adds_event_brands_to_activities(): void
     {
         $events = [
             [
@@ -336,7 +333,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_shows_the_starting_age()
+    public function it_shows_the_starting_age(): void
     {
         $events = [
             [
@@ -373,7 +370,7 @@ class HTMLFileWriterTest extends TestCase
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
-    private function getEventsWithUiTPASInfo()
+    private function getEventsWithUiTPASInfo(): array
     {
         return [
             [
@@ -418,7 +415,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_shows_uitpas_info()
+    public function it_shows_uitpas_info(): void
     {
         $events = $this->getEventsWithUiTPASInfo();
 
@@ -438,7 +435,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_shows_paspartoe_branded_uitpas_info()
+    public function it_shows_paspartoe_branded_uitpas_info(): void
     {
         $events = $this->getEventsWithUiTPASInfo();
 
@@ -460,7 +457,7 @@ class HTMLFileWriterTest extends TestCase
     /**
      * @test
      */
-    public function it_shows_a_custom_logo()
+    public function it_shows_a_custom_logo(): void
     {
         $events = [
             [
@@ -495,28 +492,20 @@ class HTMLFileWriterTest extends TestCase
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
-    /**
-     * @param array $variables
-     * @return HTMLFileWriter
-     */
-    protected function createHTMLFileWriter($variables)
+    protected function createHTMLFileWriter(array $variables): HTMLFileWriter
     {
         return new HTMLFileWriter('export.tips.html.twig', $variables);
     }
 
-    /**
-     * @return string
-     */
-    protected function getFilePath()
+    protected function getFilePath(): string
     {
         return tempnam(sys_get_temp_dir(), uniqid()) . '.html';
     }
 
     /**
-     * @param string $html
-     * @param string $filePath
+     * @test
      */
-    protected function assertHTMLFileContents($html, $filePath)
+    protected function assertHTMLFileContents(string $html, string $filePath): void
     {
         $this->assertEquals($html, file_get_contents($filePath));
     }

--- a/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
+++ b/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
@@ -26,7 +26,7 @@ class HTMLFileWriterTest extends TestCase
     {
         $events = [];
 
-        $this->assertFileNotExists($this->filePath);
+        $this->assertFileDoesNotExist($this->filePath);
 
         $fileWriter = $this->createHTMLFileWriter(
             [

--- a/tests/Label/ReadModels/Relations/ProjectorTest.php
+++ b/tests/Label/ReadModels/Relations/ProjectorTest.php
@@ -261,27 +261,27 @@ class ProjectorTest extends TestCase
             $payload
         );
 
-        $this->writeRepository->expects($this->at(0))
+        $this->writeRepository->expects($this->once())
             ->method('deleteImportedByRelationId')
             ->with($itemId);
 
-        $this->writeRepository->expects($this->at(1))
+        $this->writeRepository->expects($this->exactly(2))
             ->method('save')
-            ->with(
-                '2dotstwice',
-                $relationType,
-                $itemId,
-                true
+            ->withConsecutive(
+                [
+                    '2dotstwice',
+                    $relationType,
+                    $itemId,
+                    true,
+                ],
+                [
+                    'cultuurnet',
+                    $relationType,
+                    $itemId,
+                    true,
+                ],
             );
 
-        $this->writeRepository->expects($this->at(2))
-            ->method('save')
-            ->with(
-                'cultuurnet',
-                $relationType,
-                $itemId,
-                true
-            );
 
         $this->relationsReadRepository->expects($this->once())
             ->method('getLabelRelationsForItem')

--- a/tests/Label/ReadModels/Relations/ProjectorTest.php
+++ b/tests/Label/ReadModels/Relations/ProjectorTest.php
@@ -37,7 +37,7 @@ use CultuurNet\UDB3\Place\Events\PlaceUpdatedFromUDB2;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class ProjectorTest extends TestCase
+final class ProjectorTest extends TestCase
 {
     private string $labelName;
 

--- a/tests/Offer/BulkLabelCommandHandlerTest.php
+++ b/tests/Offer/BulkLabelCommandHandlerTest.php
@@ -144,14 +144,14 @@ final class BulkLabelCommandHandlerTest extends TestCase
     ): void {
         // One label action should fail.
         // Make sure the other offer is still labelled.
-        $this->commandBus->method('dispatch')->will(
+        $this->commandBus->method('dispatch')->withConsecutive(
+            [new AddLabel($this->offerIdentifiers[1]->getId(), $this->label)],
+            [new AddLabel($this->offerIdentifiers[2]->getId(), $this->label)]
+        )->will(
             $this->onConsecutiveCalls(
                 $this->throwException($exception),
                 false
             )
-        )->withConsecutive(
-            [new AddLabel($this->offerIdentifiers[1]->getId(), $this->label)],
-            [new AddLabel($this->offerIdentifiers[2]->getId(), $this->label)]
         );
 
         // Make sure we log the occur.

--- a/tests/Offer/BulkLabelCommandHandlerTest.php
+++ b/tests/Offer/BulkLabelCommandHandlerTest.php
@@ -149,6 +149,9 @@ final class BulkLabelCommandHandlerTest extends TestCase
                 $this->throwException($exception),
                 false
             )
+        )->withConsecutive(
+            [new AddLabel($this->offerIdentifiers[1]->getId(), $this->label)],
+            [new AddLabel($this->offerIdentifiers[2]->getId(), $this->label)]
         );
 
         // Make sure we log the occur.

--- a/tests/Offer/BulkLabelCommandHandlerTest.php
+++ b/tests/Offer/BulkLabelCommandHandlerTest.php
@@ -149,15 +149,13 @@ class BulkLabelCommandHandlerTest extends TestCase
         string $message
     ): void {
         // One label action should fail.
-        $this->commandBus->expects($this->at(0))
-            ->method('dispatch')
-            ->with(new AddLabel($this->offerIdentifiers[1]->getId(), $this->label))
-            ->willThrowException($exception);
-
         // Make sure the other offer is still labelled.
-        $this->commandBus->expects($this->at(1))
-            ->method('dispatch')
-            ->with(new AddLabel($this->offerIdentifiers[2]->getId(), $this->label));
+        $this->commandBus->method('dispatch')->will(
+            $this->onConsecutiveCalls(
+              $this->throwException($exception),
+              false
+          )
+        );
 
         // Make sure we log the occur.
         $this->logger->expects($this->once())

--- a/tests/Offer/BulkLabelCommandHandlerTest.php
+++ b/tests/Offer/BulkLabelCommandHandlerTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class BulkLabelCommandHandlerTest extends TestCase
+final class BulkLabelCommandHandlerTest extends TestCase
 {
     /**
      * @var ResultsGeneratorInterface|MockObject
@@ -30,27 +30,21 @@ class BulkLabelCommandHandlerTest extends TestCase
      */
     private $logger;
 
-    /**
-     * @var BulkLabelCommandHandler
-     */
-    private $commandHandler;
+    private BulkLabelCommandHandler $commandHandler;
 
-    /**
-     * @var string
-     */
-    private $query;
+    private string $query;
 
     private Label $label;
 
     /**
      * @var IriOfferIdentifier[]
      */
-    private $offerIdentifiers;
+    private array $offerIdentifiers;
 
     /**
      * @var ItemIdentifier[]
      */
-    private $itemIdentifiers;
+    private array $itemIdentifiers;
 
     /**
      * @var CommandBus|MockObject
@@ -152,9 +146,9 @@ class BulkLabelCommandHandlerTest extends TestCase
         // Make sure the other offer is still labelled.
         $this->commandBus->method('dispatch')->will(
             $this->onConsecutiveCalls(
-              $this->throwException($exception),
-              false
-          )
+                $this->throwException($exception),
+                false
+            )
         );
 
         // Make sure we log the occur.

--- a/tests/Offer/CommandHandlers/AddLabelHandlerTest.php
+++ b/tests/Offer/CommandHandlers/AddLabelHandlerTest.php
@@ -96,13 +96,18 @@ final class AddLabelHandlerTest extends CommandHandlerScenarioTestCase
      */
     public function it_should_use_visibility_from_the_command_if_the_label_did_not_exist_before(): void
     {
-        $this->labelService->expects($this->at(0))
+        $this->labelService->expects($this->exactly(2))
             ->method('createLabelAggregateIfNew')
-            ->with(new LabelName('visible'), true);
-
-        $this->labelService->expects($this->at(1))
-            ->method('createLabelAggregateIfNew')
-            ->with(new LabelName('hidden'), false);
+            ->withConsecutive(
+                [
+                    new LabelName('visible'),
+                    true,
+                ],
+                [
+                    new LabelName('hidden'),
+                    false,
+                ]
+            );
 
         $id = '4c6d4bb8-702b-49f1-b0ca-e51eb09a1c19';
 

--- a/tests/Offer/CommandHandlers/ImportLabelsHandlerTest.php
+++ b/tests/Offer/CommandHandlers/ImportLabelsHandlerTest.php
@@ -71,13 +71,26 @@ final class ImportLabelsHandlerTest extends CommandHandlerScenarioTestCase
      */
     public function it_should_import_labels_and_also_record_label_added_events(): void
     {
-        $this->labelService->expects($this->at(0))
+        /*$this->labelService->expects($this->at(0))
             ->method('createLabelAggregateIfNew')
             ->with(new LabelName('foo'), true);
 
         $this->labelService->expects($this->at(1))
             ->method('createLabelAggregateIfNew')
-            ->with(new LabelName('bar'), false);
+            ->with(new LabelName('bar'), false);*/
+
+        $this->labelService->expects($this->exactly(2))
+            ->method('createLabelAggregateIfNew')
+            ->withConsecutive(
+                [
+                    new LabelName('foo'),
+                    true,
+                ],
+                [
+                    new LabelName('bar'),
+                    false,
+                ]
+            );
 
         $this->labelPermissionRepository->expects($this->any())
             ->method('getByName')

--- a/tests/Offer/CommandHandlers/ImportLabelsHandlerTest.php
+++ b/tests/Offer/CommandHandlers/ImportLabelsHandlerTest.php
@@ -71,14 +71,6 @@ final class ImportLabelsHandlerTest extends CommandHandlerScenarioTestCase
      */
     public function it_should_import_labels_and_also_record_label_added_events(): void
     {
-        /*$this->labelService->expects($this->at(0))
-            ->method('createLabelAggregateIfNew')
-            ->with(new LabelName('foo'), true);
-
-        $this->labelService->expects($this->at(1))
-            ->method('createLabelAggregateIfNew')
-            ->with(new LabelName('bar'), false);*/
-
         $this->labelService->expects($this->exactly(2))
             ->method('createLabelAggregateIfNew')
             ->withConsecutive(

--- a/tests/Organizer/CommandHandler/ImportLabelsHandlerTest.php
+++ b/tests/Organizer/CommandHandler/ImportLabelsHandlerTest.php
@@ -59,13 +59,18 @@ final class ImportLabelsHandlerTest extends CommandHandlerScenarioTestCase
      */
     public function it_handles_label_imports(): void
     {
-        $this->labelService->expects($this->at(0))
+        $this->labelService->expects($this->exactly(2))
             ->method('createLabelAggregateIfNew')
-            ->with(new LabelName('foo'), true);
-
-        $this->labelService->expects($this->at(1))
-            ->method('createLabelAggregateIfNew')
-            ->with(new LabelName('bar'), true);
+            ->withConsecutive(
+                [
+                    new LabelName('foo'),
+                    true,
+                ],
+                [
+                    new LabelName('bar'),
+                    true,
+                ]
+            );
 
         $id = '86a51894-e18e-4a6a-b7c5-d774e8c81074';
 

--- a/tests/Place/CanonicalPlaceRepositoryTest.php
+++ b/tests/Place/CanonicalPlaceRepositoryTest.php
@@ -59,13 +59,18 @@ class CanonicalPlaceRepositoryTest extends TestCase
         $canonicalPlace->method('getAggregateRootId')->willReturn($canonicalPlaceId);
 
         $place->method('getCanonicalPlaceId')->willReturn($secondLevelDuplicatePlaceId);
-        $this->placeRepository->expects($this->at(0))->method('load')->with($placeId)->willReturn($place);
-
         $secondLevelDuplicatePlace->method('getCanonicalPlaceId')->willReturn($canonicalPlaceId);
-        $this->placeRepository->expects($this->at(1))->method('load')->with($secondLevelDuplicatePlaceId)->willReturn($secondLevelDuplicatePlace);
-
         $canonicalPlace->method('getCanonicalPlaceId')->willReturn(null);
-        $this->placeRepository->expects($this->at(2))->method('load')->with($canonicalPlaceId)->willReturn($canonicalPlace);
+
+        $this->placeRepository->expects($this->any())
+            ->method('load')
+            ->willReturnMap(
+                [
+                    [$placeId, $place],
+                    [$secondLevelDuplicatePlaceId, $secondLevelDuplicatePlace],
+                    [$canonicalPlaceId, $canonicalPlace],
+                ]
+            );
 
         $canonicalPlace = $this->canonicalPlaceRepository->findCanonicalFor($placeId);
 


### PR DESCRIPTION
### Fixed
- replaced deprecated `assertFileNotExists()` with `assertFileDoesNotExist()`
- replaced deprecated `at()` depending on how it was used.
- Code cleanup of edited files

---
Ticket: https://jira.uitdatabank.be/browse/III-5111
