### PR TITLE
III-5411 check JWT on public routes

### DIFF
--- a/src/Http/Auth/RequestAuthenticatorMiddleware.php
+++ b/src/Http/Auth/RequestAuthenticatorMiddleware.php
@@ -81,7 +81,7 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
      */
     public function authenticate(ServerRequestInterface $request): void
     {
-        if ($this->isCorsPreflightRequest($request)){
+        if ($this->isCorsPreflightRequest($request)) {
             return;
         }
         if ($this->isPublicRoute($request)) {

--- a/src/Http/Auth/RequestAuthenticatorMiddleware.php
+++ b/src/Http/Auth/RequestAuthenticatorMiddleware.php
@@ -81,17 +81,15 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
      */
     public function authenticate(ServerRequestInterface $request): void
     {
-        // For requests to public routes, that provide extra information to Authenticated
-        // Users. eg. show contributors
-        try {
-            $this->authenticateToken($request);
-        } catch (\Exception $exception) {
-            if ($this->isCorsPreflightRequest($request) || $this->isPublicRoute($request)) {
-                $this->token = null;
-                return;
-            }
-            throw $exception;
+        if ($this->isCorsPreflightRequest($request)){
+            return;
         }
+        if ($this->isPublicRoute($request)) {
+            $this->authenticateTokenForPublicRoutes($request);
+            return;
+        }
+
+        $this->authenticateToken($request);
 
         // Requests that use a token from the JWT provider (v1 or v2) require an API key from UiTID v1.
         // Requests that use a token that they got directly from Auth0 do not require an API key.

--- a/src/Http/Auth/RequestAuthenticatorMiddleware.php
+++ b/src/Http/Auth/RequestAuthenticatorMiddleware.php
@@ -149,6 +149,16 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
         $validator->validateClaims($this->token);
     }
 
+    private function authenticateTokenForPublicRoutes(ServerRequestInterface $request): void
+    {
+        try {
+            $this->authenticateToken($request);
+        } catch (\Exception $exception) {
+            $this->token = null;
+            return;
+        }
+    }
+
     private function authenticateApiKey(ServerRequestInterface $request): void
     {
         $apiKeyReader = new CompositeApiKeyReader(


### PR DESCRIPTION
### Added

- `authenticateTokenForPublicRoutes()` in `RequestAuthenticatorMiddleware`

### Changed

- Refactor `authenticate()` in `RequestAuthenticatorMiddleware` for public routes.

### Fixed

- public routes are again visible with invalid `apiKeys` or `tokens`

---
Ticket: https://jira.uitdatabank.be/browse/III-5411
