### PR TITLE
III-5357 RDF address projection

### DIFF
--- a/app/Event/EventGeoCoordinatesServiceProvider.php
+++ b/app/Event/EventGeoCoordinatesServiceProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Address\CultureFeedAddressFactory;
-use CultuurNet\UDB3\Address\DefaultAddressFormatter;
+use CultuurNet\UDB3\Address\FullAddressFormatter;
 use CultuurNet\UDB3\Address\LocalityAddressFormatter;
 use CultuurNet\UDB3\Broadway\EventHandling\ReplayFilteringEventListener;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
@@ -33,7 +33,7 @@ final class EventGeoCoordinatesServiceProvider extends AbstractServiceProvider
             function () use ($container): GeoCoordinatesCommandHandler {
                 $handler = new GeoCoordinatesCommandHandler(
                     $container->get('event_repository'),
-                    new DefaultAddressFormatter(),
+                    new FullAddressFormatter(),
                     new LocalityAddressFormatter(),
                     $container->get(GeocodingService::class),
                 );

--- a/app/Organizer/OrganizerGeoCoordinatesServiceProvider.php
+++ b/app/Organizer/OrganizerGeoCoordinatesServiceProvider.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Organizer;
 
 use CultuurNet\UDB3\Broadway\EventHandling\ReplayFilteringEventListener;
 use CultuurNet\UDB3\Address\CultureFeedAddressFactory;
-use CultuurNet\UDB3\Address\DefaultAddressFormatter;
+use CultuurNet\UDB3\Address\FullAddressFormatter;
 use CultuurNet\UDB3\Address\LocalityAddressFormatter;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
@@ -34,7 +34,7 @@ final class OrganizerGeoCoordinatesServiceProvider extends AbstractServiceProvid
             function () use ($container) {
                 return new UpdateGeoCoordinatesFromAddressCommandHandler(
                     $container->get('organizer_repository'),
-                    new DefaultAddressFormatter(),
+                    new FullAddressFormatter(),
                     new LocalityAddressFormatter(),
                     $container->get(GeocodingService::class)
                 );

--- a/app/Place/PlaceGeoCoordinatesServiceProvider.php
+++ b/app/Place/PlaceGeoCoordinatesServiceProvider.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Place;
 
 use CultuurNet\UDB3\Broadway\EventHandling\ReplayFilteringEventListener;
 use CultuurNet\UDB3\Address\CultureFeedAddressFactory;
-use CultuurNet\UDB3\Address\DefaultAddressFormatter;
+use CultuurNet\UDB3\Address\FullAddressFormatter;
 use CultuurNet\UDB3\Address\LocalityAddressFormatter;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
@@ -32,7 +32,7 @@ final class PlaceGeoCoordinatesServiceProvider extends AbstractServiceProvider
             function () use ($container) {
                 $handler = new GeoCoordinatesCommandHandler(
                     $container->get('place_repository'),
-                    new DefaultAddressFormatter(),
+                    new FullAddressFormatter(),
                     new LocalityAddressFormatter(),
                     $container->get(GeocodingService::class)
                 );

--- a/app/Place/PlaceRdfServiceProvider.php
+++ b/app/Place/PlaceRdfServiceProvider.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Place;
 
+use CultuurNet\UDB3\Address\GeopuntAddressParser;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use CultuurNet\UDB3\Error\LoggerFactory;
+use CultuurNet\UDB3\Error\LoggerName;
 use CultuurNet\UDB3\Place\ReadModel\RDF\RdfProjector;
 use CultuurNet\UDB3\RDF\MainLanguageRepository;
 use CultuurNet\UDB3\RDF\RdfServiceProvider;
@@ -13,7 +16,10 @@ final class PlaceRdfServiceProvider extends AbstractServiceProvider
 {
     protected function getProvidedServiceNames(): array
     {
-        return [RdfProjector::class];
+        return [
+            RdfProjector::class,
+            GeopuntAddressParser::class,
+        ];
     }
 
     public function register(): void
@@ -24,7 +30,19 @@ final class PlaceRdfServiceProvider extends AbstractServiceProvider
                 $this->container->get(MainLanguageRepository::class),
                 RdfServiceProvider::createGraphStoreRepository($this->container->get('config')['rdf']['placesGraphStoreUrl']),
                 RdfServiceProvider::createIriGenerator($this->container, 'locaties'),
+                $this->container->get(GeopuntAddressParser::class),
             )
+        );
+
+        $this->container->addShared(
+            GeopuntAddressParser::class,
+            function (): GeopuntAddressParser {
+                $logger = LoggerFactory::create($this->getContainer(), LoggerName::forService('geopunt'));
+
+                $parser = new GeopuntAddressParser();
+                $parser->setLogger($logger);
+                return $parser;
+            }
         );
     }
 }

--- a/src/Address/AddressFormatter.php
+++ b/src/Address/AddressFormatter.php
@@ -6,8 +6,5 @@ namespace CultuurNet\UDB3\Address;
 
 interface AddressFormatter
 {
-    /**
-     * @return string
-     */
-    public function format(Address $address);
+    public function format(Address $address): string;
 }

--- a/src/Address/AddressFormatter.php
+++ b/src/Address/AddressFormatter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Address;
 
