### PR TITLE
III-5392 Project common place properties

### DIFF
--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -33,6 +33,8 @@ final class RdfProjector implements EventListener
     private const PROPERTY_LOCATIE_NAAM = 'locn:geographicName';
 
     private const PROPERTY_IDENTIFICATOR_NOTATION = 'skos:notation';
+    private const PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR = 'dcterms:creator';
+    private const PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT = 'https://fixme.com/example/dataprovider/publiq';
 
     public function __construct(
         MainLanguageRepository $mainLanguageRepository,
@@ -88,6 +90,7 @@ final class RdfProjector implements EventListener
             $identificator = $graph->newBNode();
             $identificator->setType(self::TYPE_IDENTIFICATOR);
             $identificator->add(self::PROPERTY_IDENTIFICATOR_NOTATION, $uri);
+            $identificator->add(self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR, self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT);
             $resource->add(self::PROPERTY_LOCATIE_IDENTIFICATOR, $identificator);
         }
 

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -24,6 +24,7 @@ final class RdfProjector implements EventListener
     private GraphRepository $graphRepository;
     private IriGeneratorInterface $iriGenerator;
 
+    private const TYPE_LOCATIE = 'dcterms:Location';
     private const PROPERTY_LOCATIE_NAAM = 'locn:geographicName';
 
     public function __construct(
@@ -44,6 +45,7 @@ final class RdfProjector implements EventListener
 
         $uri = $this->iriGenerator->iri($domainMessage->getId());
         $graph = $this->graphRepository->get($uri);
+        $graph = $this->setGeneralProperties($graph, $uri);
 
         $eventClassToHandler = [
             MainLanguageDefined::class => fn ($e) => $this->handleMainLanguageDefined($e, $uri),
@@ -58,6 +60,12 @@ final class RdfProjector implements EventListener
                 }
             }
         }
+    }
+
+    private function setGeneralProperties(Graph $graph, string $uri): Graph
+    {
+        $graph->setType($uri, self::TYPE_LOCATIE);
+        return $graph;
     }
 
     private function handleMainLanguageDefined(MainLanguageDefined $event, string $uri): void

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -35,6 +35,7 @@ final class RdfProjector implements EventListener
     private const PROPERTY_IDENTIFICATOR_NOTATION = 'skos:notation';
     private const PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR = 'dcterms:creator';
     private const PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT = 'https://fixme.com/example/dataprovider/publiq';
+    private const PROPERTY_IDENTIFICATOR_NAAMRUIMTE = 'generiek:naamruimte';
 
     public function __construct(
         MainLanguageRepository $mainLanguageRepository,
@@ -91,6 +92,7 @@ final class RdfProjector implements EventListener
             $identificator->setType(self::TYPE_IDENTIFICATOR);
             $identificator->add(self::PROPERTY_IDENTIFICATOR_NOTATION, $uri);
             $identificator->add(self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR, self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT);
+            $identificator->add(self::PROPERTY_IDENTIFICATOR_NAAMRUIMTE, new Literal($this->iriGenerator->iri(''), null, 'xsd:string'));
             $resource->add(self::PROPERTY_LOCATIE_IDENTIFICATOR, $identificator);
         }
 

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -36,6 +36,7 @@ final class RdfProjector implements EventListener
     private const PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR = 'dcterms:creator';
     private const PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT = 'https://fixme.com/example/dataprovider/publiq';
     private const PROPERTY_IDENTIFICATOR_NAAMRUIMTE = 'generiek:naamruimte';
