### PR TITLE
III-5508 add workflow status predicate

### DIFF
--- a/src/Place/Events/PlaceCreated.php
+++ b/src/Place/Events/PlaceCreated.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\PlaceEvent;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
@@ -75,12 +76,15 @@ final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents,
 
     public function toGranularEvents(): array
     {
-        return [
-            new TitleUpdated($this->placeId, $this->title),
-            new TypeUpdated($this->placeId, $this->eventType),
-            new AddressUpdated($this->placeId, $this->address),
-            new CalendarUpdated($this->placeId, $this->calendar),
-        ];
+        return array_values(
+            array_filter([
+                new TitleUpdated($this->placeId, $this->title),
+                new TypeUpdated($this->placeId, $this->eventType),
+                new AddressUpdated($this->placeId, $this->address),
+                new CalendarUpdated($this->placeId, $this->calendar),
+                $this->publicationDate ? new Published($this->placeId, $this->publicationDate) : null,
+            ])
+        );
     }
 
     public function serialize(): array

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -20,6 +20,7 @@ use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Place\Events\Moderation\Approved;
 use CultuurNet\UDB3\Place\Events\Moderation\Published;
+use CultuurNet\UDB3\Place\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
 use CultuurNet\UDB3\Place\Events\TitleUpdated;
 use CultuurNet\UDB3\RDF\GraphRepository;
@@ -104,6 +105,7 @@ final class RdfProjector implements EventListener
             GeoCoordinatesUpdated::class => fn ($e) => $this->handleGeoCoordinatesUpdated($e, $uri, $graph),
             Published::class => fn ($e) => $this->handlePublished($e, $uri, $graph),
             Approved::class => fn ($e) => $this->handleApproved($e, $uri, $graph),
+            Rejected::class => fn ($e) => $this->handleRejected($e, $uri, $graph),
         ];
 
         foreach ($events as $event) {
@@ -330,6 +332,12 @@ final class RdfProjector implements EventListener
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, self::PROPERTY_LOCATIE_WORKFLOW_STATUS_APPROVED);
+    }
+
+    private function handleRejected(Rejected $event, string $uri, Graph $graph): void
+    {
+        $resource = $graph->resource($uri);
+        $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, self::PROPERTY_LOCATIE_WORKFLOW_STATUS_REJECTED);
     }
 
     private function deleteLanguageValue(

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -131,7 +131,7 @@ final class RdfProjector implements EventListener
 
         // Set the udb:workflowStatus property to draft if not set yet.
         if (!$resource->hasProperty(self::PROPERTY_LOCATIE_WORKFLOW_STATUS)) {
-            $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, self::PROPERTY_LOCATIE_WORKFLOW_STATUS_DRAFT);
+            $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_DRAFT));
         }
 
         // Set the dcterms:created property if not set yet.
