### PR TITLE
III-5389 Add MainLanguageDefined interface

### DIFF
--- a/src/Event/Events/EventCreated.php
+++ b/src/Event/Events/EventCreated.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\Event\EventEvent;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
+use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Theme;
@@ -15,7 +16,7 @@ use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
 
-final class EventCreated extends EventEvent implements ConvertsToGranularEvents
+final class EventCreated extends EventEvent implements ConvertsToGranularEvents, MainLanguageDefined
 {
     private Language $mainLanguage;
     private Title $title;

--- a/src/Event/Events/EventImportedFromUDB2.php
+++ b/src/Event/Events/EventImportedFromUDB2.php
@@ -6,9 +6,11 @@ namespace CultuurNet\UDB3\Event\Events;
 
 use CultureFeed_Cdb_Xml;
 use CultuurNet\UDB3\Event\EventEvent;
+use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\HasCdbXmlTrait;
+use CultuurNet\UDB3\Language;
 
-class EventImportedFromUDB2 extends EventEvent implements EventCdbXMLInterface
+class EventImportedFromUDB2 extends EventEvent implements EventCdbXMLInterface, MainLanguageDefined
 {
     use HasCdbXmlTrait;
 
@@ -17,6 +19,12 @@ class EventImportedFromUDB2 extends EventEvent implements EventCdbXMLInterface
         parent::__construct($eventId);
         $this->setCdbXml($cdbXml);
         $this->setCdbXmlNamespaceUri($cdbXmlNamespaceUri);
+    }
+
+    public function getMainLanguage(): Language
+    {
+        // Events imported from UDB2 always have the main language NL.
+        return new Language('nl');
     }
 
     public function serialize(): array

--- a/src/EventSourcing/MainLanguageDefined.php
+++ b/src/EventSourcing/MainLanguageDefined.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\EventSourcing;
+
+use CultuurNet\UDB3\Language;
+
+interface MainLanguageDefined
+{
+    public function getMainLanguage(): Language;
+}

--- a/src/Place/Events/PlaceCreated.php
+++ b/src/Place/Events/PlaceCreated.php
@@ -8,13 +8,14 @@ use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
+use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Place\PlaceEvent;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
 
-final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents
+final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents, MainLanguageDefined
 {
     private Language $mainLanguage;
     private Title $title;

--- a/src/Place/Events/PlaceImportedFromUDB2.php
+++ b/src/Place/Events/PlaceImportedFromUDB2.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Place\Events;
 
 use CultuurNet\UDB3\Actor\ActorImportedFromUDB2;
+use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
+use CultuurNet\UDB3\Language;
 
-final class PlaceImportedFromUDB2 extends ActorImportedFromUDB2
+final class PlaceImportedFromUDB2 extends ActorImportedFromUDB2 implements MainLanguageDefined
 {
+    public function getMainLanguage(): Language
+    {
+        // Places imported from UDB2 always have main language NL.
+        return new Language('nl');
+    }
 }

--- a/tests/Event/Events/EventCreatedTest.php
+++ b/tests/Event/Events/EventCreatedTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event\Events;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
@@ -95,6 +96,8 @@ class EventCreatedTest extends TestCase
             new CalendarUpdated($eventId, new Calendar(CalendarType::PERMANENT())),
         ];
 
+        $this->assertInstanceOf(ConvertsToGranularEvents::class, $eventWithTheme);
+        $this->assertInstanceOf(ConvertsToGranularEvents::class, $eventWithoutTheme);
         $this->assertEquals($expectedWithTheme, $eventWithTheme->toGranularEvents());
         $this->assertEquals($expectedWithoutTheme, $eventWithoutTheme->toGranularEvents());
     }

--- a/tests/Event/Events/EventCreatedTest.php
+++ b/tests/Event/Events/EventCreatedTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event\Events;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Theme;
@@ -96,6 +97,25 @@ class EventCreatedTest extends TestCase
 
         $this->assertEquals($expectedWithTheme, $eventWithTheme->toGranularEvents());
         $this->assertEquals($expectedWithoutTheme, $eventWithoutTheme->toGranularEvents());
