### PR TITLE
III-5365 Split up PlaceCreated in smaller events

### DIFF
--- a/src/Place/Events/PlaceCreated.php
+++ b/src/Place/Events/PlaceCreated.php
@@ -7,13 +7,14 @@ namespace CultuurNet\UDB3\Place\Events;
 use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Place\PlaceEvent;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
 
-final class PlaceCreated extends PlaceEvent
+final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents
 {
     /**
      * @var Language
@@ -95,6 +96,16 @@ final class PlaceCreated extends PlaceEvent
     public function getPublicationDate(): ?DateTimeImmutable
     {
         return $this->publicationDate;
+    }
+
+    public function toGranularEvents(): array
+    {
+        return [
+            new TitleUpdated($this->placeId, $this->title),
+            new TypeUpdated($this->placeId, $this->eventType),
+            new AddressUpdated($this->placeId, $this->address),
+            new CalendarUpdated($this->placeId, $this->calendar),
+        ];
     }
 
     public function serialize(): array

--- a/src/Place/Events/PlaceCreated.php
+++ b/src/Place/Events/PlaceCreated.php
@@ -16,41 +16,15 @@ use DateTimeInterface;
 
 final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents
 {
-    /**
-     * @var Language
-     */
-    private $mainLanguage;
+    private Language $mainLanguage;
+    private Title $title;
+    private EventType $eventType;
+    private Address $address;
+    private Calendar $calendar;
+    private ?DateTimeImmutable $publicationDate;
 
-    /**
-     * @var Title
-     */
-    private $title;
-
-    /**
-     * @var EventType
-     */
-    private $eventType;
-
-    /**
-     * @var Address
-     */
-    private $address;
-
-    /**
-     * @var Calendar
-     */
-    private $calendar;
-
-    /**
-     * @var DateTimeImmutable|null
-     */
-    private $publicationDate;
-
-    /**
-     * @param string $placeId
-     */
     public function __construct(
-        $placeId,
+        string $placeId,
         Language $mainLanguage,
         Title $title,
         EventType $eventType,

--- a/tests/Place/Events/PlaceCreatedTest.php
+++ b/tests/Place/Events/PlaceCreatedTest.php
@@ -64,6 +64,21 @@ class PlaceCreatedTest extends TestCase
     /**
      * @test
      */
+    public function it_converts_to_granular_events(): void
+    {
+        $expected = [
+            new TitleUpdated('id', new Title('title')),
+            new TypeUpdated('id', new EventType('id', 'label')),
+            new AddressUpdated('id', $this->address),
+            new CalendarUpdated('id', new Calendar(CalendarType::PERMANENT())),
+        ];
+        $actual = $this->placeCreated->toGranularEvents();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function it_stores_a_place_id()
     {
         $this->assertEquals('id', $this->placeCreated->getPlaceId());

--- a/tests/Place/Events/PlaceCreatedTest.php
+++ b/tests/Place/Events/PlaceCreatedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace test\Place\Events;
+namespace CultuurNet\UDB3\Place\Events;
 
 use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Address\Locality;
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
-use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -21,20 +20,9 @@ use PHPUnit\Framework\TestCase;
 
 class PlaceCreatedTest extends TestCase
 {
-    /**
-     * @var Address
-     */
-    private $address;
-
-    /**
-     * @var DateTimeImmutable
-     */
-    private $publicationDate;
-
-    /**
-     * @var PlaceCreated
-     */
-    private $placeCreated;
+    private Address $address;
+    private DateTimeImmutable $publicationDate;
+    private PlaceCreated $placeCreated;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
### Changed

- Implemented `ConvertsToGranularEvents` on `PlaceCreated` in preparation for the new RDF/OSLO projector

---
Ticket: https://jira.uitdatabank.be/browse/III-5365