+    private const PROPERTY_IDENTIFICATOR_LOKALE_IDENTIFICATOR = 'generiek:lokaleIdentificator';
 
     public function __construct(
         MainLanguageRepository $mainLanguageRepository,
@@ -93,6 +94,7 @@ final class RdfProjector implements EventListener
             $identificator->add(self::PROPERTY_IDENTIFICATOR_NOTATION, $uri);
             $identificator->add(self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR, self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT);
             $identificator->add(self::PROPERTY_IDENTIFICATOR_NAAMRUIMTE, new Literal($this->iriGenerator->iri(''), null, 'xsd:string'));
+            $identificator->add(self::PROPERTY_IDENTIFICATOR_LOKALE_IDENTIFICATOR, new Literal($domainMessage->getId(), null, 'xsd:string'));
             $resource->add(self::PROPERTY_LOCATIE_IDENTIFICATOR, $identificator);
         }
 

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -37,6 +37,7 @@ final class RdfProjector implements EventListener
     private const PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT = 'https://fixme.com/example/dataprovider/publiq';
     private const PROPERTY_IDENTIFICATOR_NAAMRUIMTE = 'generiek:naamruimte';
     private const PROPERTY_IDENTIFICATOR_LOKALE_IDENTIFICATOR = 'generiek:lokaleIdentificator';
+    private const PROPERTY_IDENTIFICATOR_VERSIE_ID = 'generiek:versieIdentificator';
 
     public function __construct(
         MainLanguageRepository $mainLanguageRepository,
@@ -97,6 +98,9 @@ final class RdfProjector implements EventListener
             $identificator->add(self::PROPERTY_IDENTIFICATOR_LOKALE_IDENTIFICATOR, new Literal($domainMessage->getId(), null, 'xsd:string'));
             $resource->add(self::PROPERTY_LOCATIE_IDENTIFICATOR, $identificator);
         }
+
+        $identificator = $resource->getResource(self::PROPERTY_LOCATIE_IDENTIFICATOR);
+        $identificator->set(self::PROPERTY_IDENTIFICATOR_VERSIE_ID, $recordedOnLiteral);
 
         return $graph;
     }

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -25,9 +25,14 @@ final class RdfProjector implements EventListener
     private IriGeneratorInterface $iriGenerator;
 
     private const TYPE_LOCATIE = 'dcterms:Location';
+    private const TYPE_IDENTIFICATOR = 'adms:Identifier';
+
     private const PROPERTY_LOCATIE_AANGEMAAKT_OP = 'dcterms:created';
     private const PROPERTY_LOCATIE_LAATST_AANGEPAST = 'dcterms:modified';
+    private const PROPERTY_LOCATIE_IDENTIFICATOR = 'adms:identifier';
     private const PROPERTY_LOCATIE_NAAM = 'locn:geographicName';
+
+    private const PROPERTY_IDENTIFICATOR_NOTATION = 'skos:notation';
 
     public function __construct(
         MainLanguageRepository $mainLanguageRepository,
@@ -78,6 +83,13 @@ final class RdfProjector implements EventListener
             $resource->set(self::PROPERTY_LOCATIE_AANGEMAAKT_OP, $recordedOnLiteral);
         }
         $resource->set(self::PROPERTY_LOCATIE_LAATST_AANGEPAST, $recordedOnLiteral);
+
+        if (!$resource->hasProperty(self::PROPERTY_LOCATIE_IDENTIFICATOR)) {
+            $identificator = $graph->newBNode();
+            $identificator->setType(self::TYPE_IDENTIFICATOR);
+            $identificator->add(self::PROPERTY_IDENTIFICATOR_NOTATION, $uri);
+            $resource->add(self::PROPERTY_LOCATIE_IDENTIFICATOR, $identificator);
+        }
 
         return $graph;
     }

--- a/src/RDF/RdfNamespaces.php
+++ b/src/RDF/RdfNamespaces.php
@@ -10,6 +10,10 @@ final class RdfNamespaces
 {
     public static function register(): void
     {
+        // Delete the initial 'dc' prefix for dcterms, so the other initial 'dcterms' namespace is used instead.
+        RdfNamespace::delete('dc');
+
+        // Set custom namespaces.
         RdfNamespace::set('locn', 'http://www.w3.org/ns/locn#');
     }
 }

--- a/src/RDF/RdfNamespaces.php
+++ b/src/RDF/RdfNamespaces.php
@@ -14,6 +14,7 @@ final class RdfNamespaces
         RdfNamespace::delete('dc');
 
         // Set custom namespaces.
