### PR TITLE
III-5522 Add xsd:anyUri datatype to skos:notation predicate value

### DIFF
--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -136,7 +136,7 @@ final class RdfProjector implements EventListener
         if (!$resource->hasProperty(self::PROPERTY_LOCATIE_IDENTIFICATOR)) {
             $identificator = $graph->newBNode();
             $identificator->setType(self::TYPE_IDENTIFICATOR);
-            $identificator->add(self::PROPERTY_IDENTIFICATOR_NOTATION, $uri);
+            $identificator->add(self::PROPERTY_IDENTIFICATOR_NOTATION, new Literal($uri, null, 'xsd:anyUri'));
             $identificator->add(self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR, new Resource(self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT));
             $identificator->add(self::PROPERTY_IDENTIFICATOR_NAAMRUIMTE, new Literal($this->iriGenerator->iri(''), null, 'xsd:string'));
             $identificator->add(self::PROPERTY_IDENTIFICATOR_LOKALE_IDENTIFICATOR, new Literal($domainMessage->getId(), null, 'xsd:string'));

--- a/tests/Place/ReadModel/RDF/data/address-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-translated.ttl
@@ -10,7 +10,7 @@
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/address-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-updated.ttl
@@ -10,7 +10,7 @@
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/geo-coordinates-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/geo-coordinates-updated.ttl
@@ -11,7 +11,7 @@
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -11,7 +11,7 @@
   dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -10,7 +10,7 @@
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -10,7 +10,7 @@
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -10,7 +10,7 @@
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;


### PR DESCRIPTION
### Added

- Added `xsd:anyUri` datatype to `skos:notation` predicate value

---
Ticket: https://jira.uitdatabank.be/browse/III-5522
