### PR TITLE
III-4684 Offers with MainImage and no MediaObject

### DIFF
--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -418,7 +418,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         );
 
         // Unset the main image if it matches the removed image
-        // @see https://jira.uitdatabank.be/browse/III-2201
+        // @see https://jira.uitdatabank.be/browse/III-4684
         // some historic ImageRemoved Events have http instead of https in the eventStore
         if (isset($offerLd->image) && stristr($offerLd->{'image'}, ':') === stristr($imageUrl, ':')) {
             unset($offerLd->{'image'});

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -418,7 +418,9 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         );
 
         // Unset the main image if it matches the removed image
-        if (isset($offerLd->image) && $offerLd->{'image'} === $imageUrl) {
+        // stristr() comparison is done for edge cases where an offer has multiple images
+        // @see III-4684
+        if (isset($offerLd->image) && stristr($offerLd->{'image'}, ':') === stristr($imageUrl, ':')) {
             unset($offerLd->{'image'});
         }
 

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -418,7 +418,9 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         );
 
         // Unset the main image if it matches the removed image
-        if (isset($offerLd->image) && $offerLd->{'image'} === $imageUrl) {
+        // @see https://jira.uitdatabank.be/browse/III-2201
+        // some historic ImageRemoved Events have http instead of https in the eventStore
+        if (isset($offerLd->image) && stristr($offerLd->{'image'}, ':') === stristr($imageUrl, ':')) {
             unset($offerLd->{'image'});
         }
 

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -418,7 +418,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         );
 
         // Unset the main image if it matches the removed image
-        // stristr() comparison is done for edge cases where an offer has multiple images
+        // stripping the protocol before comparison is done for edge cases where an offer has multiple images
         // @see III-4684
         if (isset($offerLd->image) && stristr($offerLd->{'image'}, ':') === stristr($imageUrl, ':')) {
             unset($offerLd->{'image'});

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -419,7 +419,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
 
         // Unset the main image if it matches the removed image
         // stripping the protocol before comparison is done for edge cases where an offer has multiple images
-        // @see III-4684
+        // @see https://jira.uitdatabank.be/browse/III-4684
         if (isset($offerLd->image) && stristr($offerLd->{'image'}, ':') === stristr($imageUrl, ':')) {
             unset($offerLd->{'image'});
         }
@@ -429,7 +429,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         }
 
         // If no media objects are left remove the attribute and the imageUrl.
-        // @see III-4684
+        // @see https://jira.uitdatabank.be/browse/III-4684
         if (empty($filteredMediaObjects)) {
             unset($offerLd->{'mediaObject'});
             unset($offerLd->{'image'});

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -418,9 +418,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         );
 
         // Unset the main image if it matches the removed image
-        // @see https://jira.uitdatabank.be/browse/III-4684
-        // some historic ImageRemoved Events have http instead of https in the eventStore
-        if (isset($offerLd->image) && stristr($offerLd->{'image'}, ':') === stristr($imageUrl, ':')) {
+        if (isset($offerLd->image) && $offerLd->{'image'} === $imageUrl) {
             unset($offerLd->{'image'});
         }
 
@@ -428,9 +426,11 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
             $offerLd->image = array_values($filteredMediaObjects)[0]->contentUrl;
         }
 
-        // If no media objects are left remove the attribute.
+        // If no media objects are left remove the attribute and the imageUrl.
+        // @see III-4684
         if (empty($filteredMediaObjects)) {
             unset($offerLd->{'mediaObject'});
+            unset($offerLd->{'image'});
         } else {
             $offerLd->mediaObject = array_values($filteredMediaObjects);
         }

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -729,6 +729,46 @@ class OfferLDProjectorTest extends TestCase
     /**
      * @test
      */