+        RdfNamespace::set('adms', 'http://www.w3.org/ns/adms#');
         RdfNamespace::set('locn', 'http://www.w3.org/ns/locn#');
     }
 }

--- a/src/RDF/RdfNamespaces.php
+++ b/src/RDF/RdfNamespaces.php
@@ -16,5 +16,6 @@ final class RdfNamespaces
         // Set custom namespaces.
         RdfNamespace::set('adms', 'http://www.w3.org/ns/adms#');
         RdfNamespace::set('locn', 'http://www.w3.org/ns/locn#');
+        RdfNamespace::set('generiek', 'https://data.vlaanderen.be/ns/generiek/#');
     }
 }

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -126,6 +126,6 @@ class RdfProjectorTest extends TestCase
     {
         $uri = 'https://mock.data.publiq.be/locaties/' . $placeId;
         $actualTurtleData = (new Turtle())->serialise($this->graphRepository->get($uri), 'turtle');
-        $this->assertEquals($expectedTurtleData, $actualTurtleData);
+        $this->assertEquals(trim($expectedTurtleData), trim($actualTurtleData));
     }
 }

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Place\ReadModel\RDF;
 
+use Broadway\Domain\DateTime as BroadwayDateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Address\Address as LegacyAddress;
@@ -23,6 +24,7 @@ use CultuurNet\UDB3\RDF\GraphRepository;
 use CultuurNet\UDB3\RDF\InMemoryGraphRepository;
 use CultuurNet\UDB3\RDF\InMemoryMainLanguageRepository;
 use CultuurNet\UDB3\Title as LegacyTitle;
+use DateTime;
 use EasyRdf\Serialiser\Turtle;
 use PHPUnit\Framework\TestCase;
 
@@ -115,9 +117,17 @@ class RdfProjectorTest extends TestCase
     private function project(string $placeId, array $events): void
     {
         $playhead = -1;
+        $recordedOn = new DateTime('2022-12-31T12:30:15+01:00');
         foreach ($events as $event) {
             $playhead++;
-            $domainMessage = DomainMessage::recordNow($placeId, $playhead, new Metadata(), $event);
+            $recordedOn->modify('+1 day');
+            $domainMessage = new DomainMessage(
+                $placeId,
+                $playhead,
+                new Metadata(),
+                $event,
+                BroadwayDateTime::fromString($recordedOn->format(DateTime::ATOM))
+            );
             $this->rdfProjector->handle($domainMessage);
         }
     }

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -1,6 +1,9 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
+  dcterms:modified "2023-01-01T12:30:15"^^xsd:dateTime ;\n
   locn:geographicName "Voorbeeld titel"@nl .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -10,6 +10,7 @@
   dcterms:modified "2023-01-01T12:30:15"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea"
+    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    dcterms:creator "https://fixme.com/example/dataprovider/publiq"
   ] ;
   locn:geographicName "Voorbeeld titel"@nl .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -1,3 +1,6 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
-<https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea> locn:geographicName "Voorbeeld titel"@nl .
+<https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a dcterms:Location ;
+  locn:geographicName "Voorbeeld titel"@nl .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -14,6 +14,7 @@
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
+    generiek:versieIdentificator "2023-01-01T12:30:15"^^xsd:dateTime
   ] ;
   locn:geographicName "Voorbeeld titel"@nl .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -1,9 +1,15 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
   dcterms:modified "2023-01-01T12:30:15"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea"
+  ] ;
   locn:geographicName "Voorbeeld titel"@nl .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -5,5 +5,5 @@
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
-  dcterms:modified "2023-01-01T12:30:15"^^xsd:dateTime ;\n
+  dcterms:modified "2023-01-01T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -2,6 +2,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -11,6 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq"
+    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string
   ] ;
   locn:geographicName "Voorbeeld titel"@nl .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -13,6 +13,7 @@
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
-    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string
+    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string
   ] ;
   locn:geographicName "Voorbeeld titel"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -1,6 +1,9 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
