### PR TITLE
III-5422 Fix events with incorrect PlaceType 

### DIFF
--- a/app/Console/Command/ChangePlaceTypeOnEvents.php
+++ b/app/Console/Command/ChangePlaceTypeOnEvents.php
@@ -23,7 +23,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
     private int $success;
 
     public function __construct(
-        CommandBus             $commandBus,
+        CommandBus $commandBus,
         SearchServiceInterface $searchService
     ) {
         $this->searchService = $searchService;

--- a/app/Console/Command/ChangePlaceTypeOnEvents.php
+++ b/app/Console/Command/ChangePlaceTypeOnEvents.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Console\Command;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Offer\Commands\UpdateType;
+use CultuurNet\UDB3\Search\ResultsGenerator;
+use CultuurNet\UDB3\Search\SearchServiceInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+final class ChangePlaceTypeOnEvents extends AbstractCommand
+{
+    private SearchServiceInterface $searchService;
+
+    private int $errors;
+
+    private int $success;
+
+    public function __construct(
+        CommandBus             $commandBus,
+        SearchServiceInterface $searchService
+    )
+    {
+        $this->searchService = $searchService;
+        $this->errors = 0;
+        $this->success = 0;
+        parent::__construct($commandBus);
+    }
+
+    public function configure(): void
+    {
+        $this->setName('event:place-eventtype:update');
+
+        $this->setDescription(
+            'Updates all events with an Place eventType and set availableFrom far in the future'
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $logger = new ConsoleLogger($output);
+
+        $mapping = $this->getMapping();
+
+        foreach ($mapping as $placeType => $correctEventType) {
+            $resultsGenerator = new ResultsGenerator(
+                $this->searchService,
+                ['created' => 'asc'],
+                100
+            );
+
+            $query = 'terms.id:' . $placeType;
+            if (!$this->askConfirmation($input, $output, $resultsGenerator->count($query), $placeType, $correctEventType)) {
+                return 0;
+            }
+
+            $events = $resultsGenerator->search($query);
+
+            foreach ($events as $event) {
+                $eventId = $event->getId();
+                try {
+                    $this->commandBus->dispatch(new UpdateType($eventId, $correctEventType));
+                    $logger->info(
+                        'Successfully changed type of event "' . $eventId . '" to  "' . $correctEventType . '"'
+                    );
+                    $this->success++;
+                } catch (\Throwable $t) {
+                    $logger->error(
+                        sprintf(
+                            'An error occurred while changing type of event "%s": %s with message %s',
+                            $eventId,
+                            get_class($t),
+                            $t->getMessage()
+                        )
+                    );
+                    $this->errors++;
+                }
+            }
+
+            $logger->info('Successfully changed the eventType of  ' . $this->success . ' events');
+
+            if ($this->errors) {
+                $logger->error('Failed to change type of ' . $this->errors . ' events');
+            }
+        }
+        return $this->errors;
+    }
+
+    private function askConfirmation(
+        InputInterface  $input,
+        OutputInterface $output,
+        int             $count,
+        string          $faultyEventType,
+        string          $correctEventType
+    ): bool
+    {
+        return $this
+            ->getHelper('question')
+            ->ask(
+                $input,
+                $output,
+                new ConfirmationQuestion(
+                    "This action will change {$faultyEventType} to {$correctEventType} on {$count} events, continue? [y/N] ",
+                    false
+                )
+            );
+    }
+
+    private function getMapping(): array
+    {
+        return [
+            'kI7uAyn2uUu9VV6Z3uWZTA' => '0.3.1.0.0',
+            'BtVNd33sR0WntjALVbyp3w' => '0.50.6.0.0',
+            'Yf4aZBfsUEu2NsQqsprngw' => '0.12.0.0.0',
+            'YVBc8KVdrU6XfTNvhMYUpg' => '0.49.0.0.0',
+            'ekdc4ATGoUitCa0e6me6xA' => '0.28.0.0.0',
+            'JCjA0i5COUmdjMwcyjNAFA' => '0.3.1.0.1',
+            '0.14.0.0.0' => '0.7.0.0.0',
+            'GnPFp9uvOUyqhOckIFMKmg' => '0.0.0.0.0',
+            '0.15.0.0.0' => '0.17.0.0.0',
+            '0.8.0.0.0' => '0.28.0.0.0',
+            '0.53.0.0.0' => '0.12.0.0.0',
+            'rJRFUqmd6EiqTD4c7HS90w' => '0.12.0.0.0',
+            'eBwaUAAhw0ur0Z02i5ttnw' => '0.59.0.0.0',
+            '8.70.0.0.0' => '0.55.0.0.0',
+            '0.41.0.0.0' => '0.28.0.0.0',
+            'VRC6HX0Wa063sq98G5ciqw' => '0.12.0.0.0',
+            'OyaPaf64AEmEAYXHeLMAtA' => '0.6.0.0.0',
+        ];
+    }
+}

--- a/app/Console/Command/ChangePlaceTypeOnEvents.php
+++ b/app/Console/Command/ChangePlaceTypeOnEvents.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Console\Command;
 
 use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Event\Events\AvailableFromUpdated;
 use CultuurNet\UDB3\Offer\Commands\UpdateType;
 use CultuurNet\UDB3\Search\ResultsGenerator;
 use CultuurNet\UDB3\Search\SearchServiceInterface;
@@ -24,8 +25,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
     public function __construct(
         CommandBus             $commandBus,
         SearchServiceInterface $searchService
-    )
-    {
+    ) {
         $this->searchService = $searchService;
         $this->errors = 0;
         $this->success = 0;
@@ -66,8 +66,9 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
                 $eventId = $event->getId();
                 try {
                     $this->commandBus->dispatch(new UpdateType($eventId, $correctEventType));
+                    $this->commandBus->dispatch(new AvailableFromUpdated($eventId, \DateTimeImmutable::createFromFormat('Y-m-d', '2100-01-01')));
                     $logger->info(
-                        'Successfully changed type of event "' . $eventId . '" to  "' . $correctEventType . '"'
+                        'Successfully changed type and availableFrom of event "' . $eventId . '" to  "' . $correctEventType . '"'
                     );
                     $this->success++;
                 } catch (\Throwable $t) {
@@ -98,8 +99,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
         int             $count,
         string          $faultyEventType,
         string          $correctEventType
-    ): bool
-    {
+    ): bool {
         return $this
             ->getHelper('question')
             ->ask(

--- a/app/Console/Command/ChangePlaceTypeOnEvents.php
+++ b/app/Console/Command/ChangePlaceTypeOnEvents.php
@@ -20,7 +20,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
 
     private int $errors;
 
-    private int $success;
+    private int $successCount;
 
     public function __construct(
         CommandBus $commandBus,
@@ -28,7 +28,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
     ) {
         $this->searchService = $searchService;
         $this->errors = 0;
-        $this->success = 0;
+        $this->successCount = 0;
         parent::__construct($commandBus);
     }
 
@@ -70,7 +70,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
                     $logger->info(
                         'Successfully changed type and availableFrom of event "' . $eventId . '" to  "' . $correctEventType . '"'
                     );
-                    $this->success++;
+                    $this->successCount++;
                 } catch (\Throwable $t) {
                     $logger->error(
                         sprintf(
@@ -84,7 +84,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
                 }
             }
 
-            $logger->info('Successfully changed the eventType of  ' . $this->success . ' events');
+            $logger->info('Successfully changed the eventType of  ' . $this->successCount . ' events');
 
             if ($this->errors) {
                 $logger->error('Failed to change type of ' . $this->errors . ' events');

--- a/app/Console/Command/ChangePlaceTypeOnEvents.php
+++ b/app/Console/Command/ChangePlaceTypeOnEvents.php
@@ -26,10 +26,10 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
         CommandBus $commandBus,
         SearchServiceInterface $searchService
     ) {
+        parent::__construct($commandBus);
         $this->searchService = $searchService;
         $this->errorCount = 0;
         $this->successCount = 0;
-        parent::__construct($commandBus);
     }
 
     public function configure(): void

--- a/app/Console/Command/ChangePlaceTypeOnEvents.php
+++ b/app/Console/Command/ChangePlaceTypeOnEvents.php
@@ -96,9 +96,9 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
     private function askConfirmation(
         InputInterface  $input,
         OutputInterface $output,
-        int             $count,
-        string          $faultyEventType,
-        string          $correctEventType
+        int $count,
+        string $faultyEventType,
+        string $correctEventType
     ): bool {
         return $this
             ->getHelper('question')

--- a/app/Console/Command/ChangePlaceTypeOnEvents.php
+++ b/app/Console/Command/ChangePlaceTypeOnEvents.php
@@ -46,7 +46,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
         $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
         $logger = new ConsoleLogger($output);
 
-        $mapping = $this->getMapping();
+        $mapping = $this->getCorrectPlaceTypeMapping();
 
         foreach ($mapping as $placeType => $correctEventType) {
             $resultsGenerator = new ResultsGenerator(
@@ -112,7 +112,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
             );
     }
 
-    private function getMapping(): array
+    private function getCorrectPlaceTypeMapping(): array
     {
         return [
             'kI7uAyn2uUu9VV6Z3uWZTA' => '0.3.1.0.0',

--- a/app/Console/Command/ChangePlaceTypeOnEvents.php
+++ b/app/Console/Command/ChangePlaceTypeOnEvents.php
@@ -46,9 +46,9 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
         $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
         $logger = new ConsoleLogger($output);
 
-        $mapping = $this->getCorrectPlaceTypeMapping();
+        $correctPlaceTypeMapping = $this->getCorrectPlaceTypeMapping();
 
-        foreach ($mapping as $placeType => $correctEventType) {
+        foreach ($correctPlaceTypeMapping as $placeType => $correctEventType) {
             $resultsGenerator = new ResultsGenerator(
                 $this->searchService,
                 ['created' => 'asc'],

--- a/app/Console/Command/ChangePlaceTypeOnEvents.php
+++ b/app/Console/Command/ChangePlaceTypeOnEvents.php
@@ -18,7 +18,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
 {
     private SearchServiceInterface $searchService;
 
-    private int $errors;
+    private int $errorCount;
 
     private int $successCount;
 
@@ -27,7 +27,7 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
         SearchServiceInterface $searchService
     ) {
         $this->searchService = $searchService;
-        $this->errors = 0;
+        $this->errorCount = 0;
         $this->successCount = 0;
         parent::__construct($commandBus);
     }
@@ -80,17 +80,17 @@ final class ChangePlaceTypeOnEvents extends AbstractCommand
                             $t->getMessage()
                         )
                     );
-                    $this->errors++;
+                    $this->errorCount++;
                 }
             }
 
             $logger->info('Successfully changed the eventType of  ' . $this->successCount . ' events');
 
-            if ($this->errors) {
-                $logger->error('Failed to change type of ' . $this->errors . ' events');
+            if ($this->errorCount) {
+                $logger->error('Failed to change type of ' . $this->errorCount . ' events');
             }
         }
-        return $this->errors;
+        return $this->errorCount;
     }
 
     private function askConfirmation(

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Console\Command\ChangeOfferOwnerInBulk;
 use CultuurNet\UDB3\Console\Command\ChangeOrganizerOwner;
 use CultuurNet\UDB3\Console\Command\ChangeOrganizerOwnerInBulk;
 use CultuurNet\UDB3\Console\Command\ChangePlaceType;
+use CultuurNet\UDB3\Console\Command\ChangePlaceTypeOnEvents;
 use CultuurNet\UDB3\Console\Command\ChangePlaceTypeOnPlacesWithEventEventType;
 use CultuurNet\UDB3\Console\Command\ConsumeCommand;
 use CultuurNet\UDB3\Console\Command\EventAncestorsCommand;
@@ -73,6 +74,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         'console.place:actortype:update',
         'console.place:actortype:reject',
         'console.place:faulty-eventtype:update',
+        'console.event:place-eventtype:update',
         'console.offer:remove-label',
         'console.organizer:remove-label',
         'console.offer:import-auto-classification-labels',
@@ -337,6 +339,14 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
             fn () => new ChangePlaceTypeOnPlacesWithEventEventType(
                 $container->get('event_command_bus'),
                 $container->get('sapi3_search_service_places')
+            )
+        );
+
+        $container->addShared(
+            'console.event:place-eventtype:update',
+            fn () => new ChangePlaceTypeOnEvents(
+                $container->get('event_command_bus'),
+                $container->get('sapi3_search_service_events')
             )
         );
 


### PR DESCRIPTION
### Added
- Command `ChangePlaceTypeOnEvents` to give `events` with an incorrect `placeType` a correct `eventType` and set their  `availableFrom` far in the future.

### Changed
- Register `ChangePlaceTypeOnEvents` in `ServiceProvider`

---
Ticket: https://jira.uitdatabank.be/browse/III-5422
