### PR TITLE
III-5214 Give contributors edit rights

### DIFF
--- a/app/Authentication/AuthServiceProvider.php
+++ b/app/Authentication/AuthServiceProvider.php
@@ -19,7 +19,6 @@ use CultuurNet\UDB3\Http\Auth\RequestAuthenticatorMiddleware;
 use CultuurNet\UDB3\Impersonator;
 use CultuurNet\UDB3\Role\UserPermissionsServiceProvider;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use CultuurNet\UDB3\Security\UserEmailAddressRepository;
 use CultuurNet\UDB3\User\CurrentUser;
 
 final class AuthServiceProvider extends AbstractServiceProvider
@@ -59,8 +58,7 @@ final class AuthServiceProvider extends AbstractServiceProvider
                     new CultureFeedApiKeyAuthenticator($container->get(ConsumerReadRepository::class)),
                     $container->get(ConsumerReadRepository::class),
                     new ConsumerIsInPermissionGroup((string) $container->get('config')['api_key']['group_id']),
-                    $container->get(UserPermissionsServiceProvider::USER_PERMISSIONS_READ_REPOSITORY),
-                    $container->get(UserEmailAddressRepository::class)
+                    $container->get(UserPermissionsServiceProvider::USER_PERMISSIONS_READ_REPOSITORY)
                 );
 
                 // We can not expect the ids of events, places and organizers to be correctly formatted as UUIDs,

--- a/app/Authentication/AuthServiceProvider.php
+++ b/app/Authentication/AuthServiceProvider.php
@@ -19,6 +19,7 @@ use CultuurNet\UDB3\Http\Auth\RequestAuthenticatorMiddleware;
 use CultuurNet\UDB3\Impersonator;
 use CultuurNet\UDB3\Role\UserPermissionsServiceProvider;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\UserEmailAddressRepository;
 use CultuurNet\UDB3\User\CurrentUser;
 
 final class AuthServiceProvider extends AbstractServiceProvider
@@ -58,7 +59,8 @@ final class AuthServiceProvider extends AbstractServiceProvider
                     new CultureFeedApiKeyAuthenticator($container->get(ConsumerReadRepository::class)),
                     $container->get(ConsumerReadRepository::class),
                     new ConsumerIsInPermissionGroup((string) $container->get('config')['api_key']['group_id']),
-                    $container->get(UserPermissionsServiceProvider::USER_PERMISSIONS_READ_REPOSITORY)
+                    $container->get(UserPermissionsServiceProvider::USER_PERMISSIONS_READ_REPOSITORY),
+                    $container->get(UserEmailAddressRepository::class)
                 );
 
                 // We can not expect the ids of events, places and organizers to be correctly formatted as UUIDs,

--- a/app/Security/OfferSecurityServiceProvider.php
+++ b/app/Security/OfferSecurityServiceProvider.php
@@ -21,7 +21,6 @@ final class OfferSecurityServiceProvider extends AbstractServiceProvider
     {
         return [
             'offer_owner_query',
-            UserEmailAddressRepository::class,
             'offer_permission_voter',
         ];
     }
@@ -36,11 +35,6 @@ final class OfferSecurityServiceProvider extends AbstractServiceProvider
                 $container->get('event_owner.repository'),
                 $container->get('place_owner.repository'),
             ])
-        );
-
-        $container->addShared(
-            UserEmailAddressRepository::class,
-            fn () => new InMemoryUserEmailAddressRepository()
         );
 
         $container->addShared(

--- a/app/Security/OrganizerSecurityServiceProvider.php
+++ b/app/Security/OrganizerSecurityServiceProvider.php
@@ -6,7 +6,9 @@ namespace CultuurNet\UDB3\Security;
 
 use CultuurNet\UDB3\ApiName;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use CultuurNet\UDB3\Contributor\ContributorRepository;
 use CultuurNet\UDB3\Security\Permission\AnyOfVoter;
+use CultuurNet\UDB3\Security\Permission\ContributorVoter;
 use CultuurNet\UDB3\Security\Permission\ResourceOwnerVoter;
 use CultuurNet\UDB3\Security\Permission\Sapi3RoleConstraintVoter;
 use GuzzleHttp\Psr7\Uri;
@@ -34,6 +36,10 @@ final class OrganizerSecurityServiceProvider extends AbstractServiceProvider
                     $container->get(ApiName::class) !== ApiName::CLI &&
                     isset($container->get('config')['performance']['resource_owner_cache']) &&
                     $container->get('config')['performance']['resource_owner_cache']
+                ),
+                new ContributorVoter(
+                    $container->get(UserEmailAddressRepository::class),
+                    $container->get(ContributorRepository::class)
                 ),
                 new Sapi3RoleConstraintVoter(
                     $container->get('user_constraints_read_repository'),

--- a/app/User/UserServiceProvider.php
+++ b/app/User/UserServiceProvider.php
@@ -58,7 +58,7 @@ final class UserServiceProvider extends AbstractServiceProvider
 
         $container->addShared(
             UserEmailAddressRepository::class,
-            fn () => new InMemoryUserEmailAddressRepository()
+            fn () => new InMemoryUserEmailAddressRepository($container->get(JsonWebToken::class))
         );
     }
 }