+    public function it_should_unset_the_main_image_if_the_old_image_removed_event_has_a_http_source(): void
+    {
+        $eventId = 'event-1';
+        $image = new Image(
+            new UUID('aa39128e-b2ca-5629-a275-b380381df0f3'),
+            new MIMEType('image/jpeg'),
+            new Description('The Gleaners'),
+            new CopyrightHolder('Jean-François Millet'),
+            new Url('http://images.uitdatabank.be/edcea9f6-756b-4935-9c8b-d7d9c262d041.jpeg'),
+            new LegacyLanguage('en')
+        );
+        $initialDocument = new JsonDocument(
+            $eventId,
+            Json::encode([
+                'mediaObject' => [
+                    [
+                        '@id' => 'https://io.uitdatabank.be/images/aa39128e-b2ca-5629-a275-b380381df0f3',
+                        '@type' => 'schema:ImageObject',
+                        'contentUrl' => 'https://images.uitdatabank.be/edcea9f6-756b-4935-9c8b-d7d9c262d041.jpeg',
+                        'thumbnailUrl' => 'https://images.uitdatabank.be/edcea9f6-756b-4935-9c8b-d7d9c262d041.jpeg',
+                        'description' => 'The Gleaners',
+                        'copyrightHolder' => 'Jean-François Millet',
+                        'inLanguage' => 'en',
+                    ],
+                ],
+                'image' => 'https://images.uitdatabank.be/edcea9f6-756b-4935-9c8b-d7d9c262d041.jpeg',
+            ])
+        );
+
+        $this->documentRepository->save($initialDocument);
+        $imageRemovedEvent = new ImageRemoved($eventId, $image);
+        $eventBody = $this->project($imageRemovedEvent, $eventId);
+
+        $this->assertObjectNotHasAttribute('mediaObject', $eventBody);
+        $this->assertObjectNotHasAttribute('image', $eventBody);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_unset_the_main_image_when_its_media_object_is_removed(): void
     {
         $eventId = 'event-1';

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -729,7 +729,7 @@ class OfferLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_should_unset_the_main_image_if_the_old_image_removed_event_has_a_http_source(): void
+    public function it_unsets_the_main_images_url_if_no_media_objects_remain(): void
     {
         $eventId = 'event-1';
         $image = new Image(

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -769,6 +769,57 @@ class OfferLDProjectorTest extends TestCase
     /**
      * @test
      */
+    public function it_should_unset_a_main_image_regardless_of_protocol(): void
+    {
+        $eventId = 'event-1';
+        $image = new Image(
+            new UUID('de305d54-75b4-431b-adb2-eb6b9e546014'),
+            new MIMEType('image/png'),
+            new Description('The Gleaners'),
+            new CopyrightHolder('Jean-François Millet'),
+            new Url('http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
+            new LegacyLanguage('en')
+        );
+        $initialDocument = new JsonDocument(
+            $eventId,
+            Json::encode([
+                'image' => 'https://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
+                'mediaObject' => [
+                    [
+                        '@id' => 'http://example.com/entity/de305d54-75b4-431b-adb2-eb6b9e546014',
+                        '@type' => 'schema:ImageObject',
+                        'contentUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
+                        'thumbnailUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
+                        'description' => 'The Gleaners',
+                        'copyrightHolder' => 'Jean-François Millet',
+                        'inLanguage' => 'en',
+                    ],
+                    [
+                        '@id' => 'https://example.com/entity/bef60647-0e56-4d33-87f7-110811092c4a',
+                        '@type' => 'schema:ImageObject',
+                        'contentUrl' => 'https://foo.bar/media/bef60647-0e56-4d33-87f7-110811092c4a.png',
+                        'thumbnailUrl' => 'https://foo.bar/media/bef60647-0e56-4d33-87f7-110811092c4a.png',
+                        'description' => 'Des glaneuses',
+                        'copyrightHolder' => 'Jean-François Millet',
+                        'inLanguage' => 'fr',
+                    ],
+                ],
+            ])
+        );
+
+        $this->documentRepository->save($initialDocument);
+        $imageRemovedEvent = new ImageRemoved($eventId, $image);
+        $eventBody = $this->project($imageRemovedEvent, $eventId);
+
+        $this->assertEquals(
+            'https://foo.bar/media/bef60647-0e56-4d33-87f7-110811092c4a.png',
+            $eventBody->image
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_should_unset_the_main_image_when_its_media_object_is_removed(): void
     {
         $eventId = 'event-1';
@@ -783,7 +834,7 @@ class OfferLDProjectorTest extends TestCase
         $initialDocument = new JsonDocument(
             $eventId,
             Json::encode([
-                'image' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
+                'image' => 'https://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
                 'mediaObject' => [
                     [
                         '@id' => 'http://example.com/entity/de305d54-75b4-431b-adb2-eb6b9e546014',


### PR DESCRIPTION
### Added
-  `OfferLDProjectorTest`: added test to check if `ImagedRemoved` with `http`-link unsets the same MainImage with `https`

### Changed
- `OfferLDProjector`: make comparison with `mainImageUrl` protocol-agnostic, when an `ImageRemoved` is applied.
- `OfferLDProjector`: always unset `mainImageUrl` if no `MainObjects` remain

### Fixed
- `ImageRemoved` with `http` can now unset the `mainImageUrl` if it is the same but url with `https`

---
Ticket: https://jira.uitdatabank.be/browse/III-4684