@@ -325,19 +325,19 @@ final class RdfProjector implements EventListener
     private function handlePublished(Published $event, string $uri, Graph $graph): void
     {
         $resource = $graph->resource($uri);
-        $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, self::PROPERTY_LOCATIE_WORKFLOW_STATUS_READY_FOR_VALIDATION);
+        $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_READY_FOR_VALIDATION));
     }
 
     private function handleApproved(Approved $event, string $uri, Graph $graph): void
     {
         $resource = $graph->resource($uri);
-        $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, self::PROPERTY_LOCATIE_WORKFLOW_STATUS_APPROVED);
+        $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_APPROVED));
     }
 
     private function handleRejected(Rejected $event, string $uri, Graph $graph): void
     {
         $resource = $graph->resource($uri);
-        $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, self::PROPERTY_LOCATIE_WORKFLOW_STATUS_REJECTED);
+        $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_REJECTED));
     }
 
     private function deleteLanguageValue(

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
+use CultuurNet\UDB3\Place\Events\Moderation\Approved;
 use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
 use CultuurNet\UDB3\Place\Events\TitleUpdated;
@@ -102,6 +103,7 @@ final class RdfProjector implements EventListener
             AddressTranslated::class => fn ($e) => $this->handleAddressTranslated($e, $uri, $graph),
             GeoCoordinatesUpdated::class => fn ($e) => $this->handleGeoCoordinatesUpdated($e, $uri, $graph),
             Published::class => fn ($e) => $this->handlePublished($e, $uri, $graph),
+            Approved::class => fn ($e) => $this->handleApproved($e, $uri, $graph),
         ];
 
         foreach ($events as $event) {
@@ -322,6 +324,12 @@ final class RdfProjector implements EventListener
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, self::PROPERTY_LOCATIE_WORKFLOW_STATUS_READY_FOR_VALIDATION);
+    }
+
+    private function handleApproved(Approved $event, string $uri, Graph $graph): void
+    {
+        $resource = $graph->resource($uri);
+        $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, self::PROPERTY_LOCATIE_WORKFLOW_STATUS_APPROVED);
     }
 
     private function deleteLanguageValue(

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -332,24 +332,28 @@ final class RdfProjector implements EventListener
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_READY_FOR_VALIDATION));
+        $this->graphRepository->save($uri, $graph);
     }
 
     private function handleApproved(string $uri, Graph $graph): void
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_APPROVED));
+        $this->graphRepository->save($uri, $graph);
     }
 
     private function handleRejected(string $uri, Graph $graph): void
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_REJECTED));
+        $this->graphRepository->save($uri, $graph);
     }
 
     private function handleDeleted(string $uri, Graph $graph): void
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_DELETED));
+        $this->graphRepository->save($uri, $graph);
     }
 
     private function deleteLanguageValue(

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -106,12 +106,12 @@ final class RdfProjector implements EventListener
             AddressUpdated::class => fn ($e) => $this->handleAddressUpdated($e, $uri, $graph),
             AddressTranslated::class => fn ($e) => $this->handleAddressTranslated($e, $uri, $graph),
             GeoCoordinatesUpdated::class => fn ($e) => $this->handleGeoCoordinatesUpdated($e, $uri, $graph),
-            Published::class => fn ($e) => $this->handlePublished($e, $uri, $graph),
-            Approved::class => fn ($e) => $this->handleApproved($e, $uri, $graph),
+            Published::class => fn ($e) => $this->handlePublished($uri, $graph),
+            Approved::class => fn ($e) => $this->handleApproved($uri, $graph),
             Rejected::class => fn ($e) => $this->handleRejected($uri, $graph),
             FlaggedAsDuplicate::class => fn ($e) => $this->handleRejected($uri, $graph),
             FlaggedAsInappropriate::class => fn ($e) => $this->handleRejected($uri, $graph),
-            PlaceDeleted::class => fn ($e) => $this->handleDeleted($e, $uri, $graph),
+            PlaceDeleted::class => fn ($e) => $this->handleDeleted($uri, $graph),
         ];
 
         foreach ($events as $event) {
@@ -328,13 +328,13 @@ final class RdfProjector implements EventListener
         $this->graphRepository->save($uri, $graph);
     }
 
-    private function handlePublished(Published $event, string $uri, Graph $graph): void
+    private function handlePublished(string $uri, Graph $graph): void
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_READY_FOR_VALIDATION));
     }
 
-    private function handleApproved(Approved $event, string $uri, Graph $graph): void
+    private function handleApproved(string $uri, Graph $graph): void
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_APPROVED));
@@ -346,7 +346,7 @@ final class RdfProjector implements EventListener
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_REJECTED));
     }
 
-    private function handleDeleted(PlaceDeleted $event, string $uri, Graph $graph): void
+    private function handleDeleted(string $uri, Graph $graph): void
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_DELETED));

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -19,6 +19,8 @@ use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Place\Events\Moderation\Approved;
+use CultuurNet\UDB3\Place\Events\Moderation\FlaggedAsDuplicate;
+use CultuurNet\UDB3\Place\Events\Moderation\FlaggedAsInappropriate;
 use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Place\Events\PlaceDeleted;
@@ -106,7 +108,9 @@ final class RdfProjector implements EventListener
             GeoCoordinatesUpdated::class => fn ($e) => $this->handleGeoCoordinatesUpdated($e, $uri, $graph),
             Published::class => fn ($e) => $this->handlePublished($e, $uri, $graph),
             Approved::class => fn ($e) => $this->handleApproved($e, $uri, $graph),
-            Rejected::class => fn ($e) => $this->handleRejected($e, $uri, $graph),
+            Rejected::class => fn ($e) => $this->handleRejected($uri, $graph),
+            FlaggedAsDuplicate::class => fn ($e) => $this->handleRejected($uri, $graph),
+            FlaggedAsInappropriate::class => fn ($e) => $this->handleRejected($uri, $graph),
             PlaceDeleted::class => fn ($e) => $this->handleDeleted($e, $uri, $graph),
         ];
 
@@ -336,7 +340,7 @@ final class RdfProjector implements EventListener
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_APPROVED));
     }
 
-    private function handleRejected(Rejected $event, string $uri, Graph $graph): void
+    private function handleRejected(string $uri, Graph $graph): void
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_REJECTED));

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -255,28 +255,6 @@ final class RdfProjector implements EventListener
         $this->graphRepository->save($uri, $graph);
     }
 
-    private function handleGeoCoordinatesUpdated(GeoCoordinatesUpdated $event, string $uri, Graph $graph): void
-    {
-        $resource = $graph->resource($uri);
-        $coordinates = $event->getCoordinates();
-
-        $gmlTemplate = '<gml:Point srsName=\'http://www.opengis.net/def/crs/OGC/1.3/CRS84\'><gml:coordinates>%s, %s</gml:coordinates></gml:Point>';
-        $gmlCoordinate = sprintf($gmlTemplate, $coordinates->getLongitude()->toDouble(), $coordinates->getLatitude()->toDouble());
-
-        if (!$resource->hasProperty(self::PROPERTY_LOCATIE_GEOMETRIE)) {
-            $resource->add(self::PROPERTY_LOCATIE_GEOMETRIE, $resource->getGraph()->newBNode());
-        }
-
-        $geometryResource = $resource->getResource(self::PROPERTY_LOCATIE_GEOMETRIE);
-        if ($geometryResource->type() !== self::TYPE_GEOMETRIE) {
-            $geometryResource->setType(self::TYPE_GEOMETRIE);
-        }
-
-        $geometryResource->set(self::PROPERTY_GEOMETRIE_GML, new Literal($gmlCoordinate, null, 'geosparql:gmlLiteral'));
-
-        $this->graphRepository->save($uri, $graph);
-    }
-
     private function updateTranslatableAddressProperties(
         Resource $resource,
         Address $address,
@@ -314,6 +292,28 @@ final class RdfProjector implements EventListener
         } else {
             $this->deleteLanguageValue($addressResource, self::PROPERTY_ADRES_STRAATNAAM, $language);
         }
+    }
+
+    private function handleGeoCoordinatesUpdated(GeoCoordinatesUpdated $event, string $uri, Graph $graph): void
+    {
+        $resource = $graph->resource($uri);
+        $coordinates = $event->getCoordinates();
+
+        $gmlTemplate = '<gml:Point srsName=\'http://www.opengis.net/def/crs/OGC/1.3/CRS84\'><gml:coordinates>%s, %s</gml:coordinates></gml:Point>';
+        $gmlCoordinate = sprintf($gmlTemplate, $coordinates->getLongitude()->toDouble(), $coordinates->getLatitude()->toDouble());
+
+        if (!$resource->hasProperty(self::PROPERTY_LOCATIE_GEOMETRIE)) {
+            $resource->add(self::PROPERTY_LOCATIE_GEOMETRIE, $resource->getGraph()->newBNode());
+        }
+
+        $geometryResource = $resource->getResource(self::PROPERTY_LOCATIE_GEOMETRIE);
+        if ($geometryResource->type() !== self::TYPE_GEOMETRIE) {
+            $geometryResource->setType(self::TYPE_GEOMETRIE);
+        }
+
+        $geometryResource->set(self::PROPERTY_GEOMETRIE_GML, new Literal($gmlCoordinate, null, 'geosparql:gmlLiteral'));
+
+        $this->graphRepository->save($uri, $graph);
     }
 
     private function deleteLanguageValue(

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
+use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
 use CultuurNet\UDB3\Place\Events\TitleUpdated;
 use CultuurNet\UDB3\RDF\GraphRepository;
@@ -100,6 +101,7 @@ final class RdfProjector implements EventListener
             AddressUpdated::class => fn ($e) => $this->handleAddressUpdated($e, $uri, $graph),
             AddressTranslated::class => fn ($e) => $this->handleAddressTranslated($e, $uri, $graph),
             GeoCoordinatesUpdated::class => fn ($e) => $this->handleGeoCoordinatesUpdated($e, $uri, $graph),
+            Published::class => fn ($e) => $this->handlePublished($e, $uri, $graph),
         ];
 
         foreach ($events as $event) {
@@ -314,6 +316,12 @@ final class RdfProjector implements EventListener
         $geometryResource->set(self::PROPERTY_GEOMETRIE_GML, new Literal($gmlCoordinate, null, 'geosparql:gmlLiteral'));
 
         $this->graphRepository->save($uri, $graph);
+    }
+
+    private function handlePublished(Published $event, string $uri, Graph $graph): void
+    {
+        $resource = $graph->resource($uri);
+        $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, self::PROPERTY_LOCATIE_WORKFLOW_STATUS_READY_FOR_VALIDATION);
     }
 
     private function deleteLanguageValue(

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -40,6 +40,13 @@ final class RdfProjector implements EventListener
     private const TYPE_ADRES = 'locn:Address';
     private const TYPE_GEOMETRIE = 'locn:Geometry';
 
+    private const PROPERTY_LOCATIE_WORKFLOW_STATUS = 'udb:workflowStatus';
+    private const PROPERTY_LOCATIE_WORKFLOW_STATUS_DRAFT = 'https://data.publiq.be/concepts/workflowStatus/draft';
+    private const PROPERTY_LOCATIE_WORKFLOW_STATUS_READY_FOR_VALIDATION = 'https://data.publiq.be/concepts/workflowStatus/ready-for-validation';
+    private const PROPERTY_LOCATIE_WORKFLOW_STATUS_APPROVED = 'https://data.publiq.be/concepts/workflowStatus/approved';
+    private const PROPERTY_LOCATIE_WORKFLOW_STATUS_REJECTED = 'https://data.publiq.be/concepts/workflowStatus/rejected';
+    private const PROPERTY_LOCATIE_WORKFLOW_STATUS_DELETED = 'https://data.publiq.be/concepts/workflowStatus/deleted';
+
     private const PROPERTY_LOCATIE_AANGEMAAKT_OP = 'dcterms:created';
     private const PROPERTY_LOCATIE_LAATST_AANGEPAST = 'dcterms:modified';
     private const PROPERTY_LOCATIE_IDENTIFICATOR = 'adms:identifier';
@@ -114,6 +121,11 @@ final class RdfProjector implements EventListener
         // by add().
         if ($resource->type() !== self::TYPE_LOCATIE) {
             $resource->setType(self::TYPE_LOCATIE);
+        }
+
+        // Set the udb:workflowStatus property to draft if not set yet.
+        if (!$resource->hasProperty(self::PROPERTY_LOCATIE_WORKFLOW_STATUS)) {
+            $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, self::PROPERTY_LOCATIE_WORKFLOW_STATUS_DRAFT);
         }
 
         // Set the dcterms:created property if not set yet.

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -21,6 +21,7 @@ use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Place\Events\Moderation\Approved;
 use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\Events\Moderation\Rejected;
+use CultuurNet\UDB3\Place\Events\PlaceDeleted;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
 use CultuurNet\UDB3\Place\Events\TitleUpdated;
 use CultuurNet\UDB3\RDF\GraphRepository;
@@ -106,6 +107,7 @@ final class RdfProjector implements EventListener
             Published::class => fn ($e) => $this->handlePublished($e, $uri, $graph),
             Approved::class => fn ($e) => $this->handleApproved($e, $uri, $graph),
             Rejected::class => fn ($e) => $this->handleRejected($e, $uri, $graph),
+            PlaceDeleted::class => fn ($e) => $this->handleDeleted($e, $uri, $graph),
         ];
 
         foreach ($events as $event) {
@@ -338,6 +340,12 @@ final class RdfProjector implements EventListener
     {
         $resource = $graph->resource($uri);
         $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_REJECTED));