--- a/app/User/UserServiceProvider.php
+++ b/app/User/UserServiceProvider.php
@@ -10,6 +10,8 @@ use CultuurNet\UDB3\Http\User\GetCurrentUserRequestHandler;
 use CultuurNet\UDB3\Http\User\GetUserByEmailRequestHandler;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
+use CultuurNet\UDB3\Security\InMemoryUserEmailAddressRepository;
+use CultuurNet\UDB3\Security\UserEmailAddressRepository;
 use CultuurNet\UDB3\UiTID\CdbXmlCreatedByToUserIdResolver;
 
 final class UserServiceProvider extends AbstractServiceProvider
@@ -20,6 +22,7 @@ final class UserServiceProvider extends AbstractServiceProvider
             'cdbxml_created_by_resolver',
             GetUserByEmailRequestHandler::class,
             GetCurrentUserRequestHandler::class,
+            UserEmailAddressRepository::class,
         ];
     }
 
@@ -51,6 +54,11 @@ final class UserServiceProvider extends AbstractServiceProvider
                 $container->get(Auth0UserIdentityResolver::class),
                 $container->get(JsonWebToken::class)
             )
+        );
+
+        $container->addShared(
+            UserEmailAddressRepository::class,
+            fn () => new InMemoryUserEmailAddressRepository()
         );
     }
 }

--- a/src/Http/Auth/Jwt/JsonWebToken.php
+++ b/src/Http/Auth/Jwt/JsonWebToken.php
@@ -119,6 +119,9 @@ final class JsonWebToken
         if ($this->token->hasClaim('email')) {
             return new EmailAddress($this->token->getClaim('email'));
         }
+        if ($this->token->hasClaim('https://publiq.be/email')) {
+            return new EmailAddress($this->token->getClaim('https://publiq.be/email'));
+        }
         return null;
     }
 

--- a/src/Http/Auth/Jwt/JsonWebToken.php
+++ b/src/Http/Auth/Jwt/JsonWebToken.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Auth\Jwt;
 
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\User\UserIdentityDetails;
 use CultuurNet\UDB3\User\UserIdentityResolver;
 use Exception;
@@ -111,6 +112,14 @@ final class JsonWebToken
         } catch (Exception $e) {
             return null;
         }
+    }
+
+    public function getEmailAddress(): ?EmailAddress
+    {
+        if ($this->token->hasClaim('email')) {
+            return new EmailAddress($this->token->getClaim('email'));
+        }
+        return null;
     }
 
     public function getClientId(): ?string

--- a/src/Http/Auth/RequestAuthenticatorMiddleware.php
+++ b/src/Http/Auth/RequestAuthenticatorMiddleware.php
@@ -17,7 +17,6 @@ use CultuurNet\UDB3\Http\Auth\Jwt\JwtValidator;
 use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine\UserPermissionsReadRepository;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use CultuurNet\UDB3\Security\UserEmailAddressRepository;
 use CultuurNet\UDB3\User\CurrentUser;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
@@ -44,7 +43,6 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
     private ApiKeyConsumerReadRepository $apiKeyConsumerReadRepository;
     private ApiKeyConsumerSpecification $apiKeyConsumerPermissionCheck;
     private UserPermissionsReadRepository $userPermissionReadRepository;
