### PR TITLE
III-5159 Rounding Error eg. € 2.30

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -775,16 +775,16 @@
         },
         {
             "name": "cultuurnet/calendar-summary-v3",
-            "version": "v4.0.2",
+            "version": "v4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/calendar-summary-v3.git",
-                "reference": "212ed0c4a180c3e91b89a287178dbbbd2eac3a6c"
+                "reference": "bdd97cd998301bcb0468e44e24b864466f3fc60f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/212ed0c4a180c3e91b89a287178dbbbd2eac3a6c",
-                "reference": "212ed0c4a180c3e91b89a287178dbbbd2eac3a6c",
+                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/bdd97cd998301bcb0468e44e24b864466f3fc60f",
+                "reference": "bdd97cd998301bcb0468e44e24b864466f3fc60f",
                 "shasum": ""
             },
             "require": {
@@ -821,9 +821,9 @@
             "description": "Library to convert cultuurnet dates to a readable summary",
             "support": {
                 "issues": "https://github.com/cultuurnet/calendar-summary-v3/issues",
-                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.2"
+                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.3"
             },
-            "time": "2022-12-06T14:59:39+00:00"
+            "time": "2023-01-03T07:49:10+00:00"
         },
         {
             "name": "cultuurnet/cdb",

--- a/src/Cdb/CdbXmlPriceInfoParser.php
+++ b/src/Cdb/CdbXmlPriceInfoParser.php
@@ -65,7 +65,7 @@ final class CdbXmlPriceInfoParser
         }
 
         $basePrice = new BasePrice(
-            MoneyFactory::createFromFloat($basePrice, new Currency('EUR'))
+            MoneyFactory::create($basePrice, new Currency('EUR'))
         );
 
         /* @var Tariff[] $tariffs */
@@ -103,7 +103,7 @@ final class CdbXmlPriceInfoParser
                 if (!isset($tariffs[$tariffIndex])) {
                     $tariff = new Tariff(
                         new MultilingualString(new LegacyLanguage($language), new StringLiteral((string) $tariffName)),
-                        MoneyFactory::createFromFloat($tariffPrice, new Currency('EUR'))
+                        MoneyFactory::create($tariffPrice, new Currency('EUR'))
                     );
                 } else {
                     $tariff = $tariffs[$tariffIndex];

--- a/src/Cdb/CdbXmlPriceInfoParser.php
+++ b/src/Cdb/CdbXmlPriceInfoParser.php
@@ -8,13 +8,13 @@ use CultureFeed_Cdb_Data_Detail;
 use CultureFeed_Cdb_Data_Price;
 use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\MoneyFactory;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\PriceInfo\Tariff;
 use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Money\Currency;
-use Money\Money;
 
 final class CdbXmlPriceInfoParser
 {
@@ -65,7 +65,7 @@ final class CdbXmlPriceInfoParser
         }
 
         $basePrice = new BasePrice(
-            new Money((int) ($basePrice * 100), new Currency('EUR'))
+            MoneyFactory::createFromFloat($basePrice, new Currency('EUR'))
         );
 
         /* @var Tariff[] $tariffs */
@@ -103,7 +103,7 @@ final class CdbXmlPriceInfoParser
                 if (!isset($tariffs[$tariffIndex])) {
                     $tariff = new Tariff(
                         new MultilingualString(new LegacyLanguage($language), new StringLiteral((string) $tariffName)),
-                        new Money((int)($tariffPrice * 100), new Currency('EUR'))
+                        MoneyFactory::createFromFloat($tariffPrice, new Currency('EUR'))
                     );
                 } else {
                     $tariff = $tariffs[$tariffIndex];

--- a/src/Model/Serializer/ValueObject/Price/PriceInfoDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Price/PriceInfoDenormalizer.php
@@ -8,8 +8,8 @@ use CultuurNet\UDB3\Model\ValueObject\Price\PriceInfo;
 use CultuurNet\UDB3\Model\ValueObject\Price\Tariff;
 use CultuurNet\UDB3\Model\ValueObject\Price\Tariffs;
 use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
+use CultuurNet\UDB3\MoneyFactory;
 use Money\Currency;
-use Money\Money;
 use Symfony\Component\Serializer\Exception\UnsupportedException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
@@ -96,7 +96,7 @@ class PriceInfoDenormalizer implements DenormalizerInterface
 
         return new Tariff(
             $tariffName,
-            new Money((int) ($tariffData['price']*100), new Currency('EUR'))
+            MoneyFactory::createFromFloat($tariffData['price'], new Currency('EUR'))
         );
     }
 }

