### PR TITLE
Make Simon CODEOWNER so he can also approve PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS are automatically assigned as possible reviewers to new PRs.
 
 # Global owners (also need to be duplicated in later rules)
-* @bertramakers @LucWollants @JonasVHG @steftrenson
+* @bertramakers @LucWollants @JonasVHG @steftrenson @simon-debruijn
 
 # Jenkins / deployment owners
 Gemfile* @willaerk @paulherbosch


### PR DESCRIPTION
### Added

- Added @simon-debruijn to the `CODEOWNERS` file so his approvals are actually valid to merge a PR

---

Simon will mostly review OSLO-related PRs at first