+    }
+
+    private function handleDeleted(PlaceDeleted $event, string $uri, Graph $graph): void
+    {
+        $resource = $graph->resource($uri);
+        $resource->set(self::PROPERTY_LOCATIE_WORKFLOW_STATUS, new Resource(self::PROPERTY_LOCATIE_WORKFLOW_STATUS_DELETED));
     }
 
     private function deleteLanguageValue(

--- a/src/RDF/InMemoryGraphRepository.php
+++ b/src/RDF/InMemoryGraphRepository.php
@@ -17,6 +17,13 @@ final class InMemoryGraphRepository implements GraphRepository
 
     public function get(string $uri): Graph
     {
-        return $this->graphs[$uri] ?? new Graph($uri);
+        if (isset($this->graphs[$uri])) {
+            // Return a clone, so that the graph is not updated in this repository without calling save() because it is
+            // updated by reference if it is not cloned first.
+            // Clone the object by serializing and unserializing it, so that is "deep" cloned, i.e. it's nested objects
+            // are also cloned.
+            return unserialize(serialize($this->graphs[$uri]));
+        }
+        return new Graph($uri);
     }
 }

--- a/src/RDF/RdfNamespaces.php
+++ b/src/RDF/RdfNamespaces.php
@@ -14,6 +14,7 @@ final class RdfNamespaces
         RdfNamespace::delete('dc');
 
         // Set custom namespaces.
+        RdfNamespace::set('udb', 'https://data.publiq.be/ns/uitdatabank#');
         RdfNamespace::set('adms', 'http://www.w3.org/ns/adms#');
         RdfNamespace::set('locn', 'http://www.w3.org/ns/locn#');
         RdfNamespace::set('generiek', 'https://data.vlaanderen.be/ns/generiek/#');

--- a/tests/Place/Events/PlaceCreatedTest.php
+++ b/tests/Place/Events/PlaceCreatedTest.php
@@ -15,6 +15,7 @@ use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -25,6 +26,7 @@ class PlaceCreatedTest extends TestCase
     private Address $address;
     private DateTimeImmutable $publicationDate;
     private PlaceCreated $placeCreated;
+    private PlaceCreated $placeCreatedWithoutPublicationDate;
 
     protected function setUp(): void
     {
@@ -35,7 +37,7 @@ class PlaceCreatedTest extends TestCase
             new CountryCode('BE')
         );
 
-        $this->publicationDate = \DateTimeImmutable::createFromFormat(
+        $this->publicationDate = DateTimeImmutable::createFromFormat(
             \DateTime::ISO8601,
             '2016-08-01T00:00:00+0200'
         );
@@ -49,6 +51,15 @@ class PlaceCreatedTest extends TestCase
             new Calendar(CalendarType::PERMANENT()),
             $this->publicationDate
         );
