### PR TITLE
Use custom RabbitMQ image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,11 +47,9 @@ services:
       timeout: 5s
 
   rabbitmq:
-    image: rabbitmq:3.9-management
-    hostname: 'udb3-rabbitmq'
+    image: public.ecr.aws/y2o7k5u2/udb3/rabbitmq:latest
+    hostname: 'rabbitdocker'
     container_name: rabbitmq.uitdatabank
-    volumes:
-      - 'udb3-rabbitmq:/var/lib/rabbitmq'
     ports:
       - 5672:5672
       - 15672:15672
@@ -66,6 +64,4 @@ volumes:
   udb3-redis:
     driver: local
   udb3-mysql:
-    driver: local
-  udb3-rabbitmq:
     driver: local

--- a/docker.md
+++ b/docker.md
@@ -26,6 +26,8 @@ You'll need to change the following lines to work with docker hosts:
   - `mysql`
 - cache.redis.host
   - `redis`
+- amqp.host
+  - `rabbitmq`
 
 To make the SAPI3 proxy work you will need to add a `scheme` and `port` to the search config
 

--- a/docker.md
+++ b/docker.md
@@ -5,6 +5,9 @@
 
 ## Configure
 
+### Local host file
+To use `udb3-backend` & `udb3-search-service` together, you'll have to add `127.0.0.1 host.docker.internal` to your `/etc/hosts` file.
+
 ### .env file
 Copy `env.dist` to the root folder and rename it to `.env`
 
@@ -43,24 +46,7 @@ Copy `public.pem` and `public-auth0.pem` from https://github.com/cultuurnet/udb3
 
 ### RabbitMQ
 
-A RabbitMQ container is now available for Apple Silicon. For now al the default settings are used.
-
-You'll have to update your `config.php` file accordingly with the default values:
-```
-'amqp' => [
-    'host' => 'rabbitmq',
-    'port' => 5672,
-    'user' => 'guest',
-    'password' => 'guest',
-    'vhost' => '/',
-```
-
-Login to the management console on http://host.docker.internal:15672/ with username `guest` and password `guest` 
-
-Create an exchange `udb3.x.domain-events` in your RabbitMQ container. 
-
-### Local host file
-To use `udb3-backend` & `udb3-search-service` together, you'll have to add `127.0.0.1 host.docker.internal` to your `/etc/hosts` file.
+Login to the management console on http://host.docker.internal:15672/ with username `vagrant` and password `vagrant` 
 
 ### Acceptance tests
 


### PR DESCRIPTION
### Changed
- Used custom RabbitMQ image with preconfigured exchange and queues equal to Vagrant setup