### PR TITLE
III-5125 Fix missing CORS headers from error responses

### DIFF
--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http;
 
 use Broadway\EventHandling\EventBus;
-use CultuurNet\UDB3\Http\Auth\CorsHeadersMiddleware;
 use CultuurNet\UDB3\Http\Auth\RequestAuthenticatorMiddleware;
 use CultuurNet\UDB3\Http\Curators\CreateNewsArticleRequestHandler;
 use CultuurNet\UDB3\Http\Curators\DeleteNewsArticleRequestHandler;
@@ -223,9 +222,6 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
         // Determines if a request requires authentication or not, and if yes it checks the JWT and optionally the API
         // key to determine if the request is correctly authenticated.
         $router->middleware($container->get(RequestAuthenticatorMiddleware::class));
-
-        // Adds CORS headers to every response that we return.
-        $router->middleware(new CorsHeadersMiddleware());
     }
 
     private function bindNewsArticles(Router $router): void

--- a/src/Http/Auth/CorsHeadersResponseDecorator.php
+++ b/src/Http/Auth/CorsHeadersResponseDecorator.php
@@ -21,7 +21,7 @@ use Psr\Http\Server\RequestHandlerInterface;
  *
  * The easiest approach is to just add the headers to every response.
  */
-final class CorsHeadersMiddleware implements MiddlewareInterface
+final class CorsHeadersResponseDecorator
 {
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/src/Http/Auth/CorsHeadersResponseDecorator.php
+++ b/src/Http/Auth/CorsHeadersResponseDecorator.php
@@ -6,8 +6,6 @@ namespace CultuurNet\UDB3\Http\Auth;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Adds the necessary headers to a response, after the request has been handled, to make it work with CORS.
@@ -23,10 +21,8 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final class CorsHeadersResponseDecorator
 {
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    public function decorate(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        $response = $handler->handle($request);
-
         // Allow any known method regardless of the URL.
         $methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
 

--- a/tests/Http/Auth/CorsHeadersResponseDecoratorTest.php
+++ b/tests/Http/Auth/CorsHeadersResponseDecoratorTest.php
@@ -7,9 +7,6 @@ namespace CultuurNet\UDB3\Http\Auth;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 
 final class CorsHeadersResponseDecoratorTest extends TestCase
 {

--- a/tests/Http/Auth/CorsHeadersResponseDecoratorTest.php
+++ b/tests/Http/Auth/CorsHeadersResponseDecoratorTest.php
@@ -13,18 +13,11 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class CorsHeadersResponseDecoratorTest extends TestCase
 {
-    private CorsHeadersResponseDecorator $corsHeadersMiddleware;
-    private RequestHandlerInterface $requestHandler;
+    private CorsHeadersResponseDecorator $corsHeadersResponseDecorator;
 
     protected function setUp(): void
     {
-        $this->corsHeadersMiddleware = new CorsHeadersResponseDecorator();
-        $this->requestHandler = new class() implements RequestHandlerInterface {
-            public function handle(ServerRequestInterface $request): ResponseInterface
-            {
-                return new NoContentResponse();
-            }
-        };
+        $this->corsHeadersResponseDecorator = new CorsHeadersResponseDecorator();
     }
 
     /**
@@ -42,7 +35,7 @@ final class CorsHeadersResponseDecoratorTest extends TestCase
             'Access-Control-Allow-Headers' => ['authorization,x-api-key'],
         ];
 
-        $response = $this->corsHeadersMiddleware->process($givenRequest, $this->requestHandler);
+        $response = $this->corsHeadersResponseDecorator->decorate($givenRequest, new NoContentResponse());
         $actualHeaders = $response->getHeaders();
 
         $this->assertEquals($expectedHeaders, $actualHeaders);
@@ -65,7 +58,7 @@ final class CorsHeadersResponseDecoratorTest extends TestCase
             'Access-Control-Allow-Headers' => ['authorization,x-api-key'],
         ];
 
-        $response = $this->corsHeadersMiddleware->process($givenRequest, $this->requestHandler);
+        $response = $this->corsHeadersResponseDecorator->decorate($givenRequest, new NoContentResponse());
         $actualHeaders = $response->getHeaders();
 
         $this->assertEquals($expectedHeaders, $actualHeaders);
@@ -88,7 +81,7 @@ final class CorsHeadersResponseDecoratorTest extends TestCase
             'Access-Control-Allow-Headers' => ['authorization,x-api-key,x-mock-header'],
         ];
 
-        $response = $this->corsHeadersMiddleware->process($givenRequest, $this->requestHandler);
+        $response = $this->corsHeadersResponseDecorator->decorate($givenRequest, new NoContentResponse());
         $actualHeaders = $response->getHeaders();
 
         $this->assertEquals($expectedHeaders, $actualHeaders);

--- a/tests/Http/Auth/CorsHeadersResponseDecoratorTest.php
+++ b/tests/Http/Auth/CorsHeadersResponseDecoratorTest.php
@@ -11,14 +11,14 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-final class CorsHeadersMiddlewareTest extends TestCase
+final class CorsHeadersResponseDecoratorTest extends TestCase
 {
-    private CorsHeadersMiddleware $corsHeadersMiddleware;
+    private CorsHeadersResponseDecorator $corsHeadersMiddleware;
     private RequestHandlerInterface $requestHandler;
 
     protected function setUp(): void
     {
-        $this->corsHeadersMiddleware = new CorsHeadersMiddleware();
+        $this->corsHeadersMiddleware = new CorsHeadersResponseDecorator();
         $this->requestHandler = new class() implements RequestHandlerInterface {
             public function handle(ServerRequestInterface $request): ResponseInterface
             {

--- a/web/index.php
+++ b/web/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+use CultuurNet\UDB3\Http\Auth\CorsHeadersResponseDecorator;
 use CultuurNet\UDB3\Http\LegacyPathRewriter;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\ApiName;
@@ -51,5 +52,10 @@ try {
     $webErrorHandler = $container->get(WebErrorHandler::class);
     $response = $webErrorHandler->handle($request, $throwable);
 }
+
+// Always add CORS headers to the response. We do not do this in a middleware because in some cases an error is
+// thrown/caught out of the middleware stack and then the CORS middleware would not be triggered and no CORS headers
+// would be added to the 4XX or 5XX response. (For example in the catch above.)
+$response = (new CorsHeadersResponseDecorator())->decorate($request, $response);
 
 (new SapiStreamEmitter())->emit($response);


### PR DESCRIPTION
### Fixed

- Every error response now also gets CORS headers added, to prevent 401, 403, 404 etc errors in the frontend from being inaccessible to the JS code due to missing CORS headers.

---
Ticket: https://jira.uitdatabank.be/browse/III-5125
