### PR TITLE
III-5166 add `image` to `NewsArticle`

### DIFF
--- a/app/Migrations/Version20230309140014.php
+++ b/app/Migrations/Version20230309140014.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230309140014 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('news_article');
+        $table->addColumn('image_url', Type::TEXT)->setDefault(null)->setNotnull(false);
+        $table->addColumn('copyrightHolder', Type::TEXT)
+            ->setDefault(null)
+            ->setNotnull(false)
+            ->setLength(250);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('news_article');
+        $table->dropColumn('image_url');
+        $table->dropColumn('copyrightHolder');
+    }
+}

--- a/app/Migrations/Version20230309140014.php
+++ b/app/Migrations/Version20230309140014.php
@@ -17,7 +17,7 @@ final class Version20230309140014 extends AbstractMigration
     {
         $table = $schema->getTable('news_article');
         $table->addColumn('image_url', Type::TEXT)->setDefault(null)->setNotnull(false);
-        $table->addColumn('copyrightHolder', Type::TEXT)
+        $table->addColumn('copyright_holder', Type::TEXT)
             ->setDefault(null)
             ->setNotnull(false)
             ->setLength(250);
@@ -27,6 +27,6 @@ final class Version20230309140014 extends AbstractMigration
     {
         $table = $schema->getTable('news_article');
         $table->dropColumn('image_url');
-        $table->dropColumn('copyrightHolder');
+        $table->dropColumn('copyright_holder');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-uitdatabank/III-5166-add-image-to-newsarticle",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/III-5166-add-image-to-newsarticle",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd8d4a318e7bfd987fae39d54d2f5884",
+    "content-hash": "7441d938a6e9ed9500993eb8e5b480e8",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5634,19 +5634,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/III-5166-add-image-to-newsarticle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "c36cf29cdbc4b37044f0c7161c910a1f3156af14"
+                "reference": "48c4a982898887bd8e884a76525110133bb86c90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/c36cf29cdbc4b37044f0c7161c910a1f3156af14",
-                "reference": "c36cf29cdbc4b37044f0c7161c910a1f3156af14",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/48c4a982898887bd8e884a76525110133bb86c90",
+                "reference": "48c4a982898887bd8e884a76525110133bb86c90",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5661,9 +5660,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5166-add-image-to-newsarticle"
             },
-            "time": "2023-03-06T08:55:23+00:00"
+            "time": "2023-03-09T15:49:21+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -5638,12 +5638,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "48c4a982898887bd8e884a76525110133bb86c90"
+                "reference": "6991d6dff62a51bf0f14ce34b46849022714dbe5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/48c4a982898887bd8e884a76525110133bb86c90",
-                "reference": "48c4a982898887bd8e884a76525110133bb86c90",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/6991d6dff62a51bf0f14ce34b46849022714dbe5",
+                "reference": "6991d6dff62a51bf0f14ce34b46849022714dbe5",
                 "shasum": ""
             },
             "type": "library",
@@ -5662,7 +5662,7 @@
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
                 "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5166-add-image-to-newsarticle"
             },
-            "time": "2023-03-09T15:49:21+00:00"
+            "time": "2023-03-10T12:57:42+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7441d938a6e9ed9500993eb8e5b480e8",
+    "content-hash": "bd8d4a318e7bfd987fae39d54d2f5884",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5634,18 +5634,19 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-uitdatabank/III-5166-add-image-to-newsarticle",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "028706c72b59559ae949f1fbf108eeded33f325c"
+                "reference": "095ccb471322a79a2ab1a3312b3c4934aa315b84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/028706c72b59559ae949f1fbf108eeded33f325c",
-                "reference": "028706c72b59559ae949f1fbf108eeded33f325c",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/095ccb471322a79a2ab1a3312b3c4934aa315b84",
+                "reference": "095ccb471322a79a2ab1a3312b3c4934aa315b84",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5660,9 +5661,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5166-add-image-to-newsarticle"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
-            "time": "2023-03-13T12:14:31+00:00"
+            "time": "2023-03-13T12:26:32+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -5638,12 +5638,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "6991d6dff62a51bf0f14ce34b46849022714dbe5"
+                "reference": "028706c72b59559ae949f1fbf108eeded33f325c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/6991d6dff62a51bf0f14ce34b46849022714dbe5",
-                "reference": "6991d6dff62a51bf0f14ce34b46849022714dbe5",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/028706c72b59559ae949f1fbf108eeded33f325c",
+                "reference": "028706c72b59559ae949f1fbf108eeded33f325c",
                 "shasum": ""
             },
             "type": "library",