-    private UserEmailAddressRepository $userEmailAddressRepository;
 
     public function __construct(
         JwtValidator $uitIdV1JwtValidator,
@@ -52,8 +50,7 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
         ApiKeyAuthenticator $apiKeyAuthenticator,
         ApiKeyConsumerReadRepository $apiKeyConsumerReadRepository,
         ApiKeyConsumerSpecification $apiKeyConsumerPermissionCheck,
-        UserPermissionsReadRepository $userPermissionsReadRepository,
-        UserEmailAddressRepository $userEmailAddressRepository
+        UserPermissionsReadRepository $userPermissionsReadRepository
     ) {
         $this->uitIdV1JwtValidator = $uitIdV1JwtValidator;
         $this->uitIdV2JwtValidator = $uitIdV2JwtValidator;
@@ -61,7 +58,6 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
         $this->apiKeyConsumerReadRepository = $apiKeyConsumerReadRepository;
         $this->apiKeyConsumerPermissionCheck = $apiKeyConsumerPermissionCheck;
         $this->userPermissionReadRepository = $userPermissionsReadRepository;
-        $this->userEmailAddressRepository = $userEmailAddressRepository;
     }
 
     public function addPublicRoute(string $pathPattern, array $methods = []): void
@@ -145,12 +141,6 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
 
         $validator->verifySignature($this->token);
         $validator->validateClaims($this->token);
-        if ($this->token->getEmailAddress()) {
-            $this->userEmailAddressRepository::addUserEmail(
-                $this->token->getUserId(),
-                $this->token->getEmailAddress()
-            );
-        }
     }
 
     private function authenticateApiKey(ServerRequestInterface $request): void

--- a/src/Security/InMemoryUserEmailAddressRepository.php
+++ b/src/Security/InMemoryUserEmailAddressRepository.php
@@ -8,6 +8,9 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 
 final class InMemoryUserEmailAddressRepository implements UserEmailAddressRepository
 {
+    /**
+     * @var EmailAddress[] $mappedUserIds
+     */
     private static array $mappedUserIds = [];
 
     public static function addUserEmail(string $userId, EmailAddress $emailAddress): void
@@ -18,9 +21,7 @@ final class InMemoryUserEmailAddressRepository implements UserEmailAddressReposi
     public function getEmailForUserId(string $userId): ?EmailAddress
     {
         if (array_key_exists($userId, self::$mappedUserIds)) {
-            /** @var EmailAddress $emailAddress */
-            $emailAddress = self::$mappedUserIds[$userId];
-            return $emailAddress;
+            return self::$mappedUserIds[$userId];
         }
         return null;
     }

--- a/src/Security/InMemoryUserEmailAddressRepository.php
+++ b/src/Security/InMemoryUserEmailAddressRepository.php
@@ -4,25 +4,20 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security;
 
+use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 
 final class InMemoryUserEmailAddressRepository implements UserEmailAddressRepository
 {
-    /**
-     * @var EmailAddress[]
-     */
-    private static array $mappedUserIds = [];
+    private JsonWebToken $token;
 
-    public static function addUserEmail(string $userId, EmailAddress $emailAddress): void
+    public function __construct(JsonWebToken $token)
     {
-        self::$mappedUserIds[$userId] = $emailAddress;
+        $this->token = $token;
     }
 
     public function getEmailForUserId(string $userId): ?EmailAddress
     {
-        if (array_key_exists($userId, self::$mappedUserIds)) {
-            return self::$mappedUserIds[$userId];
-        }
-        return null;
+        return $this->token->getEmailAddress();
     }
 }

--- a/src/Security/InMemoryUserEmailAddressRepository.php
+++ b/src/Security/InMemoryUserEmailAddressRepository.php
@@ -18,6 +18,10 @@ final class InMemoryUserEmailAddressRepository implements UserEmailAddressReposi
 
     public function getEmailForUserId(string $userId): ?EmailAddress
     {
-        return $this->token->getEmailAddress();
+        if ($this->token->getUserId() === $userId) {
+            return $this->token->getEmailAddress();
+        }
+
+        return null;
     }
 }

--- a/src/Security/InMemoryUserEmailAddressRepository.php
+++ b/src/Security/InMemoryUserEmailAddressRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Security;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+
+final class InMemoryUserEmailAddressRepository implements UserEmailAddressRepository
+{
+    private static array $mappedUserIds = [];
+
+    public static function addUserEmail(string $userId, EmailAddress $emailAddress)
+    {
+        self::$mappedUserIds[$userId] = $emailAddress;
+    }
+
+    public function getEmailForUserId(string $userId): ?EmailAddress
+    {
+        if (array_key_exists($userId, self::$mappedUserIds)) {
+            /** @var EmailAddress $emailAddress */
+            $emailAddress = self::$mappedUserIds[$userId];
+            return $emailAddress;
+        }
+        return null;
+    }
+}

--- a/src/Security/InMemoryUserEmailAddressRepository.php
+++ b/src/Security/InMemoryUserEmailAddressRepository.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 final class InMemoryUserEmailAddressRepository implements UserEmailAddressRepository
 {
     /**
-     * @var EmailAddress[] $mappedUserIds
+     * @var EmailAddress[]
      */
     private static array $mappedUserIds = [];
 

--- a/src/Security/InMemoryUserEmailAddressRepository.php
+++ b/src/Security/InMemoryUserEmailAddressRepository.php
@@ -10,7 +10,7 @@ final class InMemoryUserEmailAddressRepository implements UserEmailAddressReposi
 {
     private static array $mappedUserIds = [];
 
-    public static function addUserEmail(string $userId, EmailAddress $emailAddress)
+    public static function addUserEmail(string $userId, EmailAddress $emailAddress): void
     {
         self::$mappedUserIds[$userId] = $emailAddress;
     }

--- a/src/Security/Permission/ContributorVoter.php
+++ b/src/Security/Permission/ContributorVoter.php
@@ -27,6 +27,6 @@ final class ContributorVoter implements PermissionVoter
     public function isAllowed(Permission $permission, StringLiteral $itemId, StringLiteral $userId): bool
     {
         $email = $this->repository->getEmailForUserId($userId->toNative());
-        return $email &&  $this->contributorRepository->isContributor(new UUID($itemId->toNative()), $email);
+        return $email && $this->contributorRepository->isContributor(new UUID($itemId->toNative()), $email);
     }
 }

--- a/src/Security/Permission/ContributorVoter.php
+++ b/src/Security/Permission/ContributorVoter.php
@@ -28,6 +28,6 @@ final class ContributorVoter implements PermissionVoter
     public function isAllowed(Permission $permission, StringLiteral $itemId, StringLiteral $userId): bool
     {
         $email = $this->repository->getEmailForUserId($userId->toNative());
-        return $email &&  $this->contributorRepository->isContributor(new UUID($itemId), $email);
+        return $email &&  $this->contributorRepository->isContributor(new UUID($itemId->toNative()), $email);
     }
 }

--- a/src/Security/Permission/ContributorVoter.php
+++ b/src/Security/Permission/ContributorVoter.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\StringLiteral;
 
 final class ContributorVoter implements PermissionVoter
 {
-    private UserEmailAddressRepository $repository;
+    private UserEmailAddressRepository $userEmailAddressRepository;
 
     private ContributorRepository $contributorRepository;
 
@@ -20,13 +20,13 @@ final class ContributorVoter implements PermissionVoter
         UserEmailAddressRepository $repository,
         ContributorRepository $contributorRepository
     ) {
-        $this->repository = $repository;
+        $this->userEmailAddressRepository = $repository;
         $this->contributorRepository = $contributorRepository;
     }
 
     public function isAllowed(Permission $permission, StringLiteral $itemId, StringLiteral $userId): bool
     {
-        $email = $this->repository->getEmailForUserId($userId->toNative());
+        $email = $this->userEmailAddressRepository->getEmailForUserId($userId->toNative());
         return $email && $this->contributorRepository->isContributor(new UUID($itemId->toNative()), $email);
     }
 }

--- a/src/Security/Permission/ContributorVoter.php
+++ b/src/Security/Permission/ContributorVoter.php
@@ -28,9 +28,7 @@ final class ContributorVoter implements PermissionVoter
     public function isAllowed(Permission $permission, StringLiteral $itemId, StringLiteral $userId): bool
     {
         $email = $this->repository->getEmailForUserId($userId->toNative());
-        return $email &&
-            in_array($email, $this->getEmailAddressesForItem($itemId->toNative())->toArray()
-            );
+        return $email && in_array($email, $this->getEmailAddressesForItem($itemId->toNative())->toArray());
     }
 
     private function getEmailAddressesForItem(string $itemId): EmailAddresses

