### PR TITLE
III-5428 embed youtube url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/III-5428-youtube-embed-urls",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd8d4a318e7bfd987fae39d54d2f5884",
+    "content-hash": "807df28acd2a3c54717ae0c966287e73",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5634,19 +5634,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/III-5428-youtube-embed-urls",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "095ccb471322a79a2ab1a3312b3c4934aa315b84"
+                "reference": "a2fe031adf545dfb7b39987d2e4c6a1a00c00268"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/095ccb471322a79a2ab1a3312b3c4934aa315b84",
-                "reference": "095ccb471322a79a2ab1a3312b3c4934aa315b84",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/a2fe031adf545dfb7b39987d2e4c6a1a00c00268",
+                "reference": "a2fe031adf545dfb7b39987d2e4c6a1a00c00268",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5661,9 +5660,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5428-youtube-embed-urls"
             },
-            "time": "2023-03-13T12:26:32+00:00"
+            "time": "2023-03-28T11:04:32+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -5638,12 +5638,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "a2fe031adf545dfb7b39987d2e4c6a1a00c00268"
+                "reference": "e32275e18b5b0019a7fa7670a6c7030aa76a9713"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/a2fe031adf545dfb7b39987d2e4c6a1a00c00268",
-                "reference": "a2fe031adf545dfb7b39987d2e4c6a1a00c00268",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/e32275e18b5b0019a7fa7670a6c7030aa76a9713",
+                "reference": "e32275e18b5b0019a7fa7670a6c7030aa76a9713",
                 "shasum": ""
             },
             "type": "library",
@@ -5662,7 +5662,7 @@
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
                 "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5428-youtube-embed-urls"
             },
-            "time": "2023-03-28T11:04:32+00:00"
+            "time": "2023-03-31T09:39:49+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Model/Serializer/ValueObject/MediaObject/VideoNormalizer.php
+++ b/src/Model/Serializer/ValueObject/MediaObject/VideoNormalizer.php
@@ -34,6 +34,10 @@ final class VideoNormalizer implements NormalizerInterface
             'embed' => self::YOUTUBE_EMBED,
             'name' => self::YOUTUBE_NAME,
         ],
+        11 => [
+            'embed' => self::YOUTUBE_EMBED,
+            'name' => self::YOUTUBE_NAME,
+        ],
     ];
 
     private array $defaultCopyrightHolders;

--- a/src/Model/ValueObject/MediaObject/Video.php
+++ b/src/Model/ValueObject/MediaObject/Video.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 
 final class Video
 {
-    public const REGEX = '/^http(s?):\/\/(www\.)?((youtube\.com\/watch\?v=([^\/#&?]*))|(vimeo\.com\/([^\/#&?]*))|(youtu\.be\/([^\/#&?]*)))/';
+    public const REGEX = '/^http(s?):\/\/(www\.)?((youtube\.com\/watch\?v=([^\/#&?]*))|(vimeo\.com\/([^\/#&?]*))|(youtu\.be\/([^\/#&?]*))|(youtube.com\/embed\/([^\/#&?]*)))/';
 
     private string $id;
 

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -5909,7 +5909,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/videos/0/url',
-                'The string should match pattern: ^http(s?):\/\/(www\.)?((youtube\.com\/watch\?v=([^\/#&?]*))|(vimeo\.com\/([^\/#&?]*))|(youtu\.be\/([^\/#&?]*)))'
+                'The string should match pattern: ^http(s?):\/\/(www\.)?((youtube\.com\/watch\?v=([^\/#&?]*))|(vimeo\.com\/([^\/#&?]*))|(youtu\.be\/([^\/#&?]*))|(youtube.com/embed/([^/#&?]*)))'
             ),
         ];
 

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -5909,7 +5909,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/videos/0/url',
-                'The string should match pattern: ^http(s?):\/\/(www\.)?((youtube\.com\/watch\?v=([^\/#&?]*))|(vimeo\.com\/([^\/#&?]*))|(youtu\.be\/([^\/#&?]*))|(youtube.com/embed/([^/#&?]*)))'
+                'The string should match pattern: ^http(s?):\/\/(www\.)?((youtube\.com\/watch\?v=([^\/#&?]*))|(vimeo\.com\/([^\/#&?]*))|(youtu\.be\/([^\/#&?]*))|(youtube.com/embed/([^\/#&?]*)))'
             ),
         ];
 

--- a/tests/Http/Offer/AddVideoRequestHandlerTest.php
+++ b/tests/Http/Offer/AddVideoRequestHandlerTest.php
@@ -283,7 +283,7 @@ class AddVideoRequestHandlerTest extends TestCase
             ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/url',
-                    'The string should match pattern: ^http(s?):\/\/(www\.)?((youtube\.com\/watch\?v=([^\/#&?]*))|(vimeo\.com\/([^\/#&?]*))|(youtu\.be\/([^\/#&?]*))|(youtube.com/embed/([^/#&?]*)))'
+                    'The string should match pattern: ^http(s?):\/\/(www\.)?((youtube\.com\/watch\?v=([^\/#&?]*))|(vimeo\.com\/([^\/#&?]*))|(youtu\.be\/([^\/#&?]*))|(youtube.com/embed/([^\/#&?]*)))'
                 )
             ),
             fn () => $this->addVideoRequestHandler->handle($addVideoRequest)

--- a/tests/Http/Offer/AddVideoRequestHandlerTest.php
+++ b/tests/Http/Offer/AddVideoRequestHandlerTest.php
@@ -249,7 +249,7 @@ class AddVideoRequestHandlerTest extends TestCase
             ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/url',
-                    'The string should match pattern: ^http(s?):\/\/(www\.)?((youtube\.com\/watch\?v=([^\/#&?]*))|(vimeo\.com\/([^\/#&?]*))|(youtu\.be\/([^\/#&?]*)))'
+                    'The string should match pattern: ^http(s?):\/\/(www\.)?((youtube\.com\/watch\?v=([^\/#&?]*))|(vimeo\.com\/([^\/#&?]*))|(youtu\.be\/([^\/#&?]*))|(youtube.com/embed/([^/#&?]*)))'
                 )
             ),
             fn () => $this->addVideoRequestHandler->handle($addVideoRequest)

--- a/tests/Http/Offer/AddVideoRequestHandlerTest.php
+++ b/tests/Http/Offer/AddVideoRequestHandlerTest.php
@@ -157,6 +157,40 @@ class AddVideoRequestHandlerTest extends TestCase
      * @test
      * @dataProvider offerTypeDataProvider
      */
+    public function it_allows_adding_an_embedded_youtube_url(string $offerType): void
+    {
+        $addVideoRequest = $this->psr7RequestBuilder
+            ->withRouteParameter('offerType', $offerType)
+            ->withRouteParameter('offerId', '91c75325-3830-4000-b580-5778b2de4548')
+            ->withBodyFromString('{"url":"https://www.youtube.com/embed/yi_XlQetN28", "language":"nl"}')
+            ->build('POST');
+
+        $videoId = \Ramsey\Uuid\Uuid::uuid4();
+        $this->uuidFactory->expects($this->once())
+            ->method('uuid4')
+            ->willReturn($videoId);
+
+        $this->addVideoRequestHandler->handle($addVideoRequest);
+
+        $this->assertEquals(
+            [
+                new AddVideo(
+                    '91c75325-3830-4000-b580-5778b2de4548',
+                    new Video(
+                        $videoId->toString(),
+                        new Url('https://www.youtube.com/embed/yi_XlQetN28'),
+                        new Language('nl')
+                    )
+                ),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider offerTypeDataProvider
+     */
     public function it_requires_a_url(string $offerType): void
     {
         $addVideoRequest = $this->psr7RequestBuilder

--- a/tests/Model/Serializer/ValueObject/MediaObject/VideoNormalizerTest.php
+++ b/tests/Model/Serializer/ValueObject/MediaObject/VideoNormalizerTest.php
@@ -93,6 +93,20 @@ final class VideoNormalizerTest extends TestCase
                     'copyrightHolder' => 'Copyright afgehandeld door YouTube',
                 ],
             ],
+            'embedded_youtube_video' => [
+                new Video(
+                    '910585da-2cbe-441e-97e4-c9308b5a6c1a',
+                    new Url('https://www.youtube.com/embed/yi_XlQetN28'),
+                    new Language('nl')
+                ),
+                [
+                    'id' => '910585da-2cbe-441e-97e4-c9308b5a6c1a',
+                    'url' => 'https://www.youtube.com/embed/yi_XlQetN28',
+                    'embedUrl' => 'https://www.youtube.com/embed/yi_XlQetN28',
+                    'language' => 'nl',
+                    'copyrightHolder' => 'Copyright afgehandeld door YouTube',
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
### Added
- Test for adding embedded YouTube urls.

### Changed
- Updated `publiq/udb3-json-schemas` in `composer` to allow embedded YouTube urls.
- Updated Regex in ValueObject `Video` to allow embedded YouTube urls.
- Updated tests with new Video-url regex.
- Update `VideoNormalizer` to handle embedded YouTube urls.
- Update test for `VideoNormalizer`

---
Ticket: https://jira.uitdatabank.be/browse/III-5428