+  dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;\n
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -1,3 +1,6 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
-<https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea> locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .
+<https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a dcterms:Location ;
+  locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -1,9 +1,15 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea"
+  ] ;
   dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -12,7 +12,8 @@
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
-    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string
+    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string
   ] ;
   dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -2,6 +2,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -10,7 +11,8 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq"
+    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string
   ] ;
   dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -5,5 +5,5 @@
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
-  dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;\n
+  dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -9,7 +9,8 @@
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea"
+    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    dcterms:creator "https://fixme.com/example/dataprovider/publiq"
   ] ;
   dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -13,7 +13,8 @@
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
+    generiek:versieIdentificator "2023-01-02T12:30:15"^^xsd:dateTime
   ] ;
   dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -13,7 +13,8 @@
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
+    generiek:versieIdentificator "2023-01-05T12:30:15"^^xsd:dateTime
   ] ;
   dcterms:modified "2023-01-05T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -2,6 +2,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -10,7 +11,8 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq"
+    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string
   ] ;
   dcterms:modified "2023-01-05T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -1,3 +1,6 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
-<https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea> locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .
+<https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a dcterms:Location ;
+  locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -9,7 +9,8 @@
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea"
+    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    dcterms:creator "https://fixme.com/example/dataprovider/publiq"
   ] ;
   dcterms:modified "2023-01-05T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -1,9 +1,15 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea"
+  ] ;
   dcterms:modified "2023-01-05T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -1,6 +1,9 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
+  dcterms:modified "2023-01-05T12:30:15"^^xsd:dateTime ;\n
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -12,7 +12,8 @@
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
-    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string
+    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string
   ] ;
   dcterms:modified "2023-01-05T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -5,5 +5,5 @@
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
-  dcterms:modified "2023-01-05T12:30:15"^^xsd:dateTime ;\n
+  dcterms:modified "2023-01-05T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -1,3 +1,6 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
-<https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea> locn:geographicName "Voorbeeld titel UPDATED"@nl .
+<https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a dcterms:Location ;
+  locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -2,6 +2,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -10,7 +11,8 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq"
+    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string
   ] ;
   dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -13,7 +13,8 @@
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
+    generiek:versieIdentificator "2023-01-02T12:30:15"^^xsd:dateTime
   ] ;
   dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -9,7 +9,8 @@
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea"
+    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    dcterms:creator "https://fixme.com/example/dataprovider/publiq"
   ] ;
   dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -1,9 +1,15 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea"
+  ] ;
   dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -5,5 +5,5 @@
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
   dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
-  dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;\n
+  dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -1,6 +1,9 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
+  dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;\n
   locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -12,7 +12,8 @@
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
-    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string
+    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string
   ] ;
   dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .


### PR DESCRIPTION
### Added

- Projection of `rdf:type` property
- Projection of `dcterms:created` property ("aangemaaktOp" in OSLO generiek)
- Projection of `dcterms:modified` property ("laatstAangepast" in OSLO generiek)
- Projection of `adms:identifier` resource with:
  - `skos:notation`
  - `dcterms:creator`
  - `generiek:naamruimte` (from OSLO generiek)
  - `generiek:lokaleIdentificator` (from OSLO generiek)
  - `generiek:versieIdentificator` (from OSLO generiek)

---
Ticket: https://jira.uitdatabank.be/browse/III-5392

Notes:

- The correct URI for the `dcterms:creator` property inside `adms:Identifier` is not decided yet, needs to be replaced later (hence the "fixme.com" URL so it's clear that this is not final)
- We will also need to add a "bron" attribute to the `adms:Identifier`, but the URI for that property is not clear yet + the URI for the value neither, so I've chosen not to include that yet. We can add a ticket for that later.
- We can extract the code for setting the common properties and identificator to a separate class when we also implement the RDF/OSLO projection for events / "activiteiten", but for now I've opted to keep it simple to avoid bad abstractions early on