--- a/src/Model/Serializer/ValueObject/Price/PriceInfoDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Price/PriceInfoDenormalizer.php
@@ -96,7 +96,7 @@ class PriceInfoDenormalizer implements DenormalizerInterface
 
         return new Tariff(
             $tariffName,
-            MoneyFactory::createFromFloat($tariffData['price'], new Currency('EUR'))
+            MoneyFactory::create($tariffData['price'], new Currency('EUR'))
         );
     }
 }

--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -16,8 +16,11 @@ final class MoneyFactory
         return new Money((int) round(($price*100)), $currency);
     }
 
-    public static function createFromStringInCents(
-        string $price,
+    /**
+     * @param string|int $price
+     */
+    public static function createFromCentsValue(
+        $price,
         Currency $currency
     ): Money {
         return new Money((int) $price, $currency);

--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3;
+
+use Money\Currency;
+use Money\Money;
+
+final class MoneyFactory
+{
+    public static function createFromFloat(
+        float $price,
+        Currency $currency
+    ): Money {
+        return new Money((int) round(($price*100)), $currency);
+    }
+}

--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -9,8 +9,11 @@ use Money\Money;
 
 final class MoneyFactory
 {
-    public static function createFromFloat(
-        float $price,
+    /**
+     * @param string|int|float $price
+     */
+    public static function create(
+        $price,
         Currency $currency
     ): Money {
         return new Money((int) round(($price*100)), $currency);

--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -15,4 +15,11 @@ final class MoneyFactory
     ): Money {
         return new Money((int) round(($price*100)), $currency);
     }
+
+    public static function createFromStringInCents(
+        string $price,
+        Currency $currency
+    ): Money {
+        return new Money((int) $price, $currency);
+    }
 }

--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -20,9 +20,9 @@ final class MoneyFactory
     }
 
     /**
-     * @param string|int $price
+     * @param string|int|float $price
      */
-    public static function createFromCentsValue(
+    public static function createFromCents(
         $price,
         Currency $currency
     ): Money {

--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -16,6 +16,7 @@ final class MoneyFactory
         $price,
         Currency $currency
     ): Money {
+        self::guard($price);
         return new Money((int) round(($price*100)), $currency);
     }
 
@@ -26,6 +27,21 @@ final class MoneyFactory
         $price,
         Currency $currency
     ): Money {
+        self::guard($price);
         return new Money((int) $price, $currency);
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    private static function guard($value): void
+    {
+        if (!is_int($value) && !is_float($value) && !is_string($value)) {
+            throw new \InvalidArgumentException(
+                'Given value should be an int, string, float, double. Got ' .
+                gettype($value) .
+                ' instead.'
+            );
+        }
     }
 }

--- a/src/PriceInfo/BasePrice.php
+++ b/src/PriceInfo/BasePrice.php
@@ -45,7 +45,7 @@ class BasePrice implements Serializable
     public static function deserialize(array $data): BasePrice
     {
         return new BasePrice(
-            MoneyFactory::createFromCentsValue($data['price'], new Currency($data['currency']))
+            MoneyFactory::createFromCents($data['price'], new Currency($data['currency']))
         );
     }
 

--- a/src/PriceInfo/BasePrice.php
+++ b/src/PriceInfo/BasePrice.php
@@ -45,7 +45,7 @@ class BasePrice implements Serializable
     public static function deserialize(array $data): BasePrice
     {
         return new BasePrice(
-            MoneyFactory::createFromStringInCents($data['price'], new Currency($data['currency']))
+            MoneyFactory::createFromCentsValue($data['price'], new Currency($data['currency']))
         );
     }
 

--- a/src/PriceInfo/BasePrice.php
+++ b/src/PriceInfo/BasePrice.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\PriceInfo;
 
 use Broadway\Serializer\Serializable;
 use CultuurNet\UDB3\Model\ValueObject\Price\Tariff as Udb3ModelTariff;
+use CultuurNet\UDB3\MoneyFactory;
 use Money\Currency;
 use Money\Money;
 
@@ -44,7 +45,7 @@ class BasePrice implements Serializable
     public static function deserialize(array $data): BasePrice
     {
         return new BasePrice(
-            new Money((int) $data['price'], new Currency($data['currency']))
+            MoneyFactory::createFromStringInCents($data['price'], new Currency($data['currency']))
         );
     }
 

--- a/src/PriceInfo/Tariff.php
+++ b/src/PriceInfo/Tariff.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\PriceInfo;
 
 use Broadway\Serializer\Serializable;
 use CultuurNet\UDB3\Model\ValueObject\Price\Tariff as Udb3ModelTariff;
+use CultuurNet\UDB3\MoneyFactory;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Money\Currency;
 use Money\Money;
@@ -56,7 +57,7 @@ class Tariff implements Serializable
     {
         return new Tariff(
             MultilingualString::deserialize($data['name']),
-            new Money((int) $data['price'], new Currency($data['currency']))
+            MoneyFactory::createFromStringInCents($data['price'], new Currency($data['currency']))
         );
     }
 

--- a/src/PriceInfo/Tariff.php
+++ b/src/PriceInfo/Tariff.php
@@ -57,7 +57,7 @@ class Tariff implements Serializable
     {
         return new Tariff(
             MultilingualString::deserialize($data['name']),
-            MoneyFactory::createFromCentsValue($data['price'], new Currency($data['currency']))
+            MoneyFactory::createFromCents($data['price'], new Currency($data['currency']))
         );
     }
 

--- a/src/PriceInfo/Tariff.php
+++ b/src/PriceInfo/Tariff.php
@@ -57,7 +57,7 @@ class Tariff implements Serializable
     {
         return new Tariff(
             MultilingualString::deserialize($data['name']),
-            MoneyFactory::createFromStringInCents($data['price'], new Currency($data['currency']))
+            MoneyFactory::createFromCentsValue($data['price'], new Currency($data['currency']))
         );
     }
 

--- a/src/UiTPAS/Event/Event/PricesUpdatedDeserializer.php
+++ b/src/UiTPAS/Event/Event/PricesUpdatedDeserializer.php
@@ -72,7 +72,7 @@ final class PricesUpdatedDeserializer extends JSONDeserializer
 
             $tariffs[] = new Tariff(
                 new TranslatedTariffName(new Language('nl'), new TariffName($name)),
-                MoneyFactory::createFromFloat($tariff->price, new Currency('EUR'))
+                MoneyFactory::create($tariff->price, new Currency('EUR'))
             );
         }
 

--- a/src/UiTPAS/Event/Event/PricesUpdatedDeserializer.php
+++ b/src/UiTPAS/Event/Event/PricesUpdatedDeserializer.php
@@ -11,9 +11,9 @@ use CultuurNet\UDB3\Model\ValueObject\Price\TariffName;
 use CultuurNet\UDB3\Model\ValueObject\Price\Tariffs;
 use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\MoneyFactory;
 use CultuurNet\UDB3\StringLiteral;
 use Money\Currency;
-use Money\Money;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Validator;
 use stdClass;
@@ -69,14 +69,10 @@ final class PricesUpdatedDeserializer extends JSONDeserializer
         $tariffs = [];
         foreach ($dto->tariffs as $tariff) {
             $name = $tariff->name;
-            $price = (int) ($tariff->price * 100);
 
             $tariffs[] = new Tariff(
                 new TranslatedTariffName(new Language('nl'), new TariffName($name)),
-                new Money(
-                    $price,
-                    new Currency('EUR')
-                )
+                MoneyFactory::createFromFloat($tariff->price, new Currency('EUR'))
             );
         }
 

--- a/tests/EventExport/CalendarSummary/CalendarSummaryWithFormatterRepositoryTest.php
+++ b/tests/EventExport/CalendarSummary/CalendarSummaryWithFormatterRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\EventExport\CalendarSummary;
 
 use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
@@ -18,7 +19,7 @@ final class CalendarSummaryWithFormatterRepositoryTest extends TestCase
 
     public function setUp(): void
     {
-        Carbon::setTestNow(Carbon::create(2022));
+        CarbonImmutable::setTestNow(Carbon::create(2022));
 
         $eventRepository = new InMemoryDocumentRepository();
         $eventRepository->save(

--- a/tests/EventExport/CalendarSummary/CalendarSummaryWithFormatterRepositoryTest.php
+++ b/tests/EventExport/CalendarSummary/CalendarSummaryWithFormatterRepositoryTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\EventExport\CalendarSummary;
 
-use Carbon\Carbon;
-use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
@@ -19,7 +18,7 @@ final class CalendarSummaryWithFormatterRepositoryTest extends TestCase
 
     public function setUp(): void
     {
-        CarbonImmutable::setTestNow(Carbon::create(2022));
+        CalendarSummaryTester::setTestNow(2022);
 
         $eventRepository = new InMemoryDocumentRepository();
         $eventRepository->save(

--- a/tests/Http/Offer/GetCalendarSummaryRequestHandlerTest.php
+++ b/tests/Http/Offer/GetCalendarSummaryRequestHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Offer;
 
-use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\HtmlResponse;
@@ -28,7 +28,7 @@ class GetCalendarSummaryRequestHandlerTest extends TestCase
         $this->getCalendarSummaryRequestHandler = new GetCalendarSummaryRequestHandler(
             $this->repositoryMockFactory->create()
         );
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2022, 5, 3));
+        CalendarSummaryTester::setTestNow(2022, 5, 3);
     }
 
     /**

--- a/tests/Http/Offer/GetCalendarSummaryRequestHandlerTest.php
+++ b/tests/Http/Offer/GetCalendarSummaryRequestHandlerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Offer;
 
-use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
@@ -29,7 +28,7 @@ class GetCalendarSummaryRequestHandlerTest extends TestCase
         $this->getCalendarSummaryRequestHandler = new GetCalendarSummaryRequestHandler(
             $this->repositoryMockFactory->create()
         );
-        Carbon::setTestNow(CarbonImmutable::create(2022, 5, 3));
+        CarbonImmutable::setTestNow(CarbonImmutable::create(2022, 5, 3));
     }
 
     /**

--- a/tests/MoneyFactoryTest.php
+++ b/tests/MoneyFactoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3;
+
+use Money\Currency;
+use Money\Money;
+use PHPUnit\Framework\TestCase;
+
+final class MoneyFactoryTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider EuroDataProvider
+     */
+    public function it_can_return_a_price_from_a(Money $expectedMoney, Money $actualMoney): void
+    {
+        $this->assertEquals(
+            $expectedMoney,
+            $actualMoney
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider CentsDataProvider
+     */
+    public function it_can_return_a_price_from_cents(Money $expectedMoney, Money $actualMoney): void
+    {
+        $this->assertEquals(
+            $expectedMoney,
+            $actualMoney
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_with_an_invalid_input_type(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Given value should be an int, string, float, double. Got boolean instead.');
+
+        MoneyFactory::create(true, new Currency('EUR'));
+    }
+
+    public function EuroDataProvider(): array
+    {
+        return [
+            'euro in int' => [
+                'expectedMoney' => new Money(200, new Currency('EUR')),
+                'actualMoney' => MoneyFactory::create(2, new Currency('EUR')),
+            ],
+            'euro in float' => [
+                'expectedMoney' => new Money(230, new Currency('GBP')),
+                'actualMoney' => MoneyFactory::create(2.3, new Currency('GBP')),
+            ],
+            'euro in string' => [
+                'expectedMoney' => new Money(4500, new Currency('EUR')),
+                'actualMoney' => MoneyFactory::create('45', new Currency('EUR')),
+            ],
+            'euro in string with decimals' => [
+                'expectedMoney' => new Money(3390, new Currency('EUR')),
+                'actualMoney' => MoneyFactory::create('33.9', new Currency('EUR')),
+            ],
+        ];
+    }
+
+    public function CentsDataProvider(): array
+    {
+        return [
+            'cents in int' => [
+                'expectedMoney' => new Money(1999, new Currency('EUR')),
+                'actualMoney' => MoneyFactory::createFromCents(1999, new Currency('EUR')),
+            ],
+            'cents in string' => [
+                'expectedMoney' => new Money(2999, new Currency('EUR')),
+                'actualMoney' => MoneyFactory::createFromCents('2999', new Currency('EUR')),
+            ],
+            'cents in different currency' => [
+                'expectedMoney' => new Money(3999, new Currency('SEK')),
+                'actualMoney' => MoneyFactory::createFromCents('3999', new Currency('SEK')),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### Added
- `MoneyFactory` to better handle the conversions from `int`, `float` & `string` to `Money` 

### Fixed
- € 2.3 is no longer changed to € 2.29
- Temp Fix for `setTestNow()`

---
Ticket: https://jira.uitdatabank.be/browse/III-5159
