### PR TITLE
III-5520 Mark dcterms:creator value as a Resource

### DIFF
--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -138,7 +138,7 @@ final class RdfProjector implements EventListener
             $identificator = $graph->newBNode();
             $identificator->setType(self::TYPE_IDENTIFICATOR);
             $identificator->add(self::PROPERTY_IDENTIFICATOR_NOTATION, $uri);
-            $identificator->add(self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR, self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT);
+            $identificator->add(self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR, new Resource(self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT));
             $identificator->add(self::PROPERTY_IDENTIFICATOR_NAAMRUIMTE, new Literal($this->iriGenerator->iri(''), null, 'xsd:string'));
             $identificator->add(self::PROPERTY_IDENTIFICATOR_LOKALE_IDENTIFICATOR, new Literal($domainMessage->getId(), null, 'xsd:string'));
             $resource->add(self::PROPERTY_LOCATIE_IDENTIFICATOR, $identificator);

--- a/tests/Place/ReadModel/RDF/data/address-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-translated.ttl
@@ -11,7 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string

--- a/tests/Place/ReadModel/RDF/data/address-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-updated.ttl
@@ -11,7 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string

--- a/tests/Place/ReadModel/RDF/data/geo-coordinates-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/geo-coordinates-updated.ttl
@@ -12,7 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -12,7 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-01T12:30:15+01:00"^^xsd:string

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -11,7 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -11,7 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-05T12:30:15+01:00"^^xsd:string

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -11,7 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
-    dcterms:creator "https://fixme.com/example/dataprovider/publiq" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string


### PR DESCRIPTION
### Fixed

- `dcterms:creator` value is now a resource link, so it's wrapped in `<...>` instead of `"..."` in the Turtle data and it is a link instead of a literal string

---
Ticket: https://jira.uitdatabank.be/browse/III-5520