-interface AddressFormatterInterface
+interface AddressFormatter
 {
     /**
      * @return string

--- a/src/Address/AddressParser.php
+++ b/src/Address/AddressParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CultuurNet\UDB3\Address;
 
 interface AddressParser

--- a/src/Address/AddressParser.php
+++ b/src/Address/AddressParser.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CultuurNet\UDB3\Address;
+
+interface AddressParser
+{
+    public function parse(string $formattedAddress): ?ParsedAddress;
+}

--- a/src/Address/DefaultAddressFormatter.php
+++ b/src/Address/DefaultAddressFormatter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Address;
 
-class DefaultAddressFormatter implements AddressFormatterInterface
+class DefaultAddressFormatter implements AddressFormatter
 {
     /**
      * @return string

--- a/src/Address/FullAddressFormatter.php
+++ b/src/Address/FullAddressFormatter.php
@@ -6,10 +6,7 @@ namespace CultuurNet\UDB3\Address;
 
 final class FullAddressFormatter implements AddressFormatter
 {
-    /**
-     * @return string
-     */
-    public function format(Address $address)
+    public function format(Address $address): string
     {
         return $address->getStreetAddress() . ', ' .
             $address->getPostalCode() . ' ' .

--- a/src/Address/FullAddressFormatter.php
+++ b/src/Address/FullAddressFormatter.php
@@ -6,9 +6,11 @@ namespace CultuurNet\UDB3\Address;
 
 final class FullAddressFormatter implements AddressFormatter
 {
+    private const LINE_SEPARATOR = ', ';
+
     public function format(Address $address): string
     {
-        return implode(', ', [
+        return implode(self::LINE_SEPARATOR, [
             $address->getStreetAddress()->toNative(),
             $address->getPostalCode()->toNative() . ' ' . $address->getLocality()->toNative(),
             $address->getCountryCode()->toString(),

--- a/src/Address/FullAddressFormatter.php
+++ b/src/Address/FullAddressFormatter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Address;
 
-class DefaultAddressFormatter implements AddressFormatter
+class FullAddressFormatter implements AddressFormatter
 {
     /**
      * @return string

--- a/src/Address/FullAddressFormatter.php
+++ b/src/Address/FullAddressFormatter.php
@@ -8,9 +8,10 @@ final class FullAddressFormatter implements AddressFormatter
 {
     public function format(Address $address): string
     {
-        return $address->getStreetAddress() . ', ' .
-            $address->getPostalCode() . ' ' .
-            $address->getLocality() . ', ' .
-            $address->getCountryCode()->toString();
+        return implode(', ', [
+            $address->getStreetAddress()->toNative(),
+            $address->getPostalCode()->toNative() . ' ' . $address->getLocality()->toNative(),
+            $address->getCountryCode()->toString(),
+        ]);
     }
 }

--- a/src/Address/FullAddressFormatter.php
+++ b/src/Address/FullAddressFormatter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Address;
 
-class FullAddressFormatter implements AddressFormatter
+final class FullAddressFormatter implements AddressFormatter
 {
     /**
      * @return string

--- a/src/Address/GeopuntAddressParser.php
+++ b/src/Address/GeopuntAddressParser.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Address;
+
+use CultuurNet\UDB3\Json;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Uri;
+use Http\Adapter\Guzzle7\Client;
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Validator;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+
+final class GeopuntAddressParser implements AddressParser, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    private ClientInterface $httpClient;
+    private Uri $apiUrlV4;
+
+    public function __construct(
+        ?ClientInterface $httpClient = null,
+        ?string $apiUrlV4 = 'https://loc.geopunt.be/v4'
+    ) {
+        $this->httpClient = $httpClient ?? new Client();
+        $this->apiUrlV4 = new Uri(rtrim($apiUrlV4, '/'));
+        $this->logger = new NullLogger();
+    }
+
+    public function parse(string $formattedAddress): ?ParsedAddress
+    {
+        $url = $this->apiUrlV4
+            ->withPath($this->apiUrlV4->getPath() . '/Location')
+            ->withQuery('q=' . $formattedAddress);
+
+        $request = new Request('GET', $url);
+        $response = $this->httpClient->sendRequest($request);
+        $body = $response->getBody()->getContents();
+        $status = $response->getStatusCode();
+        $isStatusOk = $status < 400;
+
+        $logLevel = $isStatusOk ? 'info' : 'error';
+        $this->logger->log(
+            $logLevel,
+            'GET ' . $url->__toString() . ' responded with status code ' . $status . ' and body ' . $body
+        );
+
+        if (!$isStatusOk) {
+            return null;
+        }
+
+        try {
+            $data = Json::decode($body);
+        } catch (\JsonException $e) {
+            $this->logger->error('Caught \JsonException while decoding response body.', ['message' => $e->getMessage()]);
+            return null;
+        }
+
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'LocationResult' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'Municipality' => ['type' => 'string'],
+                            'Zipcode' => ['type' => 'string'],
+                            'Thoroughfarename' => ['type' => 'string'],
+                            'Housenumber' => [
+                                'anyOf' => [
+                                    ['type' => 'string'],
+                                    ['type' => 'null'],
+                                ],
+                            ],
+                        ],
+                        'required' => ['Municipality', 'Zipcode', 'Thoroughfarename', 'Housenumber'],
+                    ],
+                ],
+            ],
+            'required' => ['LocationResult'],
+        ];
+
+        $validator = new Validator(null, 100);
+        $result = $validator->validate($data, Json::encode($schema));
+        if (!$result->isValid()) {
+            $errors = (new ErrorFormatter())->format($result->error());
+            $this->logger->error(
+                'Response body did not match the expected JSON schema. Did the API introduce a breaking change?',
+                ['errors' => $errors]
+            );
+            return null;
+        }
+
+        if (!isset($data->LocationResult[0])) {
+            $this->logger->info('Response body did not contain any array items inside "LocationResult" property. Either the address is not located in Belgium, or it is not recognized as an official address.');
+            return null;
+        }
+        $result = $data->LocationResult[0];
+
+        $this->logger->info('Successfully parsed response body.');
+        return new ParsedAddress(
+            $result->Thoroughfarename,
+            $result->Housenumber,
+            $result->Zipcode,
+            $result->Municipality
+        );
+    }
+}

--- a/src/Address/LocalityAddressFormatter.php
+++ b/src/Address/LocalityAddressFormatter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Address;
 
-class LocalityAddressFormatter implements AddressFormatter
+final class LocalityAddressFormatter implements AddressFormatter
 {
     /**
      * @inheritdoc

--- a/src/Address/LocalityAddressFormatter.php
+++ b/src/Address/LocalityAddressFormatter.php
@@ -6,10 +6,7 @@ namespace CultuurNet\UDB3\Address;
 
 final class LocalityAddressFormatter implements AddressFormatter
 {
-    /**
-     * @inheritdoc
-     */
-    public function format(Address $address)
+    public function format(Address $address): string
     {
         return $address->getPostalCode() . ' ' .
             $address->getLocality() . ', ' .

--- a/src/Address/LocalityAddressFormatter.php
+++ b/src/Address/LocalityAddressFormatter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Address;
 
-class LocalityAddressFormatter implements AddressFormatterInterface
+class LocalityAddressFormatter implements AddressFormatter
 {
     /**
      * @inheritdoc

--- a/src/Address/ParsedAddress.php
+++ b/src/Address/ParsedAddress.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Address;
+
+final class ParsedAddress
+{
+    private string $thoroughfare;
+    private ?string $houseNumber;
+    private string $postalCode;
+    private string $municipality;
+
+    public function __construct(string $thoroughfare, ?string $houseNumber, string $postalCode, string $municipality)
+    {
+        $this->thoroughfare = $thoroughfare;
+        $this->houseNumber = $houseNumber;
+        $this->postalCode = $postalCode;
+        $this->municipality = $municipality;
+    }
+
+    public function getThoroughfare(): string
+    {
+        return $this->thoroughfare;
+    }
+
+    public function getHouseNumber(): ?string
+    {
+        return $this->houseNumber;
+    }
+
+    public function getPostalCode(): string
+    {
+        return $this->postalCode;
+    }
+
+    public function getMunicipality(): string
+    {
+        return $this->municipality;
+    }
+}

--- a/src/Offer/AbstractGeoCoordinatesCommandHandler.php
+++ b/src/Offer/AbstractGeoCoordinatesCommandHandler.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Offer;
 
 use Broadway\Repository\Repository;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
-use CultuurNet\UDB3\Address\AddressFormatterInterface;
+use CultuurNet\UDB3\Address\AddressFormatter;
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
 use CultuurNet\UDB3\Offer\Commands\AbstractUpdateGeoCoordinatesFromAddress;
 use Psr\Log\LoggerAwareInterface;
@@ -23,12 +23,12 @@ abstract class AbstractGeoCoordinatesCommandHandler extends Udb3CommandHandler i
     private $offerRepository;
 
     /**
-     * @var AddressFormatterInterface
+     * @var AddressFormatter
      */
     private $defaultAddressFormatter;
 
     /**
-     * @var AddressFormatterInterface
+     * @var AddressFormatter
      */
     private $fallbackAddressFormatter;
 
@@ -39,8 +39,8 @@ abstract class AbstractGeoCoordinatesCommandHandler extends Udb3CommandHandler i
 
     public function __construct(
         Repository $placeRepository,
-        AddressFormatterInterface $defaultAddressFormatter,
-        AddressFormatterInterface $fallbackAddressFormatter,
+        AddressFormatter $defaultAddressFormatter,
+        AddressFormatter $fallbackAddressFormatter,
         GeocodingService $geocodingService
     ) {
         $this->offerRepository = $placeRepository;

--- a/src/Organizer/CommandHandler/UpdateGeoCoordinatesFromAddressCommandHandler.php
+++ b/src/Organizer/CommandHandler/UpdateGeoCoordinatesFromAddressCommandHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Organizer\CommandHandler;
 
 use CultuurNet\UDB3\Geocoding\GeocodingService;
-use CultuurNet\UDB3\Address\AddressFormatterInterface;
+use CultuurNet\UDB3\Address\AddressFormatter;
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
 use CultuurNet\UDB3\Organizer\Commands\UpdateGeoCoordinatesFromAddress;
 use CultuurNet\UDB3\Organizer\Organizer;
@@ -15,16 +15,16 @@ class UpdateGeoCoordinatesFromAddressCommandHandler extends Udb3CommandHandler
 {
     private OrganizerRepository $organizerRepository;
 
-    private AddressFormatterInterface $defaultAddressFormatter;
+    private AddressFormatter $defaultAddressFormatter;
 
-    private AddressFormatterInterface $fallbackAddressFormatter;
+    private AddressFormatter $fallbackAddressFormatter;
 
     private GeocodingService $geocodingService;
 
     public function __construct(
         OrganizerRepository $organizerRepository,
-        AddressFormatterInterface $defaultAddressFormatter,
-        AddressFormatterInterface $fallbackAddressFormatter,
+        AddressFormatter $defaultAddressFormatter,
+        AddressFormatter $fallbackAddressFormatter,
         GeocodingService $geocodingService
     ) {
         $this->organizerRepository = $organizerRepository;

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -8,7 +8,9 @@ use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListener;
 use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Address\AddressFormatter;
+use CultuurNet\UDB3\Address\AddressParser;
 use CultuurNet\UDB3\Address\FullAddressFormatter;
+use CultuurNet\UDB3\Address\ParsedAddress;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
@@ -29,6 +31,7 @@ final class RdfProjector implements EventListener
     private MainLanguageRepository $mainLanguageRepository;
     private GraphRepository $graphRepository;
     private IriGeneratorInterface $iriGenerator;
+    private AddressParser $addressParser;
     private AddressFormatter $addressFormatter;
 
     private const TYPE_LOCATIE = 'dcterms:Location';
@@ -48,6 +51,8 @@ final class RdfProjector implements EventListener
     private const PROPERTY_IDENTIFICATOR_LOKALE_IDENTIFICATOR = 'generiek:lokaleIdentificator';
     private const PROPERTY_IDENTIFICATOR_VERSIE_ID = 'generiek:versieIdentificator';
 
+    private const PROPERTY_ADRES_STRAATNAAM = 'locn:thoroughfare';
+    private const PROPERTY_ADRES_HUISNUMMER = 'locn:locatorDesignator';
     private const PROPERTY_ADRES_POSTCODE = 'locn:postcode';
     private const PROPERTY_ADRES_GEMEENTENAAM = 'locn:postName';
     private const PROPERTY_ADRES_LAND = 'locn:adminUnitL1';
@@ -56,11 +61,13 @@ final class RdfProjector implements EventListener
     public function __construct(
         MainLanguageRepository $mainLanguageRepository,
         GraphRepository $graphRepository,
-        IriGeneratorInterface $iriGenerator
+        IriGeneratorInterface $iriGenerator,
+        AddressParser $addressParser
     ) {
         $this->mainLanguageRepository = $mainLanguageRepository;
         $this->graphRepository = $graphRepository;
         $this->iriGenerator = $iriGenerator;
+        $this->addressParser = $addressParser;
         $this->addressFormatter = new FullAddressFormatter();
     }
 
@@ -177,19 +184,9 @@ final class RdfProjector implements EventListener
 
     private function handleAddressUpdated(AddressUpdated $event, string $uri, Graph $graph): void
     {
-        $mainLanguage = $this->mainLanguageRepository->get($uri, new Language('nl'))->toString();
-        $this->updateAddress($graph->resource($uri), $event->getAddress(), $mainLanguage);
-        $this->graphRepository->save($uri, $graph);
-    }
+        $resource = $graph->resource($uri);
+        $address = $event->getAddress();
 
-    private function handleAddressTranslated(AddressTranslated $event, string $uri, Graph $graph): void
-    {
-        $this->updateAddress($graph->resource($uri), $event->getAddress(), $event->getLanguage()->getCode());
-        $this->graphRepository->save($uri, $graph);
-    }
-
-    private function updateAddress(Resource $resource, Address $address, string $language): void
-    {
         if (!$resource->hasProperty(self::PROPERTY_LOCATIE_ADRES)) {
             $resource->add(self::PROPERTY_LOCATIE_ADRES, $resource->getGraph()->newBNode());
         }
@@ -209,11 +206,93 @@ final class RdfProjector implements EventListener
             $addressResource->set(self::PROPERTY_ADRES_POSTCODE, $postalCode);
         }
 
+        $parsedAddress = $this->addressParser->parse($this->addressFormatter->format($address));
+        $houseNumber = $parsedAddress ? $parsedAddress->getHouseNumber() : null;
+        if ($houseNumber !== null) {
+            $addressResource->set(self::PROPERTY_ADRES_HUISNUMMER, $houseNumber);
+        }
+
+        $mainLanguage = $this->mainLanguageRepository->get($uri, new Language('nl'))->toString();
+        $this->updateTranslatableAddressProperties($resource, $address, $parsedAddress, $mainLanguage);
+
+        $this->graphRepository->save($uri, $graph);
+    }
+
+    private function handleAddressTranslated(AddressTranslated $event, string $uri, Graph $graph): void
+    {
+        $address = $event->getAddress();
+
+        // Only update the translatable address properties. We do not update other properties that are not translatable
+        // in locn like postcode, locatorDesignator or adminUnitL1 here because we assume that the values from the main
+        // language (set by handleAddressUpdated) are the source of truth, and any deviation in those propeties in
+        // AddressTranslated is a mistake since those properties are not translatable in reality, but they are in UDB3
+        // because of a historical design flaw.
+        $this->updateTranslatableAddressProperties(
+            $graph->resource($uri),
+            $address,
+            $this->addressParser->parse($this->addressFormatter->format($address)),
+            $event->getLanguage()->getCode()
+        );
+
+        $this->graphRepository->save($uri, $graph);
+    }
+
+    private function updateTranslatableAddressProperties(
+        Resource $resource,
+        Address $address,
+        ?ParsedAddress $parsedAddress,
+        string $language
+    ): void {
+        /** @var Resource|null $addressResource */
+        $addressResource = $resource->getResource(self::PROPERTY_LOCATIE_ADRES);
+        if ($addressResource === null) {
+            // This is a case that should not happen in reality, since every new place should get a locn:Address via
+            // handleAddressUpdated().
+            return;
+        }
+
+        // The locn:fullAddress predicate is set per language since it contains language-specific info like the street
+        // name and municipality name. It is included because not all addresses can be parsed into the expected
+        // thoroughfare and house number, so in those cases at least the full address is completed and consumers can
+        // always try to parse it themselves if wanted.
+        $formatted = $this->addressFormatter->format($address);
+        $this->replaceLanguageValue($addressResource, self::PROPERTY_ADRES_VOLLEDIG_ADRES, $formatted, $language);
+
+        // Always set the locn:postName predicate based on the Address, not the ParsedAddress, because in some cases an
+        // address cannot be parsed (e.g. it's outside of Belgium, or the street address could not be parsed/found), but
+        // the original address always contains the right municipality in any case.
         $locality = $address->getLocality()->toNative();
         $this->replaceLanguageValue($addressResource, self::PROPERTY_ADRES_GEMEENTENAAM, $locality, $language);
 
-        $formattedAddress = $this->addressFormatter->format($address);
-        $this->replaceLanguageValue($addressResource, self::PROPERTY_ADRES_VOLLEDIG_ADRES, $formattedAddress, $language);
+        // Only set the locn:thoroughfare predicate based on the ParsedAddress (if given), not the street in the
+        // original Address, because locn:thoroughfare MUST NOT contain a house number. If there is no ParsedAddress
+        // remove the value for the given language instead since it will probably be outdated (if set previously).
+        // Keep in mind that locn:thoroughfare is optional.
+        if ($parsedAddress) {
+            $thoroughfare = $parsedAddress->getThoroughfare();
+            $this->replaceLanguageValue($addressResource, self::PROPERTY_ADRES_STRAATNAAM, $thoroughfare, $language);
+        } else {
+            $this->deleteLanguageValue($addressResource, self::PROPERTY_ADRES_STRAATNAAM, $language);
+        }
+    }
+
+    private function deleteLanguageValue(
+        Resource $resource,
+        string $property,
+        string $language
+    ): void {
+        // Get all literal values for the property, and key them by their language tag.
+        // This will be an empty list if no value(s) are set for this property.
+        $literalValues = $resource->allLiterals($property);
+        $languages = array_map(fn (Literal $literal): string => $literal->getLang(), $literalValues);
+        $literalValuePerLanguage = array_combine($languages, $literalValues);
+
+        // Remove the value for the given language.
+        unset($literalValuePerLanguage[$language]);
+
+        // Remove all existing values of the property, then (re)add them in the intended order.
+        $resource->delete($property);
+        $resource->addLiteral($property, array_values($literalValuePerLanguage));
     }
 
     private function replaceLanguageValue(

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -56,13 +56,12 @@ final class RdfProjector implements EventListener
     public function __construct(
         MainLanguageRepository $mainLanguageRepository,
         GraphRepository $graphRepository,
-        IriGeneratorInterface $iriGenerator,
-        ?AddressFormatter $addressFormatter = null
+        IriGeneratorInterface $iriGenerator
     ) {
         $this->mainLanguageRepository = $mainLanguageRepository;
         $this->graphRepository = $graphRepository;
         $this->iriGenerator = $iriGenerator;
-        $this->addressFormatter = $addressFormatter ?? new FullAddressFormatter();
+        $this->addressFormatter = new FullAddressFormatter();
     }
 
     public function handle(DomainMessage $domainMessage): void

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -8,7 +8,7 @@ use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListener;
 use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Address\AddressFormatter;
-use CultuurNet\UDB3\Address\DefaultAddressFormatter;
+use CultuurNet\UDB3\Address\FullAddressFormatter;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
@@ -62,7 +62,7 @@ final class RdfProjector implements EventListener
         $this->mainLanguageRepository = $mainLanguageRepository;
         $this->graphRepository = $graphRepository;
         $this->iriGenerator = $iriGenerator;
-        $this->addressFormatter = $addressFormatter ?? new DefaultAddressFormatter();
+        $this->addressFormatter = $addressFormatter ?? new FullAddressFormatter();
     }
 
     public function handle(DomainMessage $domainMessage): void

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -48,6 +48,7 @@ final class RdfProjector implements EventListener
     private const PROPERTY_ADRES_POSTCODE = 'locn:postcode';
     private const PROPERTY_ADRES_GEMEENTENAAM = 'locn:postName';
     private const PROPERTY_ADRES_LAND = 'locn:adminUnitL1';
+    private const PROPERTY_ADRES_VOLLEDIG_ADRES = 'locn:fullAddress';
 
     public function __construct(
         MainLanguageRepository $mainLanguageRepository,
@@ -206,6 +207,13 @@ final class RdfProjector implements EventListener
 
         $locality = $address->getLocality()->toNative();
         $this->replaceLanguageValue($addressResource, self::PROPERTY_ADRES_GEMEENTENAAM, $locality, $language);
+
+        $formattedAddress = implode(", ", [
+            $address->getStreetAddress()->toNative(),
+            $address->getPostalCode()->toNative() . ' ' . $address->getLocality()->toNative(),
+            $address->getCountryCode()->toString()
+        ]);
+        $this->replaceLanguageValue($addressResource, self::PROPERTY_ADRES_VOLLEDIG_ADRES, $formattedAddress, $language);
     }
 
     private function replaceLanguageValue(

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
 use CultuurNet\UDB3\Place\Events\TitleUpdated;
@@ -73,6 +74,7 @@ final class RdfProjector implements EventListener
             TitleUpdated::class => fn ($e) => $this->handleTitleUpdated($e, $uri, $graph),
             TitleTranslated::class => fn ($e) => $this->handleTitleTranslated($e, $uri, $graph),
             AddressUpdated::class => fn ($e) => $this->handleAddressUpdated($e, $uri, $graph),
+            AddressTranslated::class => fn ($e) => $this->handleAddressTranslated($e, $uri, $graph),
         ];
 
         foreach ($events as $event) {
@@ -172,6 +174,12 @@ final class RdfProjector implements EventListener
     {
         $mainLanguage = $this->mainLanguageRepository->get($uri, new Language('nl'))->toString();
         $this->updateAddress($graph->resource($uri), $event->getAddress(), $mainLanguage);
+        $this->graphRepository->save($uri, $graph);
+    }
+
+    private function handleAddressTranslated(AddressTranslated $event, string $uri, Graph $graph): void
+    {
+        $this->updateAddress($graph->resource($uri), $event->getAddress(), $event->getLanguage()->getCode());
         $this->graphRepository->save($uri, $graph);
     }
 

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Place\ReadModel\RDF;
 use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListener;
 use CultuurNet\UDB3\Address\Address;
-use CultuurNet\UDB3\Address\AddressFormatterInterface;
+use CultuurNet\UDB3\Address\AddressFormatter;
 use CultuurNet\UDB3\Address\DefaultAddressFormatter;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
@@ -29,7 +29,7 @@ final class RdfProjector implements EventListener
     private MainLanguageRepository $mainLanguageRepository;
     private GraphRepository $graphRepository;
     private IriGeneratorInterface $iriGenerator;
-    private AddressFormatterInterface $addressFormatter;
+    private AddressFormatter $addressFormatter;
 
     private const TYPE_LOCATIE = 'dcterms:Location';
     private const TYPE_IDENTIFICATOR = 'adms:Identifier';
@@ -57,7 +57,7 @@ final class RdfProjector implements EventListener
         MainLanguageRepository $mainLanguageRepository,
         GraphRepository $graphRepository,
         IriGeneratorInterface $iriGenerator,
-        ?AddressFormatterInterface $addressFormatter = null
+        ?AddressFormatter $addressFormatter = null
     ) {
         $this->mainLanguageRepository = $mainLanguageRepository;
         $this->graphRepository = $graphRepository;

--- a/tests/Address/DefaultAddressFormatterTest.php
+++ b/tests/Address/DefaultAddressFormatterTest.php
@@ -14,7 +14,7 @@ class DefaultAddressFormatterTest extends TestCase
      */
     public function it_formats_addresses()
     {
-        $formatter = new DefaultAddressFormatter();
+        $formatter = new FullAddressFormatter();
 
         $address = new Address(
             new Street('Martelarenlaan 1'),

--- a/tests/Address/GeopuntAddressParserTest.php
+++ b/tests/Address/GeopuntAddressParserTest.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Address;
+
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\TestLogger;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Http\Message\Builder\ResponseBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+
+class GeopuntAddressParserTest extends TestCase
+{
+    /** @var ClientInterface&MockObject  */
+    private ClientInterface $httpClient;
+    private GeopuntAddressParser $geopuntAddressParser;
+    private TestLogger $logger;
+    private TestLogger $expectedLogs;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $this->geopuntAddressParser = new GeopuntAddressParser($this->httpClient);
+
+        $this->logger = new TestLogger();
+        $this->geopuntAddressParser->setLogger($this->logger);
+
+        $this->expectedLogs = new TestLogger();
+    }
+
+    /**
+     * @test
+     */
+    public function it_looks_up_the_given_address_in_the_geopunt_api_and_returns_a_parsed_address(): void
+    {
+        $address = 'Martelarenplein 1, 3000 Leuven, BE';
+
+        $expectedRequest = new Request(
+            'GET',
+            'https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE'
+        );
+
+        $mockResponseData = [
+            'LocationResult' => [
+                [
+                    'Municipality' => 'Leuven',
+                    'Zipcode' => '3000',
+                    'Thoroughfarename' => 'Martelarenplein',
+                    'Housenumber' => '12',
+                ],
+            ],
+        ];
+        $mockResponse = new Response(200, [], Json::encode($mockResponseData));
+
+        $this->httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($expectedRequest)
+            ->willReturn($mockResponse);
+
+        $expectedParsedAddress = new ParsedAddress(
+            'Martelarenplein',
+            '12',
+            '3000',
+            'Leuven'
+        );
+
+        $this->expectedLogs->info('GET https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE responded with status code 200 and body {"LocationResult":[{"Municipality":"Leuven","Zipcode":"3000","Thoroughfarename":"Martelarenplein","Housenumber":"12"}]}');
+        $this->expectedLogs->info('Successfully parsed response body.');
+
+        $actualParsedAddress = $this->geopuntAddressParser->parse($address);
+
+        $this->assertEquals($expectedParsedAddress, $actualParsedAddress);
+        $this->assertLogs();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_housenumber_being_null(): void
+    {
+        $address = 'Martelarenplein 1, 3000 Leuven, BE';
+
+        $expectedRequest = new Request(
+            'GET',
+            'https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE'
+        );
+
+        $mockResponseData = [
+            'LocationResult' => [
+                [
+                    'Municipality' => 'Leuven',
+                    'Zipcode' => '3000',
+                    'Thoroughfarename' => 'Martelarenplein',
+                    'Housenumber' => null,
+                ],
+            ],
+        ];
+        $mockResponse = new Response(200, [], Json::encode($mockResponseData));
+
+        $this->httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($expectedRequest)
+            ->willReturn($mockResponse);
+
+        $expectedParsedAddress = new ParsedAddress(
+            'Martelarenplein',
+            null,
+            '3000',
+            'Leuven'
+        );
+
+        $this->expectedLogs->info('GET https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE responded with status code 200 and body {"LocationResult":[{"Municipality":"Leuven","Zipcode":"3000","Thoroughfarename":"Martelarenplein","Housenumber":null}]}');
+        $this->expectedLogs->info('Successfully parsed response body.');
+
+        $actualParsedAddress = $this->geopuntAddressParser->parse($address);
+
+        $this->assertEquals($expectedParsedAddress, $actualParsedAddress);
+        $this->assertLogs();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_json_syntax_errors(): void
+    {
+        $address = 'Martelarenplein 1, 3000 Leuven, BE';
+
+        $expectedRequest = new Request(
+            'GET',
+            'https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE'
+        );
+
+        $mockResponse = new Response(200, [], '{{}');
+
+        $this->httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($expectedRequest)
+            ->willReturn($mockResponse);
+
+        $this->expectedLogs->info('GET https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE responded with status code 200 and body {{}');
+        $this->expectedLogs->error('Caught \JsonException while decoding response body.', ['message' => 'Syntax error']);
+
+        $actualParsedAddress = $this->geopuntAddressParser->parse($address);
+
+        $this->assertNull($actualParsedAddress);
+        $this->assertLogs();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_missing_LocationResult_property(): void
+    {
+        $address = 'Martelarenplein 1, 3000 Leuven, BE';
+
+        $expectedRequest = new Request(
+            'GET',
+            'https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE'
+        );
+
+        $mockResponse = new Response(200, [], '{}');
+
+        $this->httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($expectedRequest)
+            ->willReturn($mockResponse);
+
+        $this->expectedLogs->info('GET https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE responded with status code 200 and body {}');
+        $this->expectedLogs->error(
+            'Response body did not match the expected JSON schema. Did the API introduce a breaking change?',
+            [
+                'errors' => [
+                    '/' => [
+                        0 => 'The required properties (LocationResult) are missing',
+                    ],
+                ],
+            ]
+        );
+
+        $actualParsedAddress = $this->geopuntAddressParser->parse($address);
+
+        $this->assertNull($actualParsedAddress);
+        $this->assertLogs();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_missing_properties_inside_LocationResult(): void
+    {
+        $address = 'Martelarenplein 1, 3000 Leuven, BE';
+
+        $expectedRequest = new Request(
+            'GET',
+            'https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE'
+        );
+
+        $mockResponseData = [
+            'LocationResult' => [
+                (object) [],
+            ],
+        ];
+        $mockResponse = new Response(200, [], Json::encode($mockResponseData));
+
+        $this->httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($expectedRequest)
+            ->willReturn($mockResponse);
+
+        $this->expectedLogs->info('GET https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE responded with status code 200 and body {"LocationResult":[{}]}');
+        $this->expectedLogs->error(
+            'Response body did not match the expected JSON schema. Did the API introduce a breaking change?',
+            [
+                'errors' => [
+                    '/LocationResult/0' => [
+                        0 => 'The required properties (Municipality, Zipcode, Thoroughfarename, Housenumber) are missing',
+                    ],
+                ],
+            ]
+        );
+
+        $actualParsedAddress = $this->geopuntAddressParser->parse($address);
+
+        $this->assertNull($actualParsedAddress);
+        $this->assertLogs();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_incorrect_property_values_inside_LocationResult(): void
+    {
+        $address = 'Martelarenplein 1, 3000 Leuven, BE';
+
+        $expectedRequest = new Request(
+            'GET',
+            'https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE'
+        );
+
+        $mockResponseData = [
+            'LocationResult' => [
+                [
+                    'Municipality' => 8,
+                    'Zipcode' => null,
+                    'Thoroughfarename' => false,
+                    'Housenumber' => [],
+                ],
+            ],
+        ];
+        $mockResponse = new Response(200, [], Json::encode($mockResponseData));
+
+        $this->httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($expectedRequest)
+            ->willReturn($mockResponse);
+
+        $this->expectedLogs->info('GET https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE responded with status code 200 and body {"LocationResult":[{"Municipality":8,"Zipcode":null,"Thoroughfarename":false,"Housenumber":[]}]}');
+        $this->expectedLogs->error(
+            'Response body did not match the expected JSON schema. Did the API introduce a breaking change?',
+            [
+                'errors' => [
+                    '/LocationResult/0/Municipality' => [
+                        0 => 'The data (integer) must match the type: string',
+                    ],
+                    '/LocationResult/0/Zipcode' => [
+                        0 => 'The data (null) must match the type: string',
+                    ],
+                    '/LocationResult/0/Thoroughfarename' => [
+                        0 => 'The data (boolean) must match the type: string',
+                    ],
+                    '/LocationResult/0/Housenumber' => [
+                        0 => 'The data (array) must match the type: string',
+                        1 => 'The data (array) must match the type: null',
+                    ],
+                ],
+            ]
+        );
+
+        $actualParsedAddress = $this->geopuntAddressParser->parse($address);
+
+        $this->assertNull($actualParsedAddress);
+        $this->assertLogs();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_an_empty_LocationResult(): void
+    {
+        $address = 'Martelarenplein 1, 3000 Leuven, BE';
+
+        $expectedRequest = new Request(
+            'GET',
+            'https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE'
+        );
+
+        $mockResponseData = [
+            'LocationResult' => [],
+        ];
+        $mockResponse = new Response(200, [], Json::encode($mockResponseData));
+
+        $this->httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($expectedRequest)
+            ->willReturn($mockResponse);
+
+        $this->expectedLogs->info('GET https://loc.geopunt.be/v4/Location?q=Martelarenplein%201,%203000%20Leuven,%20BE responded with status code 200 and body {"LocationResult":[]}');
+        $this->expectedLogs->info('Response body did not contain any array items inside "LocationResult" property. Either the address is not located in Belgium, or it is not recognized as an official address.');
+
+        $actualParsedAddress = $this->geopuntAddressParser->parse($address);
+
+        $this->assertNull($actualParsedAddress);
+        $this->assertLogs();
+    }
+
+    private function assertLogs(): void
+    {
+        $this->assertEquals($this->expectedLogs->getLogs(), $this->logger->getLogs());
+    }
+}

--- a/tests/Address/GeopuntAddressParserTest.php
+++ b/tests/Address/GeopuntAddressParserTest.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\TestLogger;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use Http\Message\Builder\ResponseBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;

--- a/tests/Event/GeoCoordinatesCommandHandlerTest.php
+++ b/tests/Event/GeoCoordinatesCommandHandlerTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
 use CultuurNet\UDB3\Address\Address;
-use CultuurNet\UDB3\Address\AddressFormatterInterface;
+use CultuurNet\UDB3\Address\AddressFormatter;
 use CultuurNet\UDB3\Address\DefaultAddressFormatter;
 use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\LocalityAddressFormatter;
@@ -34,12 +34,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
 {
     /**
-     * @var AddressFormatterInterface
+     * @var AddressFormatter
      */
     private $defaultAddressFormatter;
 
     /**
-     * @var AddressFormatterInterface
+     * @var AddressFormatter
      */
     private $localityAddressFormatter;
 

--- a/tests/Event/GeoCoordinatesCommandHandlerTest.php
+++ b/tests/Event/GeoCoordinatesCommandHandlerTest.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
 use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Address\AddressFormatter;
-use CultuurNet\UDB3\Address\DefaultAddressFormatter;
+use CultuurNet\UDB3\Address\FullAddressFormatter;
 use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\LocalityAddressFormatter;
 use CultuurNet\UDB3\Address\PostalCode;
@@ -55,7 +55,7 @@ class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
             $eventBus
         );
 
-        $this->defaultAddressFormatter = new DefaultAddressFormatter();
+        $this->defaultAddressFormatter = new FullAddressFormatter();
         $this->localityAddressFormatter = new LocalityAddressFormatter();
 
         $this->geocodingService = $this->createMock(GeocodingService::class);

--- a/tests/Organizer/CommandHandler/UpdateGeoCoordinatesCommandHandlerTest.php
+++ b/tests/Organizer/CommandHandler/UpdateGeoCoordinatesCommandHandlerTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
 use CultuurNet\UDB3\Address\Address;
-use CultuurNet\UDB3\Address\DefaultAddressFormatter;
+use CultuurNet\UDB3\Address\FullAddressFormatter;
 use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\LocalityAddressFormatter;
 use CultuurNet\UDB3\Address\PostalCode;
@@ -37,7 +37,7 @@ class UpdateGeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestC
 
         return new UpdateGeoCoordinatesFromAddressCommandHandler(
             new OrganizerRepository($eventStore, $eventBus),
-            new DefaultAddressFormatter(),
+            new FullAddressFormatter(),
             new LocalityAddressFormatter(),
             $this->geocodingService
         );

--- a/tests/Place/GeoCoordinatesCommandHandlerTest.php
+++ b/tests/Place/GeoCoordinatesCommandHandlerTest.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
 use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Address\AddressFormatter;
-use CultuurNet\UDB3\Address\DefaultAddressFormatter;
+use CultuurNet\UDB3\Address\FullAddressFormatter;
 use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\LocalityAddressFormatter;
 use CultuurNet\UDB3\Address\PostalCode;
@@ -53,7 +53,7 @@ class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
             $eventBus
         );
 
-        $this->defaultAddressFormatter = new DefaultAddressFormatter();
+        $this->defaultAddressFormatter = new FullAddressFormatter();
         $this->localityAddressFormatter = new LocalityAddressFormatter();
 
         $this->geocodingService = $this->createMock(GeocodingService::class);

--- a/tests/Place/GeoCoordinatesCommandHandlerTest.php
+++ b/tests/Place/GeoCoordinatesCommandHandlerTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
 use CultuurNet\UDB3\Address\Address;
-use CultuurNet\UDB3\Address\AddressFormatterInterface;
+use CultuurNet\UDB3\Address\AddressFormatter;
 use CultuurNet\UDB3\Address\DefaultAddressFormatter;
 use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\LocalityAddressFormatter;
@@ -32,12 +32,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
 {
     /**
-     * @var AddressFormatterInterface
+     * @var AddressFormatter
      */
     private $defaultAddressFormatter;
 
     /**
-     * @var AddressFormatterInterface
+     * @var AddressFormatter
      */
     private $localityAddressFormatter;
 

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -40,8 +40,7 @@ class RdfProjectorTest extends TestCase
     /** @var AddressParser&MockObject */
     private AddressParser $addressParser;
     private RdfProjector $rdfProjector;
-    /** @var array<string,ParsedAddress> */
-    private array $expectedParsedAddresses;
+    private array $expectedParsedAddresses = [];
 
     private LegacyAddress $defaultAddress;
 

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -40,7 +40,7 @@ class RdfProjectorTest extends TestCase
     /** @var AddressParser&MockObject */
     private AddressParser $addressParser;
     private RdfProjector $rdfProjector;
-    private array $expectedParsedAddresses = [];
+    private array $expectedParsedAddresses;
 
     private LegacyAddress $defaultAddress;
 
@@ -55,12 +55,12 @@ class RdfProjectorTest extends TestCase
             $this->addressParser
         );
 
-        $this->expectedParsedAddresses = [];
         $this->addressParser->expects($this->any())
             ->method('parse')
             ->willReturnCallback(
                 fn (string $formatted): ?ParsedAddress => $this->expectedParsedAddresses[$formatted] ?? null
             );
+        $this->expectedParsedAddresses = [];
 
         $this->defaultAddress = new LegacyAddress(
             new LegacyStreet('Martelarenlaan 1'),

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Event\EventType as LegacyEventType;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
 use CultuurNet\UDB3\Place\Events\TitleUpdated;
@@ -95,6 +96,27 @@ class RdfProjectorTest extends TestCase
             new TitleUpdated($placeId, new LegacyTitle('Voorbeeld titel UPDATED 2')),
         ]);
         $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/title-updated-and-translated.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_address_updated(): void
+    {
+        $placeId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+        $this->project($placeId, [
+            $this->getPlaceCreated($placeId),
+            new AddressUpdated(
+                $placeId,
+                new LegacyAddress(
+                    new LegacyStreet('Martelarenlaan 2'),
+                    new LegacyPostalCode('3002'),
+                    new LegacyLocality('Amsterdam'),
+                    new CountryCode('NL')
+                )
+            ),
+        ]);
+        $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/address-updated.ttl'));
     }
 
     private function getPlaceCreated(string $placeId): PlaceCreated

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -19,7 +19,6 @@ use CultuurNet\UDB3\CalendarType as LegacyCalendarType;
 use CultuurNet\UDB3\Event\EventType as LegacyEventType;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Language as LegacyLanguage;
-use CultuurNet\UDB3\Model\ValueObject\Geography\Address;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
@@ -41,7 +40,7 @@ class RdfProjectorTest extends TestCase
     /** @var AddressParser&MockObject */
     private AddressParser $addressParser;
     private RdfProjector $rdfProjector;
-    /** @var ParsedAddress[] $expectedParsedAddresses */
+    /** @var ParsedAddress[] */
     private array $expectedParsedAddresses;
 
     private LegacyAddress $defaultAddress;

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Event\EventType as LegacyEventType;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
@@ -117,6 +118,28 @@ class RdfProjectorTest extends TestCase
             ),
         ]);
         $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/address-updated.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_address_translated(): void
+    {
+        $placeId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+        $this->project($placeId, [
+            $this->getPlaceCreated($placeId),
+            new AddressTranslated(
+                $placeId,
+                new LegacyAddress(
+                    new LegacyStreet('Martelarenlaan 1'),
+                    new LegacyPostalCode('3000'),
+                    new LegacyLocality('Louvain'),
+                    new CountryCode('BE')
+                ),
+                new LegacyLanguage('fr')
+            ),
+        ]);
+        $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/address-translated.ttl'));
     }
 
     private function getPlaceCreated(string $placeId): PlaceCreated

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -40,7 +40,7 @@ class RdfProjectorTest extends TestCase
     /** @var AddressParser&MockObject */
     private AddressParser $addressParser;
     private RdfProjector $rdfProjector;
-    /** @var ParsedAddress[] */
+    /** @var array<string,ParsedAddress> */
     private array $expectedParsedAddresses;
 
     private LegacyAddress $defaultAddress;

--- a/tests/Place/ReadModel/RDF/data/address-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-translated.ttl
@@ -1,0 +1,26 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+
+<https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a dcterms:Location ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/locaties/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    generiek:naamruimte "https://mock.data.publiq.be/locaties/"^^xsd:string ;
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
+    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+  ] ;
+  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:address [
+    a locn:Address ;
+    locn:adminUnitL1 "BE" ;
+    locn:postcode "3000" ;
+    locn:postName "Leuven"@nl, "Louvain"@fr
+  ] ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime .

--- a/tests/Place/ReadModel/RDF/data/address-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-translated.ttl
@@ -21,6 +21,7 @@
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
     locn:postcode "3000" ;
-    locn:postName "Leuven"@nl, "Louvain"@fr
+    locn:postName "Leuven"@nl, "Louvain"@fr ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl, "Martelarenlaan 1, 3000 Louvain, BE"@fr
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime .

--- a/tests/Place/ReadModel/RDF/data/address-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-translated.ttl
@@ -21,7 +21,9 @@
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
     locn:postcode "3000" ;
+    locn:locatorDesignator "1" ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl, "Martelarenlaan 1, 3000 Louvain, BE"@fr ;
     locn:postName "Leuven"@nl, "Louvain"@fr ;
-    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl, "Martelarenlaan 1, 3000 Louvain, BE"@fr
+    locn:thoroughfare "Martelarenlaan"@nl, "Martelarenlaan"@fr
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime .

--- a/tests/Place/ReadModel/RDF/data/address-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-updated.ttl
@@ -16,11 +16,11 @@
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
   ] ;
+  locn:geographicName "Voorbeeld titel"@nl ;
   locn:address [
     a locn:Address ;
-    locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
-    locn:postName "Leuven"@nl
+    locn:adminUnitL1 "NL" ;
+    locn:postcode "3002" ;
+    locn:postName "Amsterdam"@nl
   ] ;
-  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
-  locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime .

--- a/tests/Place/ReadModel/RDF/data/address-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-updated.ttl
@@ -21,6 +21,7 @@
     a locn:Address ;
     locn:adminUnitL1 "NL" ;
     locn:postcode "3002" ;
-    locn:postName "Amsterdam"@nl
+    locn:postName "Amsterdam"@nl ;
+    locn:fullAddress "Martelarenlaan 2, 3002 Amsterdam, NL"@nl
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime .

--- a/tests/Place/ReadModel/RDF/data/address-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-updated.ttl
@@ -19,9 +19,10 @@
   locn:geographicName "Voorbeeld titel"@nl ;
   locn:address [
     a locn:Address ;
+    locn:locatorDesignator "1" ;
     locn:adminUnitL1 "NL" ;
     locn:postcode "3002" ;
-    locn:postName "Amsterdam"@nl ;
-    locn:fullAddress "Martelarenlaan 2, 3002 Amsterdam, NL"@nl
+    locn:fullAddress "Martelarenlaan 2, 3002 Amsterdam, NL"@nl ;
+    locn:postName "Amsterdam"@nl
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -22,5 +22,6 @@
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
     locn:postcode "3000" ;
-    locn:postName "Leuven"@nl
+    locn:postName "Leuven"@nl ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl
   ] .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -17,4 +17,10 @@
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-01T12:30:15+01:00"^^xsd:string
   ] ;
-  locn:geographicName "Voorbeeld titel"@nl .
+  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:address [
+    a locn:Address ;
+    locn:adminUnitL1 "BE" ;
+    locn:postcode "3000" ;
+    locn:postName "Leuven"@nl
+  ] .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -22,6 +22,8 @@
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
     locn:postcode "3000" ;
+    locn:locatorDesignator "1" ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;
-    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl
+    locn:thoroughfare "Martelarenlaan"@nl
   ] .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -20,7 +20,8 @@
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
     locn:postcode "3000" ;
-    locn:postName "Leuven"@nl
+    locn:postName "Leuven"@nl ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -20,8 +20,10 @@
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
     locn:postcode "3000" ;
+    locn:locatorDesignator "1" ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;
-    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl
+    locn:thoroughfare "Martelarenlaan"@nl
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel"@nl, "Example title"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -20,7 +20,8 @@
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
     locn:postcode "3000" ;
-    locn:postName "Leuven"@nl
+    locn:postName "Leuven"@nl ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl
   ] ;
   dcterms:modified "2023-01-05T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -16,5 +16,11 @@
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-05T12:30:15+01:00"^^xsd:string
   ] ;
+  locn:address [
+    a locn:Address ;
+    locn:adminUnitL1 "BE" ;
+    locn:postcode "3000" ;
+    locn:postName "Leuven"@nl
+  ] ;
   dcterms:modified "2023-01-05T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -20,8 +20,10 @@
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
     locn:postcode "3000" ;
+    locn:locatorDesignator "1" ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;
-    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl
+    locn:thoroughfare "Martelarenlaan"@nl
   ] ;
   dcterms:modified "2023-01-05T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED 2"@nl, "Example title UPDATED"@en .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -20,8 +20,10 @@
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
     locn:postcode "3000" ;
+    locn:locatorDesignator "1" ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;
-    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl
+    locn:thoroughfare "Martelarenlaan"@nl
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -16,5 +16,11 @@
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
   ] ;
+  locn:address [
+    a locn:Address ;
+    locn:adminUnitL1 "BE" ;
+    locn:postcode "3000" ;
+    locn:postName "Leuven"@nl
+  ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -20,7 +20,8 @@
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
     locn:postcode "3000" ;
-    locn:postName "Leuven"@nl
+    locn:postName "Leuven"@nl ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   locn:geographicName "Voorbeeld titel UPDATED"@nl .

--- a/tests/TestLogger.php
+++ b/tests/TestLogger.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3;
+
+use Psr\Log\LoggerInterface;
+
+final class TestLogger implements LoggerInterface
+{
+    private array $logs = [];
+
+    public function getLogs(): array
+    {
+        return $this->logs;
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->logs[] = [
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        ];
+    }
+
+    public function emergency($message, array $context = []): void
+    {
+        $this->log('emergency', $message, $context);
+    }
+
+    public function alert($message, array $context = []): void
+    {
+        $this->log('alert', $message, $context);
+    }
+
+    public function critical($message, array $context = []): void
+    {
+        $this->log('critical', $message, $context);
+    }
+
+    public function error($message, array $context = []): void
+    {
+        $this->log('error', $message, $context);
+    }
+
+    public function warning($message, array $context = []): void
+    {
+        $this->log('warning', $message, $context);
+    }
+
+    public function notice($message, array $context = []): void
+    {
+        $this->log('notice', $message, $context);
+    }
+
+    public function info($message, array $context = []): void
+    {
+        $this->log('info', $message, $context);
+    }
+
+    public function debug($message, array $context = []): void
+    {
+        $this->log('debug', $message, $context);
+    }
+}


### PR DESCRIPTION
### Added

- Projection of `locn:address` predicate on places with `locn:Address` node with `locn:fullAddress`, `locn:thoroughfare`, `locn:locatorDesignator`, `locn:postcode`, `locn:postName`, `locn:adminUnitL1`
- `GeopuntAddressParser` to look up the thoroughfare and house number of an address given a formatted address, so that we can convert the "streetAddress" in the UDB3 data to a separate street (thoroughfare) & house number

### Changed

- Removed `Interface` suffix from `AddressFormatter(Interface)`
- Renamed `DefaultAddressFormatter` to `FullAddressFormatter`

---
Ticket: https://jira.uitdatabank.be/browse/III-5357
