### PR TITLE
III-5424 Fixed the non-default RDF prefixes not working correctly

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -46,6 +46,7 @@ use CultuurNet\UDB3\Place\PlacePermissionServiceProvider;
 use CultuurNet\UDB3\Place\PlaceRdfServiceProvider;
 use CultuurNet\UDB3\Place\PlaceReadServiceProvider;
 use CultuurNet\UDB3\Place\PlaceServiceProvider;
+use CultuurNet\UDB3\RDF\RdfNamespaces;
 use CultuurNet\UDB3\RDF\RdfServiceProvider;
 use CultuurNet\UDB3\Role\RoleRequestHandlerServiceProvider;
 use CultuurNet\UDB3\Role\RoleServiceProvider;
@@ -199,6 +200,7 @@ $container->addServiceProvider(new TermServiceProvider());
 $container->addServiceProvider(new JobsServiceProvider());
 
 /** RDF */
+RdfNamespaces::register();
 $container->addServiceProvider(new RdfServiceProvider());
 $container->addServiceProvider(new PlaceRdfServiceProvider());
 


### PR DESCRIPTION
### Fixed

- Fixed the non-default RDF prefixes not working correctly. We also have to register them globally in the regular app. Until now it was only done in tests/bootstrap.php, which is why they worked in the tests but were missing in the actual Fuseki data.

---
Ticket: https://jira.uitdatabank.be/browse/III-5424