### PR TITLE
III-5334 messaging contributors

### DIFF
--- a/app/AMQP/AMQPPublisherServiceProvider.php
+++ b/app/AMQP/AMQPPublisherServiceProvider.php
@@ -18,13 +18,16 @@ use CultuurNet\UDB3\Broadway\AMQP\Message\Properties\ContentTypePropertiesFactor
 use CultuurNet\UDB3\Broadway\AMQP\Message\Properties\CorrelationIdPropertiesFactory;
 use CultuurNet\UDB3\Broadway\AMQP\Message\Properties\DeliveryModePropertiesFactory;
 use CultuurNet\UDB3\Broadway\EventHandling\ReplayFilteringEventListener;
+use CultuurNet\UDB3\Event\EventContributorsUpdated;
 use CultuurNet\UDB3\Event\Events\EventProjectedToJSONLD;
 use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
 use CultuurNet\UDB3\Offer\ProcessManagers\RelatedDocumentProjectedToJSONLDDispatcher;
+use CultuurNet\UDB3\Organizer\OrganizerContributorsUpdated;
 use CultuurNet\UDB3\Organizer\OrganizerProjectedToJSONLD;
 use CultuurNet\UDB3\Place\Events\PlaceProjectedToJSONLD;
 use CultuurNet\UDB3\ApiName;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use CultuurNet\UDB3\Place\PlaceContributorsUpdated;
 use PhpAmqpLib\Message\AMQPMessage;
 
 final class AMQPPublisherServiceProvider extends AbstractServiceProvider
@@ -48,6 +51,9 @@ final class AMQPPublisherServiceProvider extends AbstractServiceProvider
                     EventProjectedToJSONLD::class => 'application/vnd.cultuurnet.udb3-events.event-projected-to-jsonld+json',
                     PlaceProjectedToJSONLD::class => 'application/vnd.cultuurnet.udb3-events.place-projected-to-jsonld+json',
                     OrganizerProjectedToJSONLD::class => 'application/vnd.cultuurnet.udb3-events.organizer-projected-to-jsonld+json',
+                    EventContributorsUpdated::class => 'application/vnd.cultuurnet.udb3-events.event-contributors-updated',
+                    PlaceContributorsUpdated::class => 'application/vnd.cultuurnet.udb3-events.place-contributors-updated',
+                    OrganizerContributorsUpdated::class => 'application/vnd.cultuurnet.udb3-events.organizer-contributors-updated',
                 ];
 
                 $specificationCollection = new SpecificationCollection();

--- a/app/Contributor/ContributorServiceProvider.php
+++ b/app/Contributor/ContributorServiceProvider.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Contributor;
 
+use Broadway\EventHandling\EventBus;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use CultuurNet\UDB3\Iri\CallableIriGenerator;
 
 final class ContributorServiceProvider extends AbstractServiceProvider
 {
@@ -21,7 +23,23 @@ final class ContributorServiceProvider extends AbstractServiceProvider
 
         $container->addShared(
             ContributorRepository::class,
-            fn () => new DbalContributorRepository($container->get('dbal_connection'))
+            fn () => new BroadcastingContributorRepository(
+                new DbalContributorRepository($container->get('dbal_connection')),
+                $container->get(EventBus::class),
+                new ContributorsUpdatedFactory(
+                    new CallableIriGenerator(
+                        fn ($cdbid) => $container->get('config')['url'] . '/events/' . $cdbid . '/contributors'
+                    ),
+                    new CallableIriGenerator(
+                        fn ($cdbid) => $container->get('config')['url'] . '/places/' . $cdbid . '/contributors'
+                    ),
+                    new CallableIriGenerator(
+                        fn () => new CallableIriGenerator(
+                            fn ($cdbid) => $container->get('config')['url'] . '/organizers/' . $cdbid . '/contributors'
+                        )
+                    )
+                )
+            )
         );
     }
 }

--- a/app/Contributor/ContributorServiceProvider.php
+++ b/app/Contributor/ContributorServiceProvider.php
@@ -34,9 +34,7 @@ final class ContributorServiceProvider extends AbstractServiceProvider
                         fn ($cdbid) => $container->get('config')['url'] . '/places/' . $cdbid . '/contributors'
                     ),
                     new CallableIriGenerator(
-                        fn () => new CallableIriGenerator(
-                            fn ($cdbid) => $container->get('config')['url'] . '/organizers/' . $cdbid . '/contributors'
-                        )
+                        fn ($cdbid) => $container->get('config')['url'] . '/organizers/' . $cdbid . '/contributors'
                     )
                 )
             )