--- a/src/Security/Permission/ContributorVoter.php
+++ b/src/Security/Permission/ContributorVoter.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Contributor\ContributorRepository;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Security\UserEmailAddressRepository;
 use CultuurNet\UDB3\StringLiteral;

--- a/src/Security/Permission/ContributorVoter.php
+++ b/src/Security/Permission/ContributorVoter.php
@@ -27,10 +27,9 @@ final class ContributorVoter implements PermissionVoter
 
     public function isAllowed(Permission $permission, StringLiteral $itemId, StringLiteral $userId): bool
     {
-        return $this->repository->getEmailForUserId($userId->toNative()) &&
-            in_array(
-                $this->repository->getEmailForUserId($userId->toNative()),
-                $this->getEmailAddressesForItem($itemId->toNative())->toArray()
+        $email = $this->repository->getEmailForUserId($userId->toNative());
+        return $email &&
+            in_array($email, $this->getEmailAddressesForItem($itemId->toNative())->toArray()
             );
     }
 

--- a/src/Security/Permission/ContributorVoter.php
+++ b/src/Security/Permission/ContributorVoter.php
@@ -28,11 +28,6 @@ final class ContributorVoter implements PermissionVoter
     public function isAllowed(Permission $permission, StringLiteral $itemId, StringLiteral $userId): bool
     {
         $email = $this->repository->getEmailForUserId($userId->toNative());
-        return $email && in_array($email, $this->getEmailAddressesForItem($itemId->toNative())->toArray());
-    }
-
-    private function getEmailAddressesForItem(string $itemId): EmailAddresses
-    {
-        return $this->contributorRepository->getContributors(new UUID($itemId));
+        return $email &&  $this->contributorRepository->isContributor(new UUID($itemId), $email);
     }
 }

--- a/src/Security/Permission/ContributorVoter.php
+++ b/src/Security/Permission/ContributorVoter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Security\Permission;
+
+use CultuurNet\UDB3\Contributor\ContributorRepository;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\UserEmailAddressRepository;
+use CultuurNet\UDB3\StringLiteral;
+
+final class ContributorVoter implements PermissionVoter
+{
+    private UserEmailAddressRepository $repository;
+
+    private ContributorRepository $contributorRepository;
+
+    public function __construct(
+        UserEmailAddressRepository $repository,
+        ContributorRepository $contributorRepository
+    ) {
+        $this->repository = $repository;
+        $this->contributorRepository = $contributorRepository;
+    }
+
+    public function isAllowed(Permission $permission, StringLiteral $itemId, StringLiteral $userId): bool
+    {
+        return $this->repository->getEmailForUserId($userId->toNative()) &&
+            in_array(
+                $this->repository->getEmailForUserId($userId->toNative()),
+                $this->getEmailAddressesForItem($itemId->toNative())->toArray()
+            );
+    }
+
+    private function getEmailAddressesForItem(string $itemId): EmailAddresses
+    {
+        return $this->contributorRepository->getContributors(new UUID($itemId));
+    }
+}

--- a/src/Security/UserEmailAddressRepository.php
+++ b/src/Security/UserEmailAddressRepository.php
@@ -8,5 +8,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 
 interface UserEmailAddressRepository
 {
+    public static function addUserEmail(string $userId, EmailAddress $emailAddress): void;
+
     public function getEmailForUserId(string $userId): ?EmailAddress;
 }

--- a/src/Security/UserEmailAddressRepository.php
+++ b/src/Security/UserEmailAddressRepository.php
@@ -8,7 +8,5 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 
 interface UserEmailAddressRepository
 {
-    public static function addUserEmail(string $userId, EmailAddress $emailAddress): void;
-
     public function getEmailForUserId(string $userId): ?EmailAddress;
 }

--- a/src/Security/UserEmailAddressRepository.php
+++ b/src/Security/UserEmailAddressRepository.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Security;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+
+interface UserEmailAddressRepository
+{
+    public function getEmailForUserId(string $userId): ?EmailAddress;
+}

--- a/tests/Http/Auth/Jwt/JsonWebTokenTest.php
+++ b/tests/Http/Auth/Jwt/JsonWebTokenTest.php
@@ -199,7 +199,7 @@ class JsonWebTokenTest extends TestCase
 
         $auth0Token = JsonWebTokenFactory::createWithClaims(
             [
-                'https://publiq.be/email' => 'mock@example.com'
+                'https://publiq.be/email' => 'mock@example.com',
             ]
         );
 

--- a/tests/Http/Auth/Jwt/JsonWebTokenTest.php
+++ b/tests/Http/Auth/Jwt/JsonWebTokenTest.php
@@ -191,11 +191,15 @@ class JsonWebTokenTest extends TestCase
      */
     public function it_can_get_an_email_from_a_token(): void
     {
-        $tokenWithEmail = JsonWebTokenFactory::createWithClaims(
+        $jwtToken = JsonWebTokenFactory::createWithClaims(
             [
-                'uid' => 'c82bd40c-1932-4c45-bd5d-a76cc9907cee',
-                'nick' => 'mock-nickname',
                 'email' => 'mock@example.com',
+            ]
+        );
+
+        $auth0Token = JsonWebTokenFactory::createWithClaims(
+            [
+                'https://publiq.be/email' => 'mock@example.com'
             ]
         );
 
@@ -208,7 +212,12 @@ class JsonWebTokenTest extends TestCase
 
         $this->assertEquals(
             new EmailAddress('mock@example.com'),
-            $tokenWithEmail->getEmailAddress()
+            $jwtToken->getEmailAddress()
+        );
+
+        $this->assertEquals(
+            new EmailAddress('mock@example.com'),
+            $auth0Token->getEmailAddress()
         );
 
         $this->assertNull($tokenWithoutEmail->getEmailAddress());

--- a/tests/Http/Auth/Jwt/JsonWebTokenTest.php
+++ b/tests/Http/Auth/Jwt/JsonWebTokenTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Auth\Jwt;
 
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\User\UserIdentityDetails;
 use CultuurNet\UDB3\User\UserIdentityResolver;
 use PHPUnit\Framework\TestCase;
@@ -183,6 +184,34 @@ class JsonWebTokenTest extends TestCase
         );
 
         $this->assertEquals($details, $v1Token->getUserIdentityDetails($userIdentityResolver));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_an_email_from_a_token(): void
+    {
+        $tokenWithEmail = JsonWebTokenFactory::createWithClaims(
+            [
+                'uid' => 'c82bd40c-1932-4c45-bd5d-a76cc9907cee',
+                'nick' => 'mock-nickname',
+                'email' => 'mock@example.com',
+            ]
+        );
+
+        $tokenWithoutEmail = JsonWebTokenFactory::createWithClaims(
+            [
+                'sub' => 'auth0|mock-user-id',
+                'azp' => 'mock-client',
+            ]
+        );
+
+        $this->assertEquals(
+            new EmailAddress('mock@example.com'),
+            $tokenWithEmail->getEmailAddress()
+        );
+
+        $this->assertNull($tokenWithoutEmail->getEmailAddress());
     }
 
     /**

--- a/tests/Security/InMemoryUserEmailAddressRepositoryTest.php
+++ b/tests/Security/InMemoryUserEmailAddressRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security;
 
+use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebTokenFactory;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use PHPUnit\Framework\TestCase;
 
@@ -13,19 +14,27 @@ final class InMemoryUserEmailAddressRepositoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->userEmailAddressRepository = new InMemoryUserEmailAddressRepository();
     }
 
     /**
      * @test
      */
-    public function it_can_make_a_user_email_mapping(): void
+    public function it_can_make_get_an_email_from_a_user_id(): void
     {
-        $mappedEmail = new EmailAddress('somebody@mail.com');
-        $userId = 'e7497a8b-dd4a-44dc-bfc4-ac405d66ec39';
-        $this->userEmailAddressRepository::addUserEmail($userId, $mappedEmail);
+        $existingUserId = 'e7497a8b-dd4a-44dc-bfc4-ac405d66ec39';
+        $existingUserMail = 'somebody@mail.com';
 
-        $this->assertEquals($mappedEmail, $this->userEmailAddressRepository->getEmailForUserId($userId));
+        $this->userEmailAddressRepository = new InMemoryUserEmailAddressRepository(
+            JsonWebTokenFactory::createWithClaims(
+                [
+                    'https://publiq.be/uitidv1id' => $existingUserId,
+                    'https://publiq.be/email' => $existingUserMail,
+                ]
+            )
+        );
+
+        $mappedEmail = new EmailAddress($existingUserMail);
+        $this->assertEquals($mappedEmail, $this->userEmailAddressRepository->getEmailForUserId($existingUserId));
     }
 
     /**
@@ -33,6 +42,10 @@ final class InMemoryUserEmailAddressRepositoryTest extends TestCase
      */
     public function it_returns_null_if_no_mapping_is_found(): void
     {
-        $this->assertNull($this->userEmailAddressRepository->getEmailForUserId('nobody@mail.com'));
+        $this->userEmailAddressRepository = new InMemoryUserEmailAddressRepository(
+            JsonWebTokenFactory::createWithClaims([])
+        );
+
+        $this->assertNull($this->userEmailAddressRepository->getEmailForUserId('c25a053a-bab1-428b-90fc-c30f9cb6c323'));
     }
 }