+    }
+
+    /**
+     * @test
+     */
+    public function it_implements_main_language_defined(): void
+    {
+        $event = new EventCreated(
+            '09994540-289f-4ab4-bf77-b83443d3d0fc',
+            new Language('fr'),
+            new Title('Example title'),
+            new EventType('0.50.4.0.0', 'Concert'),
+            $this->location,
+            new Calendar(CalendarType::PERMANENT()),
+            new Theme('1.8.3.5.0', 'Amusementsmuziek')
+        );
+
+        $this->assertInstanceOf(MainLanguageDefined::class, $event);
+        $this->assertEquals(new Language('fr'), $event->getMainLanguage());
     }
 
     /**

--- a/tests/Event/Events/EventImportedFromUDB2Test.php
+++ b/tests/Event/Events/EventImportedFromUDB2Test.php
@@ -5,12 +5,29 @@ declare(strict_types=1);
 namespace test\Event\Events;
 
 use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;
+use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
+use CultuurNet\UDB3\Language;
 use PHPUnit\Framework\TestCase;
 
 class EventImportedFromUDB2Test extends TestCase
 {
     public const NS_CDBXML_3_2 = 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL';
     public const NS_CDBXML_3_3 = 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL';
+
+    /**
+     * @test
+     */
+    public function it_implements_main_language_defined()
+    {
+        $event = new EventImportedFromUDB2(
+            'test 456',
+            file_get_contents(__DIR__ . '/../samples/event_entryapi_valid_with_keywords.xml'),
+            self::NS_CDBXML_3_3
+        );
+
+        $this->assertInstanceOf(MainLanguageDefined::class, $event);
+        $this->assertEquals(new Language('nl'), $event->getMainLanguage());
+    }
 
     /**
      * @test

--- a/tests/Place/Events/PlaceCreatedTest.php
+++ b/tests/Place/Events/PlaceCreatedTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
@@ -62,6 +63,8 @@ class PlaceCreatedTest extends TestCase
             new CalendarUpdated('id', new Calendar(CalendarType::PERMANENT())),
         ];
         $actual = $this->placeCreated->toGranularEvents();
+
+        $this->assertInstanceOf(ConvertsToGranularEvents::class, $this->placeCreated);
         $this->assertEquals($expected, $actual);
     }
 

--- a/tests/Place/Events/PlaceCreatedTest.php
+++ b/tests/Place/Events/PlaceCreatedTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Title;
@@ -62,6 +63,15 @@ class PlaceCreatedTest extends TestCase
         ];
         $actual = $this->placeCreated->toGranularEvents();
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function it_implements_main_language_defined(): void
+    {
+        $this->assertInstanceOf(MainLanguageDefined::class, $this->placeCreated);
+        $this->assertEquals(new Language('es'), $this->placeCreated->getMainLanguage());
     }
 
     /**

--- a/tests/Place/Events/PlaceImportedFromUDB2Test.php
+++ b/tests/Place/Events/PlaceImportedFromUDB2Test.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Place\Events;
+
+use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
+use CultuurNet\UDB3\Language;
+use PHPUnit\Framework\TestCase;
+
+final class PlaceImportedFromUDB2Test extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_implements_main_language_defined(): void
+    {
+        $event = new PlaceImportedFromUDB2(
+            '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3',
+            file_get_contents(__DIR__ . '/../actor.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertInstanceOf(MainLanguageDefined::class, $event);
+        $this->assertEquals(new Language('nl'), $event->getMainLanguage());
+    }
+}


### PR DESCRIPTION
### Added

- Added `MainLanguageDefined` interface, implemented on events that create new events|places. This was initially added in #1278 but I split it off to keep the PRs focused on a small scope.

---
Ticket: https://jira.uitdatabank.be/browse/III-5389