--- a/src/Contributor/BroadcastingContributorRepository.php
+++ b/src/Contributor/BroadcastingContributorRepository.php
@@ -40,9 +40,9 @@ final class BroadcastingContributorRepository implements ContributorRepository
         return $this->repository->isContributor($id, $emailAddress);
     }
 
-    public function overwriteContributors(UUID $id, EmailAddresses $emailAddresses, ItemType $itemType): void
+    public function updateContributors(UUID $id, EmailAddresses $emailAddresses, ItemType $itemType): void
     {
-        $this->repository->overwriteContributors($id, $emailAddresses, $itemType);
+        $this->repository->updateContributors($id, $emailAddresses, $itemType);
 
         if ($itemType->sameAs(ItemType::event())) {
             $contributorsUpdated = $this->contributorOverwrittenFactory->createEventContributorsUpdated($id->toString());

--- a/src/Contributor/BroadcastingContributorRepository.php
+++ b/src/Contributor/BroadcastingContributorRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Contributor;
+
+use Broadway\Domain\DomainEventStream;
+use Broadway\EventHandling\EventBus;
+use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
+
+final class BroadcastingContributorRepository implements ContributorRepository
+{
+    private ContributorRepository $repository;
+
+    private EventBus $eventBus;
+
+    private ContributorsUpdatedFactory $contributorOverwrittenFactory;
+
+    public function __construct(
+        ContributorRepository $repository,
+        EventBus $eventBus,
+        ContributorsUpdatedFactory $contributorOverwrittenFactory
+    ) {
+        $this->repository = $repository;
+        $this->eventBus = $eventBus;
+        $this->contributorOverwrittenFactory = $contributorOverwrittenFactory;
+    }
+
+    public function getContributors(UUID $id): EmailAddresses
+    {
+        return $this->repository->getContributors($id);
+    }
+
+    public function isContributor(UUID $id, EmailAddress $emailAddress): bool
+    {
+        return $this->repository->isContributor($id, $emailAddress);
+    }
+
+    public function overwriteContributors(UUID $id, EmailAddresses $emailAddresses, ItemType $itemType): void
+    {
+        $this->repository->overwriteContributors($id, $emailAddresses, $itemType);
+
+        if ($itemType->sameAs(ItemType::event())) {
+            $contributorsUpdated = $this->contributorOverwrittenFactory->createEventContributorsUpdated($id->toString());
+        } elseif ($itemType->sameAs(ItemType::place())) {
+            $contributorsUpdated = $this->contributorOverwrittenFactory->createPlaceContributorsUpdated($id->toString());
+        } else {
+            $contributorsUpdated = $this->contributorOverwrittenFactory->createOrganizerContributorsUpdated($id->toString());
+        }
+
+        $this->eventBus->publish(new DomainEventStream([(new DomainMessageBuilder())->create($contributorsUpdated)]));
+    }
+}

--- a/src/Contributor/BroadcastingContributorRepository.php
+++ b/src/Contributor/BroadcastingContributorRepository.php
@@ -44,13 +44,7 @@ final class BroadcastingContributorRepository implements ContributorRepository
     {
         $this->repository->updateContributors($id, $emailAddresses, $itemType);
 
-        if ($itemType->sameAs(ItemType::event())) {
-            $contributorsUpdated = $this->contributorOverwrittenFactory->createEventContributorsUpdated($id->toString());
-        } elseif ($itemType->sameAs(ItemType::place())) {
-            $contributorsUpdated = $this->contributorOverwrittenFactory->createPlaceContributorsUpdated($id->toString());
-        } else {
-            $contributorsUpdated = $this->contributorOverwrittenFactory->createOrganizerContributorsUpdated($id->toString());
-        }
+        $contributorsUpdated = $this->contributorOverwrittenFactory->createForItemType($id->toString(), $itemType);
 
         $this->eventBus->publish(new DomainEventStream([(new DomainMessageBuilder())->create($contributorsUpdated)]));
     }

--- a/src/Contributor/ContributorsUpdated.php
+++ b/src/Contributor/ContributorsUpdated.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Contributor;
+
+use Broadway\Serializer\Serializable;
+
+abstract class ContributorsUpdated implements Serializable
+{
+    private string $id;
+
+    private string $iri;
+
+    public function __construct(string $id, string $iri)
+    {
+        $this->id = $id;
+        $this->iri = $iri;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getIri(): string
+    {
+        return $this->iri;
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'iri' => $this->getIri(),
+        ];
+    }
+}

--- a/src/Contributor/ContributorsUpdatedFactory.php
+++ b/src/Contributor/ContributorsUpdatedFactory.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Contributor;
 
 use CultuurNet\UDB3\Event\EventContributorsUpdated;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Organizer\OrganizerContributorsUpdated;
 use CultuurNet\UDB3\Place\PlaceContributorsUpdated;
 
@@ -28,24 +29,22 @@ final class ContributorsUpdatedFactory
         $this->organizerContributorsUpdatedIriGenerator = $organizerContributorsUpdatedIriGenerator;
     }
 
-    public function createEventContributorsUpdated(string $id): EventContributorsUpdated
+    public function createForItemType(string $id, ItemType $itemType): ContributorsUpdated
     {
-        return new EventContributorsUpdated(
-            $id,
-            $this->eventContributorsUpdatedIriGenerator->iri($id)
-        );
-    }
+        if ($itemType->sameAs(ItemType::event())) {
+            return new EventContributorsUpdated(
+                $id,
+                $this->eventContributorsUpdatedIriGenerator->iri($id)
+            );
+        }
 
-    public function createPlaceContributorsUpdated(string $id): PlaceContributorsUpdated
-    {
-        return new PlaceContributorsUpdated(
-            $id,
-            $this->placeContributorsUpdatedIriGenerator->iri($id)
-        );
-    }
+        if ($itemType->sameAs(ItemType::place())) {
+            return new PlaceContributorsUpdated(
+                $id,
+                $this->placeContributorsUpdatedIriGenerator->iri($id)
+            );
+        }
 
-    public function createOrganizerContributorsUpdated(string $id): OrganizerContributorsUpdated
-    {
         return new OrganizerContributorsUpdated(
             $id,
             $this->organizerContributorsUpdatedIriGenerator->iri($id)

--- a/src/Contributor/ContributorsUpdatedFactory.php
+++ b/src/Contributor/ContributorsUpdatedFactory.php
@@ -12,21 +12,21 @@ use CultuurNet\UDB3\Place\PlaceContributorsUpdated;
 
 final class ContributorsUpdatedFactory
 {
-    private IriGeneratorInterface $eventContributorsUpdatedIriGenerator;
+    private IriGeneratorInterface $eventGetContributorsIriGenerator;
 
-    private IriGeneratorInterface $placeContributorsUpdatedIriGenerator;
+    private IriGeneratorInterface $placeGetContributorsIriGenerator;
 
-    private IriGeneratorInterface $organizerContributorsUpdatedIriGenerator;
+    private IriGeneratorInterface $organizerGetContributorsIriGenerator;
 
 
     public function __construct(
-        IriGeneratorInterface $eventContributorsUpdatedIriGenerator,
-        IriGeneratorInterface $placeContributorsUpdatedIriGenerator,
-        IriGeneratorInterface $organizerContributorsUpdatedIriGenerator
+        IriGeneratorInterface $eventGetContributorsIriGenerator,
+        IriGeneratorInterface $placeGetContributorsIriGenerator,
+        IriGeneratorInterface $organizerGetContributorsIriGenerator
     ) {
-        $this->eventContributorsUpdatedIriGenerator = $eventContributorsUpdatedIriGenerator;
-        $this->placeContributorsUpdatedIriGenerator = $placeContributorsUpdatedIriGenerator;
-        $this->organizerContributorsUpdatedIriGenerator = $organizerContributorsUpdatedIriGenerator;
+        $this->eventGetContributorsIriGenerator = $eventGetContributorsIriGenerator;
+        $this->placeGetContributorsIriGenerator = $placeGetContributorsIriGenerator;
+        $this->organizerGetContributorsIriGenerator = $organizerGetContributorsIriGenerator;
     }
 
     public function createForItemType(string $id, ItemType $itemType): ContributorsUpdated
@@ -34,20 +34,20 @@ final class ContributorsUpdatedFactory
         if ($itemType->sameAs(ItemType::event())) {
             return new EventContributorsUpdated(
                 $id,
-                $this->eventContributorsUpdatedIriGenerator->iri($id)
+                $this->eventGetContributorsIriGenerator->iri($id)
             );
         }
 
         if ($itemType->sameAs(ItemType::place())) {
             return new PlaceContributorsUpdated(
                 $id,
-                $this->placeContributorsUpdatedIriGenerator->iri($id)
+                $this->placeGetContributorsIriGenerator->iri($id)
             );
         }
 
         return new OrganizerContributorsUpdated(
             $id,
-            $this->organizerContributorsUpdatedIriGenerator->iri($id)
+            $this->organizerGetContributorsIriGenerator->iri($id)
         );
     }
 }

--- a/src/Contributor/ContributorsUpdatedFactory.php
+++ b/src/Contributor/ContributorsUpdatedFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Contributor;
+
+use CultuurNet\UDB3\Event\EventContributorsUpdated;
+use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Organizer\OrganizerContributorsUpdated;
+use CultuurNet\UDB3\Place\PlaceContributorsUpdated;
+
+final class ContributorsUpdatedFactory
+{
+    private IriGeneratorInterface $eventContributorsUpdatedIriGenerator;
+
+    private IriGeneratorInterface $placeContributorsUpdatedIriGenerator;
+
+    private IriGeneratorInterface $organizerContributorsUpdatedIriGenerator;
+
+
+    public function __construct(
+        IriGeneratorInterface $eventContributorsUpdatedIriGenerator,
+        IriGeneratorInterface $placeContributorsUpdatedIriGenerator,
+        IriGeneratorInterface $organizerContributorsUpdatedIriGenerator
+    ) {
+        $this->eventContributorsUpdatedIriGenerator = $eventContributorsUpdatedIriGenerator;
+        $this->placeContributorsUpdatedIriGenerator = $placeContributorsUpdatedIriGenerator;
+        $this->organizerContributorsUpdatedIriGenerator = $organizerContributorsUpdatedIriGenerator;
+    }
+
+    public function createEventContributorsUpdated(string $id): EventContributorsUpdated
+    {
+        return new EventContributorsUpdated(
+            $id,
+            $this->eventContributorsUpdatedIriGenerator->iri($id)
+        );
+    }
+
+    public function createPlaceContributorsUpdated(string $id): PlaceContributorsUpdated
+    {
+        return new PlaceContributorsUpdated(
+            $id,
+            $this->placeContributorsUpdatedIriGenerator->iri($id)
+        );
+    }
+
+    public function createOrganizerContributorsUpdated(string $id): OrganizerContributorsUpdated
+    {
+        return new OrganizerContributorsUpdated(
+            $id,
+            $this->organizerContributorsUpdatedIriGenerator->iri($id)
+        );
+    }
+}

--- a/src/Event/EventContributorsUpdated.php
+++ b/src/Event/EventContributorsUpdated.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event;
+
+use CultuurNet\UDB3\Contributor\ContributorsUpdated;
+
+final class EventContributorsUpdated extends ContributorsUpdated
+{
+    public function __construct(string $id, string $iri)
+    {
+        parent::__construct($id, $iri);
+    }
+
+    public static function deserialize(array $data): EventContributorsUpdated
+    {
+        return new self($data['id'], $data['iri']);
+    }
+}

--- a/src/Event/EventContributorsUpdated.php
+++ b/src/Event/EventContributorsUpdated.php
@@ -8,11 +8,6 @@ use CultuurNet\UDB3\Contributor\ContributorsUpdated;
 
 final class EventContributorsUpdated extends ContributorsUpdated
 {
-    public function __construct(string $id, string $iri)
-    {
-        parent::__construct($id, $iri);
-    }
-
     public static function deserialize(array $data): EventContributorsUpdated
     {
         return new self($data['id'], $data['iri']);

--- a/src/Organizer/OrganizerContributorsUpdated.php
+++ b/src/Organizer/OrganizerContributorsUpdated.php
@@ -8,11 +8,6 @@ use CultuurNet\UDB3\Contributor\ContributorsUpdated;
 
 final class OrganizerContributorsUpdated extends ContributorsUpdated
 {
-    public function __construct(string $id, string $iri)
-    {
-        parent::__construct($id, $iri);
-    }
-
     public static function deserialize(array $data): OrganizerContributorsUpdated
     {
         return new self($data['id'], $data['iri']);

--- a/src/Organizer/OrganizerContributorsUpdated.php
+++ b/src/Organizer/OrganizerContributorsUpdated.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer;
+
+use CultuurNet\UDB3\Contributor\ContributorsUpdated;
+
+final class OrganizerContributorsUpdated extends ContributorsUpdated
+{
+    public function __construct(string $id, string $iri)
+    {
+        parent::__construct($id, $iri);
+    }
+
+    public static function deserialize(array $data): OrganizerContributorsUpdated
+    {
+        return new self($data['id'], $data['iri']);
+    }
+}

--- a/src/Place/PlaceContributorsUpdated.php
+++ b/src/Place/PlaceContributorsUpdated.php
@@ -8,11 +8,6 @@ use CultuurNet\UDB3\Contributor\ContributorsUpdated;
 
 final class PlaceContributorsUpdated extends ContributorsUpdated
 {
-    public function __construct(string $id, string $iri)
-    {
-        parent::__construct($id, $iri);
-    }
-
     public static function deserialize(array $data): PlaceContributorsUpdated
     {
         return new self($data['id'], $data['iri']);

--- a/src/Place/PlaceContributorsUpdated.php
+++ b/src/Place/PlaceContributorsUpdated.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Place;
+
+use CultuurNet\UDB3\Contributor\ContributorsUpdated;
+
+final class PlaceContributorsUpdated extends ContributorsUpdated
+{
+    public function __construct(string $id, string $iri)
+    {
+        parent::__construct($id, $iri);
+    }
+
+    public static function deserialize(array $data): PlaceContributorsUpdated
+    {
+        return new self($data['id'], $data['iri']);
+    }
+}

--- a/tests/Contributor/BroadcastingContributorRepositoryTest.php
+++ b/tests/Contributor/BroadcastingContributorRepositoryTest.php
@@ -60,7 +60,7 @@ final class BroadcastingContributorRepositoryTest extends TestCase
      * @test
      * @dataProvider contributorsUpdatedProvider
      */
-    public function test_todo(ItemType $itemType, ContributorsUpdated $contributorsUpdated): void
+    public function it_will_publish_when_contributors_are_updated(ItemType $itemType, ContributorsUpdated $contributorsUpdated): void
     {
         $validEmails = EmailAddresses::fromArray([new EmailAddress('foo@bar.com')]);
         $this->contributorRepository->updateContributors($this->itemId, $validEmails, $itemType);

--- a/tests/Contributor/BroadcastingContributorRepositoryTest.php
+++ b/tests/Contributor/BroadcastingContributorRepositoryTest.php
@@ -30,6 +30,8 @@ final class BroadcastingContributorRepositoryTest extends TestCase
 
     private UUID $itemId;
 
+    private EmailAddresses $emails;
+
     protected function setUp(): void
     {
         $this->itemId = new UUID('f28b47d1-4d06-4c46-94cc-d0ddbaad102f');
@@ -46,10 +48,12 @@ final class BroadcastingContributorRepositoryTest extends TestCase
                     fn ($cdbid) =>  'https://io.uitdatabank.dev/places/' . $cdbid . '/contributors'
                 ),
                 new CallableIriGenerator(
-                        fn ($cdbid) => 'https://io.uitdatabank.dev/organizers/' . $cdbid . '/contributors'
+                    fn ($cdbid) => 'https://io.uitdatabank.dev/organizers/' . $cdbid . '/contributors'
                 )
             )
         );
+
+        $this->emails = EmailAddresses::fromArray([new EmailAddress('foo@bar.com')]);
 
         $this->eventBus->trace();
     }
@@ -60,13 +64,11 @@ final class BroadcastingContributorRepositoryTest extends TestCase
      */
     public function it_will_publish_when_contributors_are_updated(ItemType $itemType, ContributorsUpdated $contributorsUpdated): void
     {
-        $validEmails = EmailAddresses::fromArray([new EmailAddress('foo@bar.com')]);
-
         $this->decoratee->expects($this->once())
             ->method('updateContributors')
-            ->with($this->itemId, $validEmails, $itemType);
+            ->with($this->itemId, $this->emails, $itemType);
 
-        $this->contributorRepository->updateContributors($this->itemId, $validEmails, $itemType);
+        $this->contributorRepository->updateContributors($this->itemId, $this->emails, $itemType);
 
         $expected = [$contributorsUpdated];
         $actual = $this->eventBus->getEvents();

--- a/tests/Contributor/BroadcastingContributorRepositoryTest.php
+++ b/tests/Contributor/BroadcastingContributorRepositoryTest.php
@@ -46,9 +46,7 @@ final class BroadcastingContributorRepositoryTest extends TestCase
                     fn ($cdbid) =>  'https://io.uitdatabank.dev/places/' . $cdbid . '/contributors'
                 ),
                 new CallableIriGenerator(
-                    fn () => new CallableIriGenerator(
                         fn ($cdbid) => 'https://io.uitdatabank.dev/organizers/' . $cdbid . '/contributors'
-                    )
                 )
             )
         );

--- a/tests/Contributor/BroadcastingContributorRepositoryTest.php
+++ b/tests/Contributor/BroadcastingContributorRepositoryTest.php
@@ -61,6 +61,11 @@ final class BroadcastingContributorRepositoryTest extends TestCase
     public function it_will_publish_when_contributors_are_updated(ItemType $itemType, ContributorsUpdated $contributorsUpdated): void
     {
         $validEmails = EmailAddresses::fromArray([new EmailAddress('foo@bar.com')]);
+
+        $this->decoratee->expects($this->once())
+            ->method('updateContributors')
+            ->with($this->itemId, $validEmails, $itemType);
+
         $this->contributorRepository->updateContributors($this->itemId, $validEmails, $itemType);
 
         $expected = [$contributorsUpdated];

--- a/tests/Contributor/BroadcastingContributorRepositoryTest.php
+++ b/tests/Contributor/BroadcastingContributorRepositoryTest.php
@@ -30,6 +30,8 @@ final class BroadcastingContributorRepositoryTest extends TestCase
 
     private UUID $itemId;
 
+    private EmailAddress $email;
+
     private EmailAddresses $emails;
 
     protected function setUp(): void
@@ -53,7 +55,8 @@ final class BroadcastingContributorRepositoryTest extends TestCase
             )
         );
 
-        $this->emails = EmailAddresses::fromArray([new EmailAddress('foo@bar.com')]);
+        $this->email = new EmailAddress('foo@bar.com');
+        $this->emails = EmailAddresses::fromArray([$this->email]);
 
         $this->eventBus->trace();
     }
@@ -71,6 +74,19 @@ final class BroadcastingContributorRepositoryTest extends TestCase
         $result = $this->contributorRepository->getContributors($this->itemId);
 
         $this->assertEquals($this->emails, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_check_if_an_email_is_a_contributor(): void
+    {
+        $this->decoratee->expects($this->once())
+            ->method('isContributor')
+            ->with($this->itemId, $this->email)
+            ->willReturn(true);
+
+        $this->assertTrue($this->contributorRepository->isContributor($this->itemId, $this->email));
     }
 
     /**

--- a/tests/Contributor/BroadcastingContributorRepositoryTest.php
+++ b/tests/Contributor/BroadcastingContributorRepositoryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Contributor;
+
+use Broadway\EventHandling\EventBus;
+use CultuurNet\UDB3\Event\EventContributorsUpdated;
+use CultuurNet\UDB3\EventBus\TraceableEventBus;
+use CultuurNet\UDB3\Iri\CallableIriGenerator;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
+use CultuurNet\UDB3\Organizer\OrganizerContributorsUpdated;
+use CultuurNet\UDB3\Place\PlaceContributorsUpdated;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class BroadcastingContributorRepositoryTest extends TestCase
+{
+    /**
+     * @var ContributorRepository|MockObject
+     */
+    private $decoratee;
+
+    private TraceableEventBus $eventBus;
+
+    private BroadcastingContributorRepository $contributorRepository;
+
+    private UUID $itemId;
+
+    protected function setUp(): void
+    {
+        $this->itemId = new UUID('f28b47d1-4d06-4c46-94cc-d0ddbaad102f');
+        $this->decoratee = $this->createMock(ContributorRepository::class);
+        $this->eventBus = new TraceableEventBus($this->createMock(EventBus::class));
+        $this->contributorRepository = new BroadcastingContributorRepository(
+            $this->decoratee,
+            $this->eventBus,
+            new ContributorsUpdatedFactory(
+                new CallableIriGenerator(
+                    fn ($cdbid) => 'https://io.uitdatabank.dev/events/' . $cdbid . '/contributors'
+                ),
+                new CallableIriGenerator(
+                    fn ($cdbid) =>  'https://io.uitdatabank.dev/places/' . $cdbid . '/contributors'
+                ),
+                new CallableIriGenerator(
+                    fn () => new CallableIriGenerator(
+                        fn ($cdbid) => 'https://io.uitdatabank.dev/organizers/' . $cdbid . '/contributors'
+                    )
+                )
+            )
+        );
+
+        $this->eventBus->trace();
+    }
+
+    /**
+     * @test
+     * @dataProvider contributorsUpdatedProvider
+     */
+    public function test_todo(ItemType $itemType, ContributorsUpdated $contributorsUpdated): void
+    {
+        $validEmails = EmailAddresses::fromArray([new EmailAddress('foo@bar.com')]);
+        $this->contributorRepository->updateContributors($this->itemId, $validEmails, $itemType);
+
+        $expected = [$contributorsUpdated];
+        $actual = $this->eventBus->getEvents();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function contributorsUpdatedProvider(): array
+    {
+        return [
+            'event' => [
+                ItemType::event(),
+                new EventContributorsUpdated(
+                    'f28b47d1-4d06-4c46-94cc-d0ddbaad102f',
+                    'https://io.uitdatabank.dev/events/f28b47d1-4d06-4c46-94cc-d0ddbaad102f/contributors'
+                ),
+            ],
+            'place' => [
+                ItemType::place(),
+                new PlaceContributorsUpdated(
+                    'f28b47d1-4d06-4c46-94cc-d0ddbaad102f',
+                    'https://io.uitdatabank.dev/places/f28b47d1-4d06-4c46-94cc-d0ddbaad102f/contributors'
+                ),
+            ],
+            'organizer' => [
+                ItemType::organizer(),
+                new OrganizerContributorsUpdated(
+                    'f28b47d1-4d06-4c46-94cc-d0ddbaad102f',
+                    'https://io.uitdatabank.dev/organizers/f28b47d1-4d06-4c46-94cc-d0ddbaad102f/contributors'
+                ),
+            ],
+        ];
+    }
+}

--- a/tests/Contributor/BroadcastingContributorRepositoryTest.php
+++ b/tests/Contributor/BroadcastingContributorRepositoryTest.php
@@ -60,6 +60,21 @@ final class BroadcastingContributorRepositoryTest extends TestCase
 
     /**
      * @test
+     */
+    public function it_can_get_contributors(): void
+    {
+        $this->decoratee->expects($this->once())
+            ->method('getContributors')
+            ->with($this->itemId)
+            ->willReturn($this->emails);
+
+        $result = $this->contributorRepository->getContributors($this->itemId);
+
+        $this->assertEquals($this->emails, $result);
+    }
+
+    /**
+     * @test
      * @dataProvider contributorsUpdatedProvider
      */
     public function it_will_publish_when_contributors_are_updated(ItemType $itemType, ContributorsUpdated $contributorsUpdated): void


### PR DESCRIPTION
### Added

- `BroadcastingContributorRepository` as `Decorator` to publish messages
- Abstract `ContributorsUpdated` And childClasses `EventContributorsUpdated`, `PlaceContributorsUpdated` & `OrganizerContributorsUpdated` for Messages
- `ContributorsUpdatedFactory` to create message depending on `ItemType`

### Changed

- Use `BroadcastingContributorRepository` instead of `DbalContributorRepository` in `ServiceProvider`

---
Ticket: https://jira.uitdatabank.be/browse/III-5334