@@ -5662,7 +5662,7 @@
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
                 "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5166-add-image-to-newsarticle"
             },
-            "time": "2023-03-10T12:57:42+00:00"
+            "time": "2023-03-13T12:14:31+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Curators/NewsArticle.php
+++ b/src/Curators/NewsArticle.php
@@ -26,7 +26,7 @@ final class NewsArticle
 
     private Url $publisherLogo;
 
-    private ?NewsArticleImage $image;
+    private ?NewsArticleImage $image = null;
 
     public function __construct(
         UUID $id,

--- a/src/Curators/NewsArticle.php
+++ b/src/Curators/NewsArticle.php
@@ -26,6 +26,8 @@ final class NewsArticle
 
     private Url $publisherLogo;
 
+    private ?NewsArticleImage $image;
+
     public function __construct(
         UUID $id,
         string $headline,
@@ -34,7 +36,8 @@ final class NewsArticle
         string $about,
         string $publisher,
         Url $url,
-        Url $publisherLogo
+        Url $publisherLogo,
+        NewsArticleImage $image = null
     ) {
         $this->id = $id;
         $this->headline = $headline;
@@ -44,6 +47,7 @@ final class NewsArticle
         $this->publisher = $publisher;
         $this->url = $url;
         $this->publisherLogo = $publisherLogo;
+        $this->image = $image;
     }
 
     public function getId(): UUID
@@ -84,5 +88,10 @@ final class NewsArticle
     public function getPublisherLogo(): Url
     {
         return $this->publisherLogo;
+    }
+
+    public function getImage(): ?NewsArticleImage
+    {
+        return $this->image;
     }
 }

--- a/src/Curators/NewsArticle.php
+++ b/src/Curators/NewsArticle.php
@@ -36,8 +36,7 @@ final class NewsArticle
         string $about,
         string $publisher,
         Url $url,
-        Url $publisherLogo,
-        NewsArticleImage $image = null
+        Url $publisherLogo
     ) {
         $this->id = $id;
         $this->headline = $headline;
@@ -47,7 +46,6 @@ final class NewsArticle
         $this->publisher = $publisher;
         $this->url = $url;
         $this->publisherLogo = $publisherLogo;
-        $this->image = $image;
     }
 
     public function getId(): UUID
@@ -88,6 +86,13 @@ final class NewsArticle
     public function getPublisherLogo(): Url
     {
         return $this->publisherLogo;
+    }
+
+    public function withImage(NewsArticleImage $image): NewsArticle
+    {
+        $clone = clone $this;
+        $clone->image = $image;
+        return $clone;
     }
 
     public function getImage(): ?NewsArticleImage

--- a/src/Curators/NewsArticleImage.php
+++ b/src/Curators/NewsArticleImage.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Curators;
+
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+
+final class NewsArticleImage
+{
+    private Url $imageUrl;
+
+    private CopyrightHolder $copyrightHolder;
+
+    public function __construct(
+        Url $imageUrl,
+        CopyrightHolder $copyrightHolder
+    ) {
+        $this->imageUrl = $imageUrl;
+        $this->copyrightHolder = $copyrightHolder;
+    }
+
+    public function getImageUrl(): Url
+    {
+        return $this->imageUrl;
+    }
+
+    public function getCopyrightHolder(): CopyrightHolder
+    {
+        return $this->copyrightHolder;
+    }
+}

