### PR TITLE
III-5352 events from udb2 to granular events dummy locations

### DIFF
--- a/src/Event/Events/DummyLocation.php
+++ b/src/Event/Events/DummyLocation.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events;
+
+use CultuurNet\UDB3\Model\ValueObject\Geography\Address;
+use CultuurNet\UDB3\Model\ValueObject\Text\Title;
+
+final class DummyLocation
+{
+    private Title $title;
+
+    private Address $address;
+
+    public function __construct(Title $title, Address $address)
+    {
+        $this->title = $title;
+        $this->address = $address;
+    }
+
+    public function getTitle(): Title
+    {
+        return $this->title;
+    }
+
+    public function getAddress(): Address
+    {
+        return $this->address;
+    }
+}

--- a/src/Event/Events/DummyLocationUpdated.php
+++ b/src/Event/Events/DummyLocationUpdated.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events;
+
+interface DummyLocationUpdated
+{
+    public function getDummyLocation(): ?DummyLocation;
+}

--- a/src/Event/Events/EventImportedFromUDB2.php
+++ b/src/Event/Events/EventImportedFromUDB2.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\HasCdbXmlTrait;
 use CultuurNet\UDB3\Language;
 
-final class EventImportedFromUDB2 extends EventEvent implements EventCdbXMLInterface, MainLanguageDefined, ConvertsToGranularEvents
+final class EventImportedFromUDB2 extends EventEvent implements EventCdbXMLInterface, MainLanguageDefined, ConvertsToGranularEvents, DummyLocationUpdated, ExternalIdLocationUpdated
 {
     use HasCdbXmlTrait;
     use EventFromUDB2;

--- a/src/Event/Events/EventUpdatedFromUDB2.php
+++ b/src/Event/Events/EventUpdatedFromUDB2.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Event\EventEvent;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\HasCdbXmlTrait;
 
-final class EventUpdatedFromUDB2 extends EventEvent implements EventCdbXMLInterface, ConvertsToGranularEvents
+final class EventUpdatedFromUDB2 extends EventEvent implements EventCdbXMLInterface, ConvertsToGranularEvents, DummyLocationUpdated, ExternalIdLocationUpdated
 {
     use HasCdbXmlTrait;
     use EventFromUDB2;

--- a/src/Event/Events/ExternalIdLocationUpdated.php
+++ b/src/Event/Events/ExternalIdLocationUpdated.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events;
+
+interface ExternalIdLocationUpdated
+{
+    public function getExternalId(): ?string;
+}

--- a/tests/Event/Events/EventImportedFromUDB2Test.php
+++ b/tests/Event/Events/EventImportedFromUDB2Test.php
@@ -194,7 +194,7 @@ final class EventImportedFromUDB2Test extends TestCase
     /**
      * @test
      */
-    public function it_does_not_give_a_dummy_location_if_a_location_id_is_present(): void
+    public function it_does_not_return_a_dummy_location_if_location_id_is_present(): void
     {
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventWithLocationId = new EventImportedFromUDB2(
@@ -235,7 +235,7 @@ final class EventImportedFromUDB2Test extends TestCase
     /**
      * @test
      */
-    public function it_can_return_an_external_id_if_present(): void
+    public function it_returns_an_external_id_if_present(): void
     {
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventWithExternalIdLocation = new EventImportedFromUDB2(
@@ -253,7 +253,7 @@ final class EventImportedFromUDB2Test extends TestCase
     /**
      * @test
      */
-    public function it_can_returns_null_if_no_external_id_is_present(): void
+    public function it_returns_null_if_no_external_id_is_present(): void
     {
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventWithExternalIdLocation = new EventImportedFromUDB2(

--- a/tests/Event/Events/EventImportedFromUDB2Test.php
+++ b/tests/Event/Events/EventImportedFromUDB2Test.php
@@ -203,10 +203,7 @@ final class EventImportedFromUDB2Test extends TestCase
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
-        $this->assertEquals(
-            null,
-            $eventWithLocationId->getDummyLocation()
-        );
+        $this->assertNull($eventWithLocationId->getDummyLocation());
     }
 
     /**
@@ -215,7 +212,7 @@ final class EventImportedFromUDB2Test extends TestCase
     public function it_returns_a_dummy_location_(): void
     {
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
-        $eventWithLocationId = new EventImportedFromUDB2(
+        $eventWithDummyLocation = new EventImportedFromUDB2(
             $eventId,
             file_get_contents(__DIR__ . '/../samples/event_with_photo.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
@@ -231,8 +228,41 @@ final class EventImportedFromUDB2Test extends TestCase
                     new CountryCode('BE')
                 )
             ),
-            $eventWithLocationId->getDummyLocation()
+            $eventWithDummyLocation->getDummyLocation()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_return_an_external_id_if_present(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventWithExternalIdLocation = new EventImportedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            'SKB:9ccbf9c1-a5c5-4689-9687-9a7dd3c51aee',
+            $eventWithExternalIdLocation->getExternalId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_returns_null_if_no_external_id_is_present(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventWithExternalIdLocation = new EventImportedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_existing_location.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertNull($eventWithExternalIdLocation->getExternalId());
     }
 
     /**

--- a/tests/Event/Events/EventUpdatedFromUDB2Test.php
+++ b/tests/Event/Events/EventUpdatedFromUDB2Test.php
@@ -7,6 +7,7 @@ namespace test\Event\Events;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\Events\CalendarUpdated;
+use CultuurNet\UDB3\Event\Events\DummyLocation;
 use CultuurNet\UDB3\Event\Events\EventUpdatedFromUDB2;
 use CultuurNet\UDB3\Event\Events\LocationUpdated;
 use CultuurNet\UDB3\Event\Events\TitleTranslated;
@@ -15,8 +16,14 @@ use CultuurNet\UDB3\Event\Events\TypeUpdated;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Geography\Address;
+use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\Model\ValueObject\Geography\Locality;
+use CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode;
+use CultuurNet\UDB3\Model\ValueObject\Geography\Street;
+use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Timestamp;
-use CultuurNet\UDB3\Title;
+use CultuurNet\UDB3\Title as LegacyTitle;
 use PHPUnit\Framework\TestCase;
 
 final class EventUpdatedFromUDB2Test extends TestCase
@@ -63,9 +70,9 @@ final class EventUpdatedFromUDB2Test extends TestCase
 
         $this->assertEquals(
             [
-                new TitleUpdated($eventId, new Title('Het evenement!')),
-                new TitleTranslated($eventId, new Language('fr'), new Title('L\'événement!')),
-                new TitleTranslated($eventId, new Language('de'), new Title('Das Ereignis!')),
+                new TitleUpdated($eventId, new LegacyTitle('Het evenement!')),
+                new TitleTranslated($eventId, new Language('fr'), new LegacyTitle('L\'événement!')),
+                new TitleTranslated($eventId, new Language('de'), new LegacyTitle('Das Ereignis!')),
                 new TypeUpdated($eventId, new EventType('0.3.1.0.0', 'Cursus of workshop')),
             ],
             $eventUpdatedFromUdb2->toGranularEvents()
@@ -86,9 +93,9 @@ final class EventUpdatedFromUDB2Test extends TestCase
 
         $this->assertEquals(
             [
-                new TitleUpdated($eventId, new Title('Het evenement!')),
-                new TitleTranslated($eventId, new Language('fr'), new Title('L\'événement!')),
-                new TitleTranslated($eventId, new Language('de'), new Title('Das Ereignis!')),
+                new TitleUpdated($eventId, new LegacyTitle('Het evenement!')),
+                new TitleTranslated($eventId, new Language('fr'), new LegacyTitle('L\'événement!')),
+                new TitleTranslated($eventId, new Language('de'), new LegacyTitle('Das Ereignis!')),
                 new TypeUpdated($eventId, new EventType('0.3.1.0.0', 'Cursus of workshop')),
                 new LocationUpdated($eventId, new LocationId('28d2900d-f784-4d04-8d66-5b93900c6f9c')),
                 new CalendarUpdated(
@@ -108,6 +115,80 @@ final class EventUpdatedFromUDB2Test extends TestCase
             ],
             $eventUpdatedFromUdb2->toGranularEvents()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_return_a_dummy_location_if_location_id_is_present(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventWithLocationId = new EventUpdatedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_existing_location.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertNull($eventWithLocationId->getDummyLocation());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_dummy_location_(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventWithDummyLocation = new EventUpdatedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_photo.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            new DummyLocation(
+                new Title('Liberaal Archief'),
+                new Address(
+                    new Street('Kramersplein 23'),
+                    new PostalCode('9000'),
+                    new Locality('Gent'),
+                    new CountryCode('BE')
+                )
+            ),
+            $eventWithDummyLocation->getDummyLocation()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_external_id_if_present(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventWithExternalIdLocation = new EventUpdatedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            'SKB:9ccbf9c1-a5c5-4689-9687-9a7dd3c51aee',
+            $eventWithExternalIdLocation->getExternalId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_if_no_external_id_is_present(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventWithExternalIdLocation = new EventUpdatedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_existing_location.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertNull($eventWithExternalIdLocation->getExternalId());
     }
 
     public function serializationDataProvider(): array

--- a/tests/Event/samples/event_with_externalid_location.cdbxml.xml
+++ b/tests/Event/samples/event_with_externalid_location.cdbxml.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cdb:event xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL" availablefrom="2016-04-13T13:21:55" availableto="2016-04-14T00:00:00" cdbid="e3604613-af01-4d2b-8cee-13ab61b89651" createdby="nick@2dotstwice.be" creationdate="2016-04-13T13:21:55" externalid="CDB:e3604613-af01-4d2b-8cee-13ab61b89651" lastupdated="2016-04-14T17:33:31" lastupdatedby="nick@2dotstwice.be" owner="Invoerders Algemeen " pctcomplete="40" private="false" published="true" publisher="469781698cdbbd84d5c9c60822a5a8ff" validator="Leuven Validatoren" wfstatus="readyforvalidation" isparent="false">
+    <cdb:calendar>
+        <cdb:timestamps>
+            <cdb:timestamp>
+                <cdb:date>2016-04-13</cdb:date>
+            </cdb:timestamp>
+        </cdb:timestamps>
+    </cdb:calendar>
+    <cdb:categories>
+        <cdb:category type="theme" catid="1.25.0.0.0">Wetenschap</cdb:category>
+        <cdb:category type="flanderstouristregion" catid="reg.367">Kunststad Leuven</cdb:category>
+        <cdb:category type="eventtype" catid="0.3.1.0.0">Cursus of workshop</cdb:category>
+        <cdb:category type="flandersregion" catid="reg.638">3000 Leuven</cdb:category>
+    </cdb:categories>
+    <cdb:contactinfo>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Leuven</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>4.748294</cdb:xcoordinate>
+                    <cdb:ycoordinate>50.894600</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>44</cdb:housenr>
+                <cdb:street>teststraat</cdb:street>
+                <cdb:zipcode>3000</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+    </cdb:contactinfo>
+    <cdb:eventdetails>
+        <cdb:eventdetail lang="nl">
+            <cdb:calendarsummary>woe 13/04/16</cdb:calendarsummary>
+            <cdb:title>Het evenement!</cdb:title>
+        </cdb:eventdetail>
+        <cdb:eventdetail lang="fr">
+            <cdb:calendarsummary>mer 13/04/16</cdb:calendarsummary>
+            <cdb:title>L'événement!</cdb:title>
+        </cdb:eventdetail>
+        <cdb:eventdetail lang="de">
+            <cdb:calendarsummary>mit 13/04/16</cdb:calendarsummary>
+            <cdb:title>Das Ereignis!</cdb:title>
+        </cdb:eventdetail>
+    </cdb:eventdetails>
+    <cdb:keywords />
+    <cdb:location>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Leuven</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>4.748294</cdb:xcoordinate>
+                    <cdb:ycoordinate>50.894600</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>44</cdb:housenr>
+                <cdb:street>teststraat</cdb:street>
+                <cdb:zipcode>3000</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:label externalid="SKB:9ccbf9c1-a5c5-4689-9687-9a7dd3c51aee">Test locatie 2099</cdb:label>
+    </cdb:location>
+</cdb:event>


### PR DESCRIPTION
### Added
- `DummyLocation`- class to store `Title` & `Address` of a DummyLocation from `UDB2`
- interface `DummyLocationUpdated` to get `DummyLocation` from `EventImportedFromUDB2` & `EventUpdatedFromUDB2 `
- interface `ExternalIdLocationUpdated ` to get `externalId` from `EventImportedFromUDB2` & `EventUpdatedFromUDB2 `
- implemented `DummyLocationUpdated` & `ExternalIdLocationUpdated` in trait `EventFromUDB2`

### Changed
- Added tests for `getDummyLocation()` & `getExternalId()`

---
Ticket: https://jira.uitdatabank.be/browse/III-5352
