### PR TITLE
III-5364 Split up EventCreated

### DIFF
--- a/src/Event/Events/EventCreated.php
+++ b/src/Event/Events/EventCreated.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event\Events;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\Event\EventEvent;
 use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Theme;
@@ -14,7 +15,7 @@ use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
 
-final class EventCreated extends EventEvent
+final class EventCreated extends EventEvent implements ConvertsToGranularEvents
 {
     /**
      * @var Language
@@ -105,6 +106,21 @@ final class EventCreated extends EventEvent
     public function getPublicationDate(): ?DateTimeImmutable
     {
         return $this->publicationDate;
+    }
+
+    public function toGranularEvents(): array
+    {
+        return array_values(
+            array_filter(
+                [
+                    new TitleUpdated($this->eventId, $this->title),
+                    new TypeUpdated($this->eventId, $this->eventType),
+                    $this->theme ? new ThemeUpdated($this->eventId, $this->theme) : null,
+                    new LocationUpdated($this->eventId, $this->location),
+                    new CalendarUpdated($this->eventId, $this->calendar),
+                ]
+            )
+        );
     }
 
     public function serialize(): array

--- a/src/Event/Events/EventCreated.php
+++ b/src/Event/Events/EventCreated.php
@@ -17,40 +17,13 @@ use DateTimeInterface;
 
 final class EventCreated extends EventEvent implements ConvertsToGranularEvents
 {
-    /**
-     * @var Language
-     */
-    private $mainLanguage;
-
-    /**
-     * @var Title
-     */
-    private $title;
-
-    /**
-     * @var EventType
-     */
-    private $eventType;
-
-    /**
-     * @var Theme|null
-     */
-    private $theme;
-
-    /**
-     * @var LocationId
-     */
-    private $location;
-
-    /**
-     * @var Calendar
-     */
-    private $calendar;
-
-    /**
-     * @var DateTimeImmutable|null
-     */
-    private $publicationDate;
+    private Language $mainLanguage;
+    private Title $title;
+    private EventType $eventType;
+    private ?Theme $theme;
+    private LocationId $location;
+    private Calendar $calendar;
+    private ?DateTimeImmutable $publicationDate;
 
     public function __construct(
         string $eventId,

--- a/src/EventSourcing/ConvertsToGranularEvents.php
+++ b/src/EventSourcing/ConvertsToGranularEvents.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\EventSourcing;
+
+/**
+ * An interface for (usually historical) "bloated" events that contain multiple unrelated changes at once, which
+ * require additional code in event listeners to handle on top of the more modern "granular" events.
+ * By converting the bloated event to granular events, event listeners do not need to implement additional support for
+ * the "bloated" events.
+ */
+interface ConvertsToGranularEvents
+{
+    /**
+     * @return array
+     *   An array of more granular events that can represent the same changes as recorded in the event that implements
+     *   this interface.
+     *   Useful in event listeners that already support the more granular events, so they do not need to add extra
+     *   logic for more coarse events.
+     */
+    public function toGranularEvents(): array;
+}

--- a/tests/Event/Events/EventCreatedTest.php
+++ b/tests/Event/Events/EventCreatedTest.php
@@ -2,16 +2,10 @@
 
 declare(strict_types=1);
 
-namespace test\Event\Events;
+namespace CultuurNet\UDB3\Event\Events;
 
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
-use CultuurNet\UDB3\Event\Events\CalendarUpdated;
-use CultuurNet\UDB3\Event\Events\EventCreated;
-use CultuurNet\UDB3\Event\Events\LocationUpdated;
-use CultuurNet\UDB3\Event\Events\ThemeUpdated;
-use CultuurNet\UDB3\Event\Events\TitleUpdated;
-use CultuurNet\UDB3\Event\Events\TypeUpdated;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;

--- a/tests/Event/Events/EventCreatedTest.php
+++ b/tests/Event/Events/EventCreatedTest.php
@@ -6,7 +6,12 @@ namespace test\Event\Events;
 
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Event\Events\CalendarUpdated;
 use CultuurNet\UDB3\Event\Events\EventCreated;
+use CultuurNet\UDB3\Event\Events\LocationUpdated;
+use CultuurNet\UDB3\Event\Events\ThemeUpdated;
+use CultuurNet\UDB3\Event\Events\TitleUpdated;
+use CultuurNet\UDB3\Event\Events\TypeUpdated;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
@@ -52,6 +57,51 @@ class EventCreatedTest extends TestCase
             new Theme('id', 'label'),
             $this->publicationDate
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_to_granular_events(): void
+    {
+        $eventId = '09994540-289f-4ab4-bf77-b83443d3d0fc';
+
+        $eventWithTheme = new EventCreated(
+            $eventId,
+            new Language('nl'),
+            new Title('Example title'),
+            new EventType('0.50.4.0.0', 'Concert'),
+            $this->location,
+            new Calendar(CalendarType::PERMANENT()),
+            new Theme('1.8.3.5.0', 'Amusementsmuziek')
+        );
+
+        $eventWithoutTheme = new EventCreated(
+            $eventId,
+            new Language('nl'),
+            new Title('Example title'),
+            new EventType('0.50.4.0.0', 'Concert'),
+            $this->location,
+            new Calendar(CalendarType::PERMANENT())
+        );
+
+        $expectedWithTheme = [
+            new TitleUpdated($eventId, new Title('Example title')),
+            new TypeUpdated($eventId, new EventType('0.50.4.0.0', 'Concert')),
+            new ThemeUpdated($eventId, new Theme('1.8.3.5.0', 'Amusementsmuziek')),
+            new LocationUpdated($eventId, $this->location),
+            new CalendarUpdated($eventId, new Calendar(CalendarType::PERMANENT())),
+        ];
+
+        $expectedWithoutTheme = [
+            new TitleUpdated($eventId, new Title('Example title')),
+            new TypeUpdated($eventId, new EventType('0.50.4.0.0', 'Concert')),
+            new LocationUpdated($eventId, $this->location),
+            new CalendarUpdated($eventId, new Calendar(CalendarType::PERMANENT())),
+        ];
+
+        $this->assertEquals($expectedWithTheme, $eventWithTheme->toGranularEvents());
+        $this->assertEquals($expectedWithoutTheme, $eventWithoutTheme->toGranularEvents());
     }
 
     /**


### PR DESCRIPTION
### Added

- Added a method to convert `EventCreated` into smaller events, in preparation for the RDF/OSLO projector

---
Ticket: https://jira.uitdatabank.be/browse/III-5364