+
+        $this->placeCreatedWithoutPublicationDate = new PlaceCreated(
+            'id',
+            new Language('es'),
+            new Title('title'),
+            new EventType('id', 'label'),
+            $this->address,
+            new Calendar(CalendarType::PERMANENT())
+        );
     }
 
     /**
@@ -61,11 +72,21 @@ class PlaceCreatedTest extends TestCase
             new TypeUpdated('id', new EventType('id', 'label')),
             new AddressUpdated('id', $this->address),
             new CalendarUpdated('id', new Calendar(CalendarType::PERMANENT())),
+            new Published('id', DateTimeImmutable::createFromFormat(DateTimeImmutable::ISO8601, '2016-08-01T00:00:00+0200')),
         ];
+        $expectedWithoutPublicationDate = [
+            new TitleUpdated('id', new Title('title')),
+            new TypeUpdated('id', new EventType('id', 'label')),
+            new AddressUpdated('id', $this->address),
+            new CalendarUpdated('id', new Calendar(CalendarType::PERMANENT())),
+        ];
+
         $actual = $this->placeCreated->toGranularEvents();
+        $actualWithoutPublicationDate = $this->placeCreatedWithoutPublicationDate->toGranularEvents();
 
         $this->assertInstanceOf(ConvertsToGranularEvents::class, $this->placeCreated);
         $this->assertEquals($expected, $actual);
+        $this->assertEquals($expectedWithoutPublicationDate, $actualWithoutPublicationDate);
     }
 
     /**
@@ -281,7 +302,7 @@ class PlaceCreatedTest extends TestCase
                     new Calendar(
                         CalendarType::PERMANENT()
                     ),
-                    \DateTimeImmutable::createFromFormat(
+                    DateTimeImmutable::createFromFormat(
                         DateTimeInterface::ATOM,
                         '2016-08-01T00:00:00+02:00'
                     )

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -26,6 +26,7 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
+use CultuurNet\UDB3\Place\Events\Moderation\Approved;
 use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
@@ -221,6 +222,19 @@ class RdfProjectorTest extends TestCase
             new Published($placeId, new DateTime('2023-04-23T12:30:15+02:00')),
         ]);
         $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-published.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_approved(): void
+    {
+        $placeId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+        $this->project($placeId, [
+            $this->getPlaceCreated($placeId),
+            new Approved($placeId),
+        ]);
+        $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-approved.ttl'));
     }
 
     private function getPlaceCreated(string $placeId): PlaceCreated

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -27,6 +27,8 @@ use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Place\Events\Moderation\Approved;
+use CultuurNet\UDB3\Place\Events\Moderation\FlaggedAsDuplicate;
+use CultuurNet\UDB3\Place\Events\Moderation\FlaggedAsInappropriate;
 use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
@@ -249,6 +251,32 @@ class RdfProjectorTest extends TestCase
         $this->project($placeId, [
             $this->getPlaceCreated($placeId),
             new Rejected($placeId, new StringLiteral('Not good enough!')),
+        ]);
+        $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-rejected.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_flagged_as_duplicate(): void
+    {
+        $placeId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+        $this->project($placeId, [
+            $this->getPlaceCreated($placeId),
+            new FlaggedAsDuplicate($placeId),
+        ]);
+        $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-rejected.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_flagged_as_inappropriate(): void
+    {
+        $placeId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+        $this->project($placeId, [
+            $this->getPlaceCreated($placeId),
+            new FlaggedAsInappropriate($placeId),
         ]);
         $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-rejected.ttl'));
     }

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -28,12 +28,14 @@ use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Place\Events\Moderation\Approved;
 use CultuurNet\UDB3\Place\Events\Moderation\Published;
+use CultuurNet\UDB3\Place\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
 use CultuurNet\UDB3\Place\Events\TitleUpdated;
 use CultuurNet\UDB3\RDF\GraphRepository;
 use CultuurNet\UDB3\RDF\InMemoryGraphRepository;
 use CultuurNet\UDB3\RDF\InMemoryMainLanguageRepository;
+use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Title as LegacyTitle;
 use DateTime;
 use EasyRdf\Serialiser\Turtle;
@@ -235,6 +237,19 @@ class RdfProjectorTest extends TestCase
             new Approved($placeId),
         ]);
         $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-approved.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_rejected(): void
+    {
+        $placeId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+        $this->project($placeId, [
+            $this->getPlaceCreated($placeId),
+            new Rejected($placeId, new StringLiteral('Not good enough!')),
+        ]);
+        $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-rejected.ttl'));
     }
 
     private function getPlaceCreated(string $placeId): PlaceCreated

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -41,6 +41,7 @@ use CultuurNet\UDB3\RDF\InMemoryMainLanguageRepository;
 use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Title as LegacyTitle;
 use DateTime;
+use DateTimeImmutable;
 use EasyRdf\Serialiser\Turtle;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -101,6 +102,31 @@ class RdfProjectorTest extends TestCase
             $this->getPlaceCreated($placeId),
         ]);
         $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-created.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_place_created_with_publication_date(): void
+    {
+        $placeId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+        $this->project($placeId, [
+            new PlaceCreated(
+                $placeId,
+                new LegacyLanguage('nl'),
+                new LegacyTitle('Voorbeeld titel'),
+                new LegacyEventType('0.14.0.0.0', 'Monument'),
+                new LegacyAddress(
+                    new LegacyStreet('Martelarenlaan 1'),
+                    new LegacyPostalCode('3000'),
+                    new LegacyLocality('Leuven'),
+                    new CountryCode('BE')
+                ),
+                new Calendar(LegacyCalendarType::PERMANENT()),
+                new DateTimeImmutable('2022-12-31T12:30:15+01:00')
+            ),
+        ]);
+        $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-created-with-publication-date.ttl'));
     }
 
     /**

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -30,6 +30,7 @@ use CultuurNet\UDB3\Place\Events\Moderation\Approved;
 use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
+use CultuurNet\UDB3\Place\Events\PlaceDeleted;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
 use CultuurNet\UDB3\Place\Events\TitleUpdated;
 use CultuurNet\UDB3\RDF\GraphRepository;
@@ -250,6 +251,19 @@ class RdfProjectorTest extends TestCase
             new Rejected($placeId, new StringLiteral('Not good enough!')),
         ]);
         $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-rejected.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_deleted(): void
+    {
+        $placeId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+        $this->project($placeId, [
+            $this->getPlaceCreated($placeId),
+            new PlaceDeleted($placeId),
+        ]);
+        $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-deleted.ttl'));
     }
 
     private function getPlaceCreated(string $placeId): PlaceCreated

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -26,6 +26,7 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
 use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
+use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\TitleTranslated;
 use CultuurNet\UDB3\Place\Events\TitleUpdated;
@@ -207,6 +208,19 @@ class RdfProjectorTest extends TestCase
             ),
         ]);
         $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/geo-coordinates-updated.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_published(): void
+    {
+        $placeId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+        $this->project($placeId, [
+            $this->getPlaceCreated($placeId),
+            new Published($placeId, new DateTime('2023-04-23T12:30:15+02:00')),
+        ]);
+        $this->assertTurtleData($placeId, file_get_contents(__DIR__ . '/data/place-published.ttl'));
     }
 
     private function getPlaceCreated(string $placeId): PlaceCreated

--- a/tests/Place/ReadModel/RDF/data/address-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-translated.ttl
@@ -8,7 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/address-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-translated.ttl
@@ -1,4 +1,5 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -7,6 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/address-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-updated.ttl
@@ -8,7 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/address-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-updated.ttl
@@ -1,4 +1,5 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -7,6 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/geo-coordinates-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/geo-coordinates-updated.ttl
@@ -1,4 +1,5 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -8,6 +9,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/geo-coordinates-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/geo-coordinates-updated.ttl
@@ -9,7 +9,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/place-approved.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-approved.ttl
@@ -17,7 +17,7 @@
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
   ] ;
-  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;

--- a/tests/Place/ReadModel/RDF/data/place-approved.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-approved.ttl
@@ -1,0 +1,31 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+
+<https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a dcterms:Location ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
+    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
+    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+  ] ;
+  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:address [
+    a locn:Address ;
+    locn:adminUnitL1 "BE" ;
+    locn:postcode "3000" ;
+    locn:locatorDesignator "1" ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
+    locn:postName "Leuven"@nl ;
+    locn:thoroughfare "Martelarenlaan"@nl
+  ] ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
+  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/approved" .

--- a/tests/Place/ReadModel/RDF/data/place-approved.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-approved.ttl
@@ -28,4 +28,4 @@
     locn:thoroughfare "Martelarenlaan"@nl
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
-  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/approved" .
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/approved> .

--- a/tests/Place/ReadModel/RDF/data/place-approved.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-approved.ttl
@@ -11,7 +11,7 @@
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/place-created-with-publication-date.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created-with-publication-date.ttl
@@ -12,7 +12,7 @@
   dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/place-created-with-publication-date.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created-with-publication-date.ttl
@@ -18,7 +18,7 @@
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-01T12:30:15+01:00"^^xsd:string
   ] ;
-  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;

--- a/tests/Place/ReadModel/RDF/data/place-created-with-publication-date.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created-with-publication-date.ttl
@@ -1,0 +1,31 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+
+<https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a dcterms:Location ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
+    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
+    generiek:versieIdentificator "2023-01-01T12:30:15+01:00"^^xsd:string
+  ] ;
+  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:address [
+    a locn:Address ;
+    locn:adminUnitL1 "BE" ;
+    locn:postcode "3000" ;
+    locn:locatorDesignator "1" ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
+    locn:postName "Leuven"@nl ;
+    locn:thoroughfare "Martelarenlaan"@nl
+  ] ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/ready-for-validation> .

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -8,7 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -1,4 +1,5 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -7,6 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [

--- a/tests/Place/ReadModel/RDF/data/place-deleted.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-deleted.ttl
@@ -17,7 +17,7 @@
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
   ] ;
-  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;

--- a/tests/Place/ReadModel/RDF/data/place-deleted.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-deleted.ttl
@@ -1,0 +1,31 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+
+<https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a dcterms:Location ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
+    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
+    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+  ] ;
+  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:address [
+    a locn:Address ;
+    locn:adminUnitL1 "BE" ;
+    locn:postcode "3000" ;
+    locn:locatorDesignator "1" ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
+    locn:postName "Leuven"@nl ;
+    locn:thoroughfare "Martelarenlaan"@nl
+  ] ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/deleted> .

--- a/tests/Place/ReadModel/RDF/data/place-deleted.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-deleted.ttl
@@ -11,7 +11,7 @@
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/place-published.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-published.ttl
@@ -17,7 +17,7 @@
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
   ] ;
-  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;

--- a/tests/Place/ReadModel/RDF/data/place-published.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-published.ttl
@@ -28,4 +28,4 @@
     locn:thoroughfare "Martelarenlaan"@nl
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
-  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/ready-for-validation" .
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/ready-for-validation> .

--- a/tests/Place/ReadModel/RDF/data/place-published.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-published.ttl
@@ -1,0 +1,31 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+
+<https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a dcterms:Location ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
+    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
+    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+  ] ;
+  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:address [
+    a locn:Address ;
+    locn:adminUnitL1 "BE" ;
+    locn:postcode "3000" ;
+    locn:locatorDesignator "1" ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
+    locn:postName "Leuven"@nl ;
+    locn:thoroughfare "Martelarenlaan"@nl
+  ] ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
+  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/ready-for-validation" .

--- a/tests/Place/ReadModel/RDF/data/place-published.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-published.ttl
@@ -11,7 +11,7 @@
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/place-rejected.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-rejected.ttl
@@ -28,4 +28,4 @@
     locn:thoroughfare "Martelarenlaan"@nl
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
-  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/rejected" .
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/rejected> .

--- a/tests/Place/ReadModel/RDF/data/place-rejected.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-rejected.ttl
@@ -17,7 +17,7 @@
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
     generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
   ] ;
-  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;

--- a/tests/Place/ReadModel/RDF/data/place-rejected.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-rejected.ttl
@@ -11,7 +11,7 @@
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;
-    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
     dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
     generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
     generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;

--- a/tests/Place/ReadModel/RDF/data/place-rejected.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-rejected.ttl
@@ -1,0 +1,31 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+
+<https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a dcterms:Location ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea" ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
+    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
+    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
+    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+  ] ;
+  locn:geographicName "Voorbeeld titel"@nl ;
+  locn:address [
+    a locn:Address ;
+    locn:adminUnitL1 "BE" ;
+    locn:postcode "3000" ;
+    locn:locatorDesignator "1" ;
+    locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
+    locn:postName "Leuven"@nl ;
+    locn:thoroughfare "Martelarenlaan"@nl
+  ] ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
+  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/rejected" .

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -8,7 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -1,4 +1,5 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -7,6 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -8,7 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -1,4 +1,5 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -7,6 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -8,7 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
-  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -1,4 +1,5 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -7,6 +8,7 @@
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a dcterms:Location ;
+  udb:workflowStatus "https://data.publiq.be/concepts/workflowStatus/draft" ;
   dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
   adms:identifier [
     a adms:Identifier ;


### PR DESCRIPTION
### Added

- Added `udb:workflowStatus` predicate based on `PlaceCreated`, `PlaceDeleted`, `Published`, `Approved`, `Rejected`, `FlaggedAsDuplicate` and `FlaggedAsInappropriate` events (based on how the `workflowStatus` property is set in the JSON projector)

---
Ticket: https://jira.uitdatabank.be/browse/III-5508