--- a/src/Curators/NewsArticleSchemaConfigurator.php
+++ b/src/Curators/NewsArticleSchemaConfigurator.php
@@ -22,6 +22,12 @@ final class NewsArticleSchemaConfigurator
         $table->addColumn('publisher', Type::TEXT)->setDefault(null)->setNotnull(false);
         $table->addColumn('url', Type::TEXT)->setDefault(null)->setNotnull(false);
         $table->addColumn('publisher_logo', Type::TEXT)->setDefault(null)->setNotnull(false);
+        $table->addColumn('image_url', Type::TEXT)->setDefault(null)->setNotnull(false);
+        $table->addColumn('copyright_holder', Type::TEXT)
+            ->setDefault(null)
+            ->setNotnull(false)
+            ->setLength(250);
+
 
         $table->setPrimaryKey(['id']);
 

--- a/src/Curators/Serializer/NewsArticleDenormalizer.php
+++ b/src/Curators/Serializer/NewsArticleDenormalizer.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Curators\Serializer;
 
 use CultuurNet\UDB3\Curators\NewsArticle;
+use CultuurNet\UDB3\Curators\NewsArticleImage;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -21,7 +23,7 @@ final class NewsArticleDenormalizer implements DenormalizerInterface
 
     public function denormalize($data, $type, $format = null, array $context = []): NewsArticle
     {
-        return new NewsArticle(
+        $newsArticle = new NewsArticle(
             $this->uuid,
             $data['headline'],
             new Language($data['inLanguage']),
@@ -31,6 +33,17 @@ final class NewsArticleDenormalizer implements DenormalizerInterface
             new Url($data['url']),
             new Url($data['publisherLogo'])
         );
+
+        if (isset($data['image'])) {
+            $newsArticle = $newsArticle->withImage(
+                new NewsArticleImage(
+                    new Url($data['image']['url']),
+                    new CopyrightHolder($data['image']['copyrightHolder'])
+                )
+            );
+        }
+
+        return $newsArticle;
     }
 
     public function supportsDenormalization($data, $type, $format = null): bool

--- a/src/Curators/Serializer/NewsArticleNormalizer.php
+++ b/src/Curators/Serializer/NewsArticleNormalizer.php
@@ -42,6 +42,15 @@ final class NewsArticleNormalizer implements NormalizerInterface
             'publisherLogo' => $newsArticle->getPublisherLogo()->toString(),
         ];
 
+        if ($newsArticle->getImage() !== null) {
+            $data += [
+                'image' => [
+                    'url' => $newsArticle->getImage()->getImageUrl()->toString(),
+                    'copyrightHolder' => $newsArticle->getImage()->getCopyrightHolder()->toString(),
+                ],
+            ];
+        }
+
         return $data;
     }
 

--- a/tests/Curators/DBALNewsArticleRepositoryTest.php
+++ b/tests/Curators/DBALNewsArticleRepositoryTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Curators;
 
 use CultuurNet\UDB3\DBALTestConnectionTrait;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