--- a/tests/Security/InMemoryUserEmailAddressRepositoryTest.php
+++ b/tests/Security/InMemoryUserEmailAddressRepositoryTest.php
@@ -12,8 +12,26 @@ final class InMemoryUserEmailAddressRepositoryTest extends TestCase
 {
     private UserEmailAddressRepository $userEmailAddressRepository;
 
+    private string $existingUserId;
+
+    private string $otherUserId;
+
+    private string $existingUserMail;
+
     protected function setUp(): void
     {
+        $this->existingUserId = 'e7497a8b-dd4a-44dc-bfc4-ac405d66ec39';
+        $this->otherUserId = 'c25a053a-bab1-428b-90fc-c30f9cb6c323';
+        $this->existingUserMail = 'somebody@mail.com';
+
+        $this->userEmailAddressRepository = new InMemoryUserEmailAddressRepository(
+            JsonWebTokenFactory::createWithClaims(
+                [
+                    'https://publiq.be/uitidv1id' => $this->existingUserId,
+                    'https://publiq.be/email' => $this->existingUserMail,
+                ]
+            )
+        );
     }
 
     /**
@@ -21,20 +39,8 @@ final class InMemoryUserEmailAddressRepositoryTest extends TestCase
      */
     public function it_can_make_get_an_email_from_a_user_id(): void
     {
-        $existingUserId = 'e7497a8b-dd4a-44dc-bfc4-ac405d66ec39';
-        $existingUserMail = 'somebody@mail.com';
-
-        $this->userEmailAddressRepository = new InMemoryUserEmailAddressRepository(
-            JsonWebTokenFactory::createWithClaims(
-                [
-                    'https://publiq.be/uitidv1id' => $existingUserId,
-                    'https://publiq.be/email' => $existingUserMail,
-                ]
-            )
-        );
-
-        $mappedEmail = new EmailAddress($existingUserMail);
-        $this->assertEquals($mappedEmail, $this->userEmailAddressRepository->getEmailForUserId($existingUserId));
+        $mappedEmail = new EmailAddress($this->existingUserMail);
+        $this->assertEquals($mappedEmail, $this->userEmailAddressRepository->getEmailForUserId($this->existingUserId));
     }
 
     /**
@@ -42,10 +48,6 @@ final class InMemoryUserEmailAddressRepositoryTest extends TestCase
      */
     public function it_returns_null_if_no_mapping_is_found(): void
     {
-        $this->userEmailAddressRepository = new InMemoryUserEmailAddressRepository(
-            JsonWebTokenFactory::createWithClaims([])
-        );
-
-        $this->assertNull($this->userEmailAddressRepository->getEmailForUserId('c25a053a-bab1-428b-90fc-c30f9cb6c323'));
+        $this->assertNull($this->userEmailAddressRepository->getEmailForUserId($this->otherUserId));
     }
 }

