### PR TITLE
III-5334 dont save dynamic field `production` in `JsonDocument`

### DIFF
--- a/src/Event/Productions/ProductionEnrichedEventRepository.php
+++ b/src/Event/Productions/ProductionEnrichedEventRepository.php
@@ -10,17 +10,11 @@ use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 
-class ProductionEnrichedEventRepository extends DocumentRepositoryDecorator
+final class ProductionEnrichedEventRepository extends DocumentRepositoryDecorator
 {
-    /**
-     * @var ProductionRepository
-     */
-    private $productionRepository;
+    private ProductionRepository $productionRepository;
 
-    /**
-     * @var IriGeneratorInterface
-     */
-    private $iriGenerator;
+    private IriGeneratorInterface $iriGenerator;
 
     public function __construct(
         DocumentRepository $repository,

--- a/src/Event/Productions/ProductionEnrichedEventRepository.php
+++ b/src/Event/Productions/ProductionEnrichedEventRepository.php
@@ -39,6 +39,18 @@ class ProductionEnrichedEventRepository extends DocumentRepositoryDecorator
         );
     }
 
+    public function save(JsonDocument $readModel): void
+    {
+        parent::save(
+            $readModel->applyAssoc(
+                function (array $json) {
+                    unset($json['production']);
+                    return $json;
+                }
+            )
+        );
+    }
+
     private function enrich(JsonDocument $document): JsonDocument
     {
         $jsonObject = $document->getBody();

--- a/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
+++ b/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
@@ -12,12 +12,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class ProductionEnrichedEventRepositoryTest extends TestCase
+final class ProductionEnrichedEventRepositoryTest extends TestCase
 {
-    /**
-     * @var ProductionEnrichedEventRepository
-     */
-    private $productionEnrichedEventRepository;
+    private ProductionEnrichedEventRepository $productionEnrichedEventRepository;
 
     /**
      * @var ProductionRepository | MockObject


### PR DESCRIPTION
### Changed

- Don't save dynamic field `production` in `JsonDocument`

---
Ticket: https://jira.uitdatabank.be/browse/III-5334