@@ -215,6 +216,35 @@ final class DBALNewsArticleRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_can_create_a_news_article_with_an_image(): void
+    {
+        $newsArticle = (new NewsArticle(
+            new UUID('727cf17c-d81f-4ec6-ba39-ef0227b5eb40'),
+            'Creating news articles works',
+            new Language('en'),
+            'This test covers the creation of news articles',
+            '17284745-7bcf-461a-aad0-d3ad54880e75',
+            'TECH',
+            new Url('https://www.tech.com/blog/create'),
+            new Url('https://www.tech.com/img/favicon.png')
+        ))->withImage(
+            new NewsArticleImage(
+                new Url('https://www.tech.com/image.jpeg'),
+                new CopyrightHolder('tech vzw')
+            )
+        );
+
+        $this->dbalNewsArticleRepository->create($newsArticle);
+
+        $this->assertEquals(
+            $newsArticle,
+            $this->dbalNewsArticleRepository->getById(new UUID('727cf17c-d81f-4ec6-ba39-ef0227b5eb40'))
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_can_update_a_news_article(): void
     {
         $newsArticle = new NewsArticle(
@@ -226,6 +256,35 @@ final class DBALNewsArticleRepositoryTest extends TestCase
             'UPDATE',
             new Url('https://www.update.com/blog/create'),
             new Url('https://www.update.com/img/favicon.png')
+        );
+
+        $this->dbalNewsArticleRepository->update($newsArticle);
+
+        $this->assertEquals(
+            $newsArticle,
+            $this->dbalNewsArticleRepository->getById(new UUID('4bd47771-4c83-4023-be0d-e4e93681c2ba'))
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_update_a_news_article_with_an_image(): void
+    {
+        $newsArticle = (new NewsArticle(
+            new UUID('4bd47771-4c83-4023-be0d-e4e93681c2ba'),
+            'Updating news articles works',
+            new Language('nl'),
+            'This test covers the update of news articles',
+            '17284745-7bcf-461a-aad0-d3ad54880e75',
+            'UPDATE',
+            new Url('https://www.update.com/blog/create'),
+            new Url('https://www.update.com/img/favicon.png')
+        ))->withImage(
+            new NewsArticleImage(
+                new Url('https://www.update.com/image.png'),
+                new CopyrightHolder('update vzw')
+            )
         );
 
         $this->dbalNewsArticleRepository->update($newsArticle);

--- a/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
@@ -22,7 +22,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class CreateNewsArticleRequestHandlerTest extends TestCase
+final class CreateNewsArticleRequestHandlerTest extends TestCase
 {
     use AssertApiProblemTrait;
 

--- a/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
@@ -178,7 +178,7 @@ final class CreateNewsArticleRequestHandlerTest extends TestCase
                 'publisherLogo' => 'https://www.bill.be/img/favicon.png',
                 'image' => [
                     'url' => 'https://www.uitinvlaanderen.be/img.png',
-                ]
+                ],
             ]),
             $response->getBody()->getContents()
         );

--- a/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
@@ -378,7 +378,7 @@ class CreateNewsArticleRequestHandlerTest extends TestCase
      * @test
      * @dataProvider invalidNewsArticleProviders
      */
-    public function it_throws_on_missing_properties(array $body, ApiProblem $apiProblem): void
+    public function it_throws_on_missing_and_invalid_properties(array $body, ApiProblem $apiProblem): void
     {
         $createNewsArticleRequest = $this->psr7RequestBuilder
             ->withJsonBodyFromArray($body)
@@ -438,6 +438,47 @@ class CreateNewsArticleRequestHandlerTest extends TestCase
                     new SchemaError(
                         '/',
                         'The required properties (headline, inLanguage, text, about, publisher, publisherLogo, url) are missing'
+                    )
+                ),
+            ],
+            'invalid image url' => [
+                [
+                    'headline' => 'publiq wint API award',
+                    'inLanguage' => 'nl',
+                    'text' => 'Op 10 januari 2020 wint publiq de API award',
+                    'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
+                    'publisher' => 'BILL',
+                    'url' => 'https://www.publiq.be/blog/api-reward',
+                    'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+                    'image' => [
+                        'url' => 'https://www.uitinvlaanderen.be/img/manual.pdf',
+                        'copyrightHolder' => 'Publiq vzw',
+                    ],
+                ],
+                ApiProblem::bodyInvalidData(
+                    new SchemaError(
+                        '/image/url',
+                        'The string should match pattern: ^http(s?):([/|.|\w|\s|-])*\.(?:jpeg|jpeg|gif|png)'
+                    )
+                ),
+            ],
+            'image without copyright' => [
+                [
+                    'headline' => 'publiq wint API award',
+                    'inLanguage' => 'nl',
+                    'text' => 'Op 10 januari 2020 wint publiq de API award',
+                    'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
+                    'publisher' => 'BILL',
+                    'url' => 'https://www.publiq.be/blog/api-reward',
+                    'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+                    'image' => [
+                        'url' => 'https://www.uitinvlaanderen.be/img/setting.png',
+                    ],
+                ],
+                ApiProblem::bodyInvalidData(
+                    new SchemaError(
+                        '/image',
+                        'The required properties (copyrightHolder) are missing'
                     )
                 ),
             ],

