### PR TITLE
IIII-5214 Update udb3-json-schemas to allow empty array in contributors endPoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-uitdatabank/III-5214-delete-contributors",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/III-5214-delete-contributors",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd8d4a318e7bfd987fae39d54d2f5884",
+    "content-hash": "0b6161120587592f360017eb8e643a50",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5634,19 +5634,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/III-5214-delete-contributors",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "c84d51acbefec0cde9a7d99182cab96d60c6fff2"
+                "reference": "c36cf29cdbc4b37044f0c7161c910a1f3156af14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/c84d51acbefec0cde9a7d99182cab96d60c6fff2",
-                "reference": "c84d51acbefec0cde9a7d99182cab96d60c6fff2",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/c36cf29cdbc4b37044f0c7161c910a1f3156af14",
+                "reference": "c36cf29cdbc4b37044f0c7161c910a1f3156af14",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5661,9 +5660,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5214-delete-contributors"
             },
-            "time": "2023-02-08T10:57:28+00:00"
+            "time": "2023-03-06T08:55:23+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b6161120587592f360017eb8e643a50",
+    "content-hash": "bd8d4a318e7bfd987fae39d54d2f5884",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5634,7 +5634,7 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-uitdatabank/III-5214-delete-contributors",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
@@ -5646,6 +5646,7 @@
                 "reference": "c36cf29cdbc4b37044f0c7161c910a1f3156af14",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5660,7 +5661,7 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5214-delete-contributors"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
             "time": "2023-03-06T08:55:23+00:00"
         },


### PR DESCRIPTION
### Changed

- Update `udb3-json-schemas` to allow `[]` in `contributors` endpoint, needed to delete all `contributors`

---
Ticket: https://jira.uitdatabank.be/browse/IIII-5214
