### PR TITLE
III-5350 split up major info (Event)

### DIFF
--- a/src/Event/Events/MajorInfoUpdated.php
+++ b/src/Event/Events/MajorInfoUpdated.php
@@ -7,11 +7,12 @@ namespace CultuurNet\UDB3\Event\Events;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\Offer\Events\AbstractEvent;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 
-final class MajorInfoUpdated extends AbstractEvent
+final class MajorInfoUpdated extends AbstractEvent implements ConvertsToGranularEvents
 {
     /**
      * @var Title
@@ -78,6 +79,21 @@ final class MajorInfoUpdated extends AbstractEvent
     public function getLocation(): LocationId
     {
         return $this->location;
+    }
+
+    public function toGranularEvents(): array
+    {
+        return array_values(
+            array_filter(
+                [
+                    new TitleUpdated($this->itemId, $this->title),
+                    new TypeUpdated($this->itemId, $this->eventType),
+                    $this->theme ? new ThemeUpdated($this->itemId, $this->theme) : null,
+                    new LocationUpdated($this->itemId, $this->location),
+                    new CalendarUpdated($this->itemId, $this->calendar),
+                ]
+            )
+        );
     }
 
     public function serialize(): array

--- a/src/Event/Events/MajorInfoUpdated.php
+++ b/src/Event/Events/MajorInfoUpdated.php
@@ -14,30 +14,11 @@ use CultuurNet\UDB3\Title;
 
 final class MajorInfoUpdated extends AbstractEvent implements ConvertsToGranularEvents
 {
-    /**
-     * @var Title
-     */
-    private $title;
-
-    /**
-     * @var EventType
-     */
-    private $eventType;
-
-    /**
-     * @var Theme|null
-     */
-    private $theme;
-
-    /**
-     * @var LocationId
-     */
-    private $location;
-
-    /**
-     * @var Calendar
-     */
-    private $calendar;
+    private Title $title;
+    private EventType $eventType;
+    private ?Theme $theme;
+    private LocationId $location;
+    private Calendar $calendar;
 
     public function __construct(
         string $eventId,

--- a/src/EventSourcing/ConvertsToGranularEvents.php
+++ b/src/EventSourcing/ConvertsToGranularEvents.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\EventSourcing;
+
+/**
+ * An interface for (usually historical) "bloated" events that contain multiple unrelated changes at once, which
+ * require additional code in event listeners to handle on top of the more modern "granular" events.
+ * By converting the bloated event to granular events, event listeners do not need to implement additional support for
+ * the "bloated" events.
+ */
+interface ConvertsToGranularEvents
+{
+    /**
+     * @return array
+     *   An array of more granular events that can represent the same changes as recorded in the event that implements
+     *   this interface.
+     *   Useful in event listeners that already support the more granular events, so they do not need to add extra
+     *   logic for more coarse events.
+     */
+    public function toGranularEvents(): array;
+}

--- a/tests/Event/Events/MajorInfoUpdatedTest.php
+++ b/tests/Event/Events/MajorInfoUpdatedTest.php
@@ -6,7 +6,12 @@ namespace test\Event\Events;
 
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Event\Events\CalendarUpdated;
+use CultuurNet\UDB3\Event\Events\LocationUpdated;
 use CultuurNet\UDB3\Event\Events\MajorInfoUpdated;
+use CultuurNet\UDB3\Event\Events\ThemeUpdated;
+use CultuurNet\UDB3\Event\Events\TitleUpdated;
+use CultuurNet\UDB3\Event\Events\TypeUpdated;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Theme;
@@ -15,6 +20,49 @@ use PHPUnit\Framework\TestCase;
 
 class MajorInfoUpdatedTest extends TestCase
 {
+    /**
+     * @test
+     */
+    public function it_can_be_converted_to_modern_granular_events(): void
+    {
+        $eventId = '08efd45f-3319-4321-bde6-6fb30fc80d41';
+
+        $eventWithTheme = new MajorInfoUpdated(
+            $eventId,
+            new Title('title'),
+            new EventType('0.50.4.0.0', 'Concert'),
+            new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e'),
+            new Calendar(CalendarType::PERMANENT()),
+            new Theme('1.8.3.5.0', 'Amusementsmuziek')
+        );
+
+        $eventWithoutTheme = new MajorInfoUpdated(
+            $eventId,
+            new Title('title'),
+            new EventType('0.50.4.0.0', 'Concert'),
+            new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e'),
+            new Calendar(CalendarType::PERMANENT())
+        );
+
+        $expectedWithTheme = [
+            new TitleUpdated($eventId, new Title('title')),
+            new TypeUpdated($eventId, new EventType('0.50.4.0.0', 'Concert')),
+            new ThemeUpdated($eventId, new Theme('1.8.3.5.0', 'Amusementsmuziek')),
+            new LocationUpdated($eventId, new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e')),
+            new CalendarUpdated($eventId, new Calendar(CalendarType::PERMANENT())),
+        ];
+
+        $expectedWithoutTheme = [
+            new TitleUpdated($eventId, new Title('title')),
+            new TypeUpdated($eventId, new EventType('0.50.4.0.0', 'Concert')),
+            new LocationUpdated($eventId, new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e')),
+            new CalendarUpdated($eventId, new Calendar(CalendarType::PERMANENT())),
+        ];
+
+        $this->assertEquals($expectedWithTheme, $eventWithTheme->toGranularEvents());
+        $this->assertEquals($expectedWithoutTheme, $eventWithoutTheme->toGranularEvents());
+    }
+
     /**
      * @test
      * @dataProvider serializationDataProvider

--- a/tests/Event/Events/MajorInfoUpdatedTest.php
+++ b/tests/Event/Events/MajorInfoUpdatedTest.php
@@ -2,16 +2,10 @@
 
 declare(strict_types=1);
 
-namespace test\Event\Events;
+namespace CultuurNet\UDB3\Event\Events;
 
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
-use CultuurNet\UDB3\Event\Events\CalendarUpdated;
-use CultuurNet\UDB3\Event\Events\LocationUpdated;
-use CultuurNet\UDB3\Event\Events\MajorInfoUpdated;
-use CultuurNet\UDB3\Event\Events\ThemeUpdated;
-use CultuurNet\UDB3\Event\Events\TitleUpdated;
-use CultuurNet\UDB3\Event\Events\TypeUpdated;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Theme;


### PR DESCRIPTION
### Added

- Added a way to split up `MajorInfoUpdated` events from `Event` namespace, in preparation of the RDF/OSLO projector in UDB3

---
Ticket: https://jira.uitdatabank.be/browse/III-5350