--- a/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
@@ -534,7 +534,7 @@ final class CreateNewsArticleRequestHandlerTest extends TestCase
                 ApiProblem::bodyInvalidData(
                     new SchemaError(
                         '/image/url',
-                        'The string should match pattern: ^http(s?):([/|.|\w|\s|-])*\.(?:jpeg|jpeg|gif|png)'
+                        'The string should match pattern: ^http(s?):([/|.|\w|\s|-])*\.(?:jpeg|jpeg|gif|png)$'
                     )
                 ),
             ],

--- a/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
@@ -178,6 +178,7 @@ final class CreateNewsArticleRequestHandlerTest extends TestCase
                 'publisherLogo' => 'https://www.bill.be/img/favicon.png',
                 'image' => [
                     'url' => 'https://www.uitinvlaanderen.be/img.png',
+                    'copyrightHolder' => 'Publiq vzw',
                 ],
             ]),
             $response->getBody()->getContents()

--- a/tests/Http/Curators/GetNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/GetNewsArticleRequestHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Curators;
 
 use CultuurNet\UDB3\Curators\NewsArticle;
+use CultuurNet\UDB3\Curators\NewsArticleImage;
 use CultuurNet\UDB3\Curators\NewsArticleNotFound;
 use CultuurNet\UDB3\Curators\NewsArticleRepository;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
@@ -12,12 +13,13 @@ use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class GetNewsArticleRequestHandlerTest extends TestCase
+final class GetNewsArticleRequestHandlerTest extends TestCase
 {
     use AssertApiProblemTrait;
 
@@ -77,6 +79,62 @@ class GetNewsArticleRequestHandlerTest extends TestCase
                 'publisher' => 'BILL',
                 'url' => 'https://www.publiq.be/blog/api-reward',
                 'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+            ]),
+            $response->getBody()->getContents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_getting_a_news_article_with_an_image(): void
+    {
+        $articleId = new UUID('ec00bcd0-41e9-47a0-8364-71aad7e537c5');
+
+        $newsArticle = (new NewsArticle(
+            $articleId,
+            'publiq wint API award',
+            new Language('nl'),
+            'Op 10 januari 2020 wint publiq de API award',
+            '17284745-7bcf-461a-aad0-d3ad54880e75',
+            'BILL',
+            new Url('https://www.publiq.be/blog/api-reward'),
+            new Url('https://www.bill.be/img/favicon.png')
+        ))->withImage(
+            new NewsArticleImage(
+                new Url('https://www.publiq.be/afbeelding.gif'),
+                new CopyrightHolder('Publiq vzw')
+            )
+        );
+
+        $getNewsArticleRequest = $this->psr7RequestBuilder
+            ->withRouteParameter('articleId', $articleId->toString())
+            ->build('GET');
+
+        $this->newsArticleRepository->expects($this->once())
+            ->method('getById')
+            ->with($articleId)
+            ->willReturn($newsArticle);
+
+        $response = $this->getNewsArticleRequestHandler->handle($getNewsArticleRequest);
+
+        $this->assertEquals(
+            Json::encode([
+                '@context' => '/contexts/NewsArticle',
+                '@id' => '/news-articles/' . $articleId->toString(),
+                '@type' => 'https://schema.org/NewsArticle',
+                'id' => $articleId->toString(),
+                'headline' => 'publiq wint API award',
+                'inLanguage' => 'nl',
+                'text' => 'Op 10 januari 2020 wint publiq de API award',
+                'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
+                'publisher' => 'BILL',
+                'url' => 'https://www.publiq.be/blog/api-reward',
+                'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+                'image' => [
+                    'url' => 'https://www.publiq.be/afbeelding.gif',
+                    'copyrightHolder' => 'Publiq vzw',
+                ],
             ]),
             $response->getBody()->getContents()
         );

--- a/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
@@ -20,7 +20,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class UpdateNewsArticleRequestHandlerTest extends TestCase
+final class UpdateNewsArticleRequestHandlerTest extends TestCase
 {
     use AssertApiProblemTrait;
 

--- a/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Curators;
 
 use CultuurNet\UDB3\Curators\NewsArticle;
+use CultuurNet\UDB3\Curators\NewsArticleImage;
 use CultuurNet\UDB3\Curators\NewsArticleNotFound;
 use CultuurNet\UDB3\Curators\NewsArticleRepository;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -267,6 +270,170 @@ class UpdateNewsArticleRequestHandlerTest extends TestCase
                 'publisherLogo' => 'https://www.bill.be/img/favicon.png',
             ]),
             $response->getBody()->getContents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_updates_a_news_article_with_an_image(): void