--- a/tests/Security/InMemoryUserEmailAddressRepositoryTest.php
+++ b/tests/Security/InMemoryUserEmailAddressRepositoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Security;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use PHPUnit\Framework\TestCase;
+
+final class InMemoryUserEmailAddressRepositoryTest extends TestCase
+{
+    private UserEmailAddressRepository $userEmailAddressRepository;
+
+    protected function setUp(): void
+    {
+        $this->userEmailAddressRepository = new InMemoryUserEmailAddressRepository();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_make_a_user_email_mapping(): void
+    {
+        $mappedEmail = new EmailAddress('somebody@mail.com');
+        $userId = 'e7497a8b-dd4a-44dc-bfc4-ac405d66ec39';
+        $this->userEmailAddressRepository::addUserEmail($userId, $mappedEmail);
+
+        $this->assertEquals($mappedEmail, $this->userEmailAddressRepository->getEmailForUserId($userId));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_if_no_mapping_is_found(): void
+    {
+        $this->assertNull($this->userEmailAddressRepository->getEmailForUserId('nobody@mail.com'));
+    }
+}

--- a/tests/Security/Permission/ContributorVoterTest.php
+++ b/tests/Security/Permission/ContributorVoterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Security\Permission;
+
+use CultuurNet\UDB3\Contributor\ContributorRepository;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\UserEmailAddressRepository;
+use CultuurNet\UDB3\StringLiteral;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ContributorVoterTest extends TestCase
+{
+    private ContributorVoter $contributorVoter;
+
+    /**
+     * @var UserEmailAddressRepository|MockObject
+     */
+    private $userEmailAddressRepository;
+
+    /**
+     * @var ContributorRepository|MockObject
+     */
+    private $contributorRepository;
+
+    private string $userId;
+
+    private string $itemId;
+
+    private EmailAddress $email;
+
+    public function setup(): void
+    {
+        $this->userEmailAddressRepository = $this->createMock(UserEmailAddressRepository::class);
+        $this->contributorRepository = $this->createMock(ContributorRepository::class);
+        $this->contributorVoter = new ContributorVoter(
+            $this->userEmailAddressRepository,
+            $this->contributorRepository
+        );
+        $this->userId = 'bd04e0a4-4f3c-4180-9011-afbc673f58be';
+        $this->itemId = '71653d1f-5f6d-4f89-b654-1aed64d5c528';
+        $this->email = new EmailAddress('somebody@mail.com');
+    }
+
+    /**
+     * @test
+     */
+    public function it_gives_permission_if_a_user_is_a_contributor(): void
+    {
+        $this->userEmailAddressRepository->expects($this->once())
+            ->method('getEmailForUserId')
+            ->with($this->userId)
+            ->willReturn($this->email);
+
+        $this->contributorRepository->expects($this->once())
+            ->method('isContributor')
+            ->with(new UUID($this->itemId), $this->email)
+            ->willReturn(true);
+
+        $this->assertTrue(
+            $this->contributorVoter->isAllowed(
+                Permission::aanbodBewerken(),
+                new StringLiteral($this->itemId),
+                new StringLiteral($this->userId)
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_gives_no_permission_if_a_user_is_not_a_contributor(): void
+    {
+        $this->userEmailAddressRepository->expects($this->once())
+            ->method('getEmailForUserId')
+            ->with($this->userId)
+            ->willReturn($this->email);
+
+        $this->contributorRepository->expects($this->once())
+            ->method('isContributor')
+            ->with(new UUID($this->itemId), $this->email)
+            ->willReturn(false);
+
+        $this->assertFalse(
+            $this->contributorVoter->isAllowed(
+                Permission::aanbodBewerken(),
+                new StringLiteral($this->itemId),
+                new StringLiteral($this->userId)
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_gives_no_permission_if_a_user_has_no_email_mapping(): void
+    {
+        $this->userEmailAddressRepository->expects($this->once())
+            ->method('getEmailForUserId')
+            ->with($this->userId)
+            ->willReturn(null);
+
+        $this->contributorRepository->expects($this->never())
+            ->method('isContributor');
+
+        $this->assertFalse(
+            $this->contributorVoter->isAllowed(
+                Permission::aanbodBewerken(),
+                new StringLiteral($this->itemId),
+                new StringLiteral($this->userId)
+            )
+        );
+    }
+}


### PR DESCRIPTION
### Added
- `ContributorVoter` to  give Contributors `edit` rights.
- `UserEmailAddressRepository` to retrieve `email` from `userId`
- `InMemoryUserEmailAddressRepository` as implementation of `UserEmailAddressRepository`

### Changed
- Added `ContributorVoter` to `OfferSecurityServiceProvider` & `OrganizerSecurityServiceProvider`
- `getEmailAddress()` on `JsonWebToken`

---
Ticket: https://jira.uitdatabank.be/browse/III-5214
