### PR TITLE
III-5417 Fix datetime properties

### DIFF
--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -77,6 +77,7 @@ final class RdfProjector implements EventListener
 
     private function setGeneralProperties(Graph $graph, string $uri, DomainMessage $domainMessage): Graph
     {
+        $recordedOn = $domainMessage->getRecordedOn()->toNative();
         $resource = $graph->resource($uri);
 
         // Set the rdf:type property, but only if it is not set before to avoid needlessly shifting it to the end of the
@@ -86,18 +87,20 @@ final class RdfProjector implements EventListener
             $resource->setType(self::TYPE_LOCATIE);
         }
 
-        // Create a literal value for the recorded_on datetime (used in multiple properties)
-        $recordedOn = $domainMessage->getRecordedOn()->toNative();
-        $recordedOnLiteral = new Literal($recordedOn->format(DateTime::ATOM), null, 'xsd:dateTime');
-
         // Set the dcterms:created property if not set yet.
         // (Otherwise it would constantly update like dcterms:modified).
         if (!$resource->hasProperty(self::PROPERTY_LOCATIE_AANGEMAAKT_OP)) {
-            $resource->set(self::PROPERTY_LOCATIE_AANGEMAAKT_OP, $recordedOnLiteral);
+            $resource->set(
+                self::PROPERTY_LOCATIE_AANGEMAAKT_OP,
+                new Literal($recordedOn->format(DateTime::ATOM), null, 'xsd:dateTime')
+            );
         }
 
         // Always update the dcterms:modified property since it should change on every update to the resource.
-        $resource->set(self::PROPERTY_LOCATIE_LAATST_AANGEPAST, $recordedOnLiteral);
+        $resource->set(
+            self::PROPERTY_LOCATIE_LAATST_AANGEPAST,
+            new Literal($recordedOn->format(DateTime::ATOM), null, 'xsd:dateTime')
+        );
 
         // Add an adms:Indentifier if not set yet. Like rdf:type we only do this once to avoid needlessly shifting it
         // to the end of the properties in the serialized Turtle data.
@@ -113,7 +116,10 @@ final class RdfProjector implements EventListener
 
         // Add/update the generiek:versieIdentificator inside the linked adms:Identifier on every change.
         $identificator = $resource->getResource(self::PROPERTY_LOCATIE_IDENTIFICATOR);
-        $identificator->set(self::PROPERTY_IDENTIFICATOR_VERSIE_ID, $recordedOnLiteral);
+        $identificator->set(
+            self::PROPERTY_IDENTIFICATOR_VERSIE_ID,
+            new Literal($recordedOn->format(DateTime::ATOM), null, 'xsd:string')
+        );
 
         return $graph;
     }

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -77,7 +77,7 @@ final class RdfProjector implements EventListener
 
     private function setGeneralProperties(Graph $graph, string $uri, DomainMessage $domainMessage): Graph
     {
-        $recordedOn = $domainMessage->getRecordedOn()->toNative();
+        $recordedOn = $domainMessage->getRecordedOn()->toNative()->format(DateTime::ATOM);
         $resource = $graph->resource($uri);
 
         // Set the rdf:type property, but only if it is not set before to avoid needlessly shifting it to the end of the
@@ -92,14 +92,14 @@ final class RdfProjector implements EventListener
         if (!$resource->hasProperty(self::PROPERTY_LOCATIE_AANGEMAAKT_OP)) {
             $resource->set(
                 self::PROPERTY_LOCATIE_AANGEMAAKT_OP,
-                new Literal($recordedOn->format(DateTime::ATOM), null, 'xsd:dateTime')
+                new Literal($recordedOn, null, 'xsd:dateTime')
             );
         }
 
         // Always update the dcterms:modified property since it should change on every update to the resource.
         $resource->set(
             self::PROPERTY_LOCATIE_LAATST_AANGEPAST,
-            new Literal($recordedOn->format(DateTime::ATOM), null, 'xsd:dateTime')
+            new Literal($recordedOn, null, 'xsd:dateTime')
         );
 
         // Add an adms:Indentifier if not set yet. Like rdf:type we only do this once to avoid needlessly shifting it
@@ -118,7 +118,7 @@ final class RdfProjector implements EventListener
         $identificator = $resource->getResource(self::PROPERTY_LOCATIE_IDENTIFICATOR);
         $identificator->set(
             self::PROPERTY_IDENTIFICATOR_VERSIE_ID,
-            new Literal($recordedOn->format(DateTime::ATOM), null, 'xsd:string')
+            new Literal($recordedOn, null, 'xsd:string')
         );
 
         return $graph;

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\RDF\MainLanguageRepository;
 use EasyRdf\Graph;
 use EasyRdf\Literal;
 use EasyRdf\Resource;
+use DateTime;
 
 final class RdfProjector implements EventListener
 {
@@ -87,7 +88,7 @@ final class RdfProjector implements EventListener
 
         // Create a literal value for the recorded_on datetime (used in multiple properties)
         $recordedOn = $domainMessage->getRecordedOn()->toNative();
-        $recordedOnLiteral = new Literal($recordedOn->format('Y-m-d\TH:i:s'), null, 'xsd:dateTime');
+        $recordedOnLiteral = new Literal($recordedOn->format(DateTime::ATOM), null, 'xsd:dateTime');
 
         // Set the dcterms:created property if not set yet.
         // (Otherwise it would constantly update like dcterms:modified).

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -15,6 +15,6 @@
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-01T12:30:15+01:00"^^xsd:dateTime
+    generiek:versieIdentificator "2023-01-01T12:30:15+01:00"^^xsd:string
   ] ;
   locn:geographicName "Voorbeeld titel"@nl .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -7,14 +7,14 @@
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
-  dcterms:modified "2023-01-01T12:30:15"^^xsd:dateTime ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-01T12:30:15"^^xsd:dateTime
+    generiek:versieIdentificator "2023-01-01T12:30:15+01:00"^^xsd:dateTime
   ] ;
   locn:geographicName "Voorbeeld titel"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -14,7 +14,7 @@
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:dateTime
+    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -7,14 +7,14 @@
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15"^^xsd:dateTime
+    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:dateTime
   ] ;
-  dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -7,14 +7,14 @@
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-05T12:30:15"^^xsd:dateTime
+    generiek:versieIdentificator "2023-01-05T12:30:15+01:00"^^xsd:dateTime
   ] ;
-  dcterms:modified "2023-01-05T12:30:15"^^xsd:dateTime ;
+  dcterms:modified "2023-01-05T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -14,7 +14,7 @@
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-05T12:30:15+01:00"^^xsd:dateTime
+    generiek:versieIdentificator "2023-01-05T12:30:15+01:00"^^xsd:string
   ] ;
   dcterms:modified "2023-01-05T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -7,14 +7,14 @@
 
 <https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  dcterms:created "2023-01-01T12:30:15"^^xsd:dateTime ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15"^^xsd:dateTime
+    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:dateTime
   ] ;
-  dcterms:modified "2023-01-02T12:30:15"^^xsd:dateTime ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -14,7 +14,7 @@
     dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
     generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:dateTime
+    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .


### PR DESCRIPTION
### Fixed

- Added missing timezones to `xsd:dateTime` datatype properties
- Changed `generiek:versieIdentificator` from datatype `xsd:dateTime` to `xsd:string` for correct compatibility with OSLO generiek

---
Ticket: https://jira.uitdatabank.be/browse/III-5417