+    {
+        $updateNewsArticleRequest = $this->psr7RequestBuilder
+            ->withRouteParameter('articleId', '6c583739-a848-41ab-b8a3-8f7dab6f8ee1')
+            ->withJsonBodyFromArray([
+                'headline' => 'publiq wint API award',
+                'inLanguage' => 'nl',
+                'text' => 'Op 10 januari 2020 wint publiq de API award',
+                'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
+                'publisher' => 'BILL',
+                'url' => 'https://www.publiq.be/blog/api-reward',
+                'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+                'image' => [
+                    'url' => 'https://www.publiq.be/assets/logo.png',
+                    'copyrightHolder' => 'Publiq vzw',
+                ],
+            ])
+            ->build('PUT');
+
+        $newsArticle = new NewsArticle(
+            new UUID('6c583739-a848-41ab-b8a3-8f7dab6f8ee1'),
+            'publiq wint API award',
+            new Language('nl'),
+            'Op 10 januari 2020 wint publiq de API award',
+            '17284745-7bcf-461a-aad0-d3ad54880e75',
+            'BILL',
+            new Url('https://www.publiq.be/blog/api-reward'),
+            new Url('https://www.bill.be/img/favicon.png')
+        );
+
+        $updateNewsArticle = $newsArticle->withImage(
+            new NewsArticleImage(
+                new Url('https://www.publiq.be/assets/logo.png'),
+                new CopyrightHolder('Publiq vzw')
+            )
+        );
+
+        $this->newsArticleRepository->expects($this->once())
+            ->method('getById')
+            ->with(new UUID('6c583739-a848-41ab-b8a3-8f7dab6f8ee1'))
+            ->willReturn($newsArticle);
+
+        $this->newsArticleRepository->expects($this->once())
+            ->method('update')
+            ->with($updateNewsArticle);
+
+        $response = $this->updateNewsArticleRequestHandler->handle($updateNewsArticleRequest);
+
+        $this->assertEquals(
+            Json::encode([
+                '@context' => '/contexts/NewsArticle',
+                '@id' => '/news-articles/6c583739-a848-41ab-b8a3-8f7dab6f8ee1',
+                '@type' => 'https://schema.org/NewsArticle',
+                'id' => '6c583739-a848-41ab-b8a3-8f7dab6f8ee1',
+                'headline' => 'publiq wint API award',
+                'inLanguage' => 'nl',
+                'text' => 'Op 10 januari 2020 wint publiq de API award',
+                'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
+                'publisher' => 'BILL',
+                'url' => 'https://www.publiq.be/blog/api-reward',
+                'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+                'image' => [
+                    'url' => 'https://www.publiq.be/assets/logo.png',
+                    'copyrightHolder' => 'Publiq vzw',
+                ],
+            ]),
+            $response->getBody()->getContents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_on_invalid_image_url(): void
+    {
+        $updateNewsArticleRequest = $this->psr7RequestBuilder
+            ->withRouteParameter('articleId', '6c583739-a848-41ab-b8a3-8f7dab6f8ee1')
+            ->withJsonBodyFromArray([
+                'headline' => 'publiq wint API award',
+                'inLanguage' => 'nl',
+                'text' => 'Op 10 januari 2020 wint publiq de API award',
+                'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
+                'publisher' => 'BILL',
+                'url' => 'https://www.publiq.be/blog/api-reward',
+                'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+                'image' => [
+                    'url' => 'https://www.publiq.be/assets/logo.pdf',
+                    'copyrightHolder' => 'Publiq vzw',
+                ],
+            ])
+            ->build('PUT');
+
+        $newsArticle = new NewsArticle(
+            new UUID('6c583739-a848-41ab-b8a3-8f7dab6f8ee1'),
+            'publiq wint API award',
+            new Language('nl'),
+            'Op 10 januari 2020 wint publiq de API award',
+            '17284745-7bcf-461a-aad0-d3ad54880e75',
+            'BILL',
+            new Url('https://www.publiq.be/blog/api-reward'),
+            new Url('https://www.bill.be/img/favicon.png')
+        );
+
+        $this->newsArticleRepository->expects($this->once())
+            ->method('getById')
+            ->with(new UUID('6c583739-a848-41ab-b8a3-8f7dab6f8ee1'))
+            ->willReturn($newsArticle);
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidData(
+                new SchemaError('/image/url', 'The string should match pattern: ^http(s?):([/|.|\w|\s|-])*\.(?:jpeg|jpeg|gif|png)')
+            ),
+            fn () => $this->updateNewsArticleRequestHandler->handle($updateNewsArticleRequest)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_an_image_without_copyright(): void
+    {
+        $updateNewsArticleRequest = $this->psr7RequestBuilder
+            ->withRouteParameter('articleId', '6c583739-a848-41ab-b8a3-8f7dab6f8ee1')
+            ->withJsonBodyFromArray([
+                'headline' => 'publiq wint API award',
+                'inLanguage' => 'nl',
+                'text' => 'Op 10 januari 2020 wint publiq de API award',
+                'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
+                'publisher' => 'BILL',
+                'url' => 'https://www.publiq.be/blog/api-reward',
+                'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+                'image' => [
+                    'url' => 'https://www.publiq.be/assets/logo.jpeg',
+                ],
+            ])
+            ->build('PUT');
+
+        $newsArticle = new NewsArticle(
+            new UUID('6c583739-a848-41ab-b8a3-8f7dab6f8ee1'),
+            'publiq wint API award',
+            new Language('nl'),
+            'Op 10 januari 2020 wint publiq de API award',
+            '17284745-7bcf-461a-aad0-d3ad54880e75',
+            'BILL',
+            new Url('https://www.publiq.be/blog/api-reward'),
+            new Url('https://www.bill.be/img/favicon.png')
+        );
+
+        $this->newsArticleRepository->expects($this->once())
+            ->method('getById')
+            ->with(new UUID('6c583739-a848-41ab-b8a3-8f7dab6f8ee1'))
+            ->willReturn($newsArticle);
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidData(
+                new SchemaError('/image', 'The required properties (copyrightHolder) are missing')
+            ),
+            fn () => $this->updateNewsArticleRequestHandler->handle($updateNewsArticleRequest)
         );
     }
 

