### PR TITLE
Abstraction Layer setTestNow()

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -775,16 +775,16 @@
         },
         {
             "name": "cultuurnet/calendar-summary-v3",
-            "version": "v4.0.2",
+            "version": "v4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/calendar-summary-v3.git",
-                "reference": "212ed0c4a180c3e91b89a287178dbbbd2eac3a6c"
+                "reference": "bdd97cd998301bcb0468e44e24b864466f3fc60f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/212ed0c4a180c3e91b89a287178dbbbd2eac3a6c",
-                "reference": "212ed0c4a180c3e91b89a287178dbbbd2eac3a6c",
+                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/bdd97cd998301bcb0468e44e24b864466f3fc60f",
+                "reference": "bdd97cd998301bcb0468e44e24b864466f3fc60f",
                 "shasum": ""
             },
             "require": {
@@ -821,9 +821,9 @@
             "description": "Library to convert cultuurnet dates to a readable summary",
             "support": {
                 "issues": "https://github.com/cultuurnet/calendar-summary-v3/issues",
-                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.2"
+                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.3"
             },
-            "time": "2022-12-06T14:59:39+00:00"
+            "time": "2023-01-03T07:49:10+00:00"
         },
         {
             "name": "cultuurnet/cdb",

--- a/tests/EventExport/CalendarSummary/CalendarSummaryWithFormatterRepositoryTest.php
+++ b/tests/EventExport/CalendarSummary/CalendarSummaryWithFormatterRepositoryTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\EventExport\CalendarSummary;
 
-use Carbon\Carbon;
-use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
@@ -19,7 +18,7 @@ final class CalendarSummaryWithFormatterRepositoryTest extends TestCase
 
     public function setUp(): void
     {
-        CarbonImmutable::setTestNow(Carbon::create(2022));
+        CalendarSummaryTester::setTestNow(2022);
 
         $eventRepository = new InMemoryDocumentRepository();
         $eventRepository->save(

--- a/tests/Http/Offer/GetCalendarSummaryRequestHandlerTest.php
+++ b/tests/Http/Offer/GetCalendarSummaryRequestHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Offer;
 
-use Carbon\CarbonImmutable;
+use CultuurNet\CalendarSummaryV3\CalendarSummaryTester;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\HtmlResponse;
@@ -28,7 +28,7 @@ class GetCalendarSummaryRequestHandlerTest extends TestCase
         $this->getCalendarSummaryRequestHandler = new GetCalendarSummaryRequestHandler(
             $this->repositoryMockFactory->create()
         );
-        CarbonImmutable::setTestNow(CarbonImmutable::create(2022, 5, 3));
+        CalendarSummaryTester::setTestNow(2022, 5, 3);
     }
 
     /**


### PR DESCRIPTION
### Changed
- updated calendar-summary to v4.0.3
- Replaced `CarbonImmutable::setTestNow()` with abstraction in calendar-summary

---
Ticket: https://jira.uitdatabank.be/browse/...