--- a/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
@@ -386,7 +386,7 @@ final class UpdateNewsArticleRequestHandlerTest extends TestCase
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidData(
-                new SchemaError('/image/url', 'The string should match pattern: ^http(s?):([/|.|\w|\s|-])*\.(?:jpeg|jpeg|gif|png)')
+                new SchemaError('/image/url', 'The string should match pattern: ^http(s?):([/|.|\w|\s|-])*\.(?:jpeg|jpeg|gif|png)$')
             ),
             fn () => $this->updateNewsArticleRequestHandler->handle($updateNewsArticleRequest)
         );


### PR DESCRIPTION
### Added

- Migration to add `image_url` & `copyright_holder` to `news_article` table
- class `NewsArticleImage`

### Changed

- updated `publiq/udb3-json-schemas` in `composer`
- `NewsArticle`: added optional `NewsArticleImage`
- `DBALNewsArticleRepository`: added support for CRUD-options on `NewsArticle` with `Images`
- `NewsArticleDenormalizer`: added support for `Images`
- `NewsArticleNormalizer`: added support for `Images`
- `*NewsArticleRequestHandlers`: added tests for `NewsArticle` with `image`
- `DBALNewsArticleRepositoryTest`: added tests for `NewsArticle` with `image`


---
Ticket: https://jira.uitdatabank.be/browse/III-5166
