### PR TITLE
III-5544 polyfill mainimage

### DIFF
--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -38,6 +38,7 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
         $document = $this->removeObsoleteProperties($document);
         $document = $this->removeNullLabels($document);
         $document = $this->removeThemes($document);
+        $document = $this->fixMainImage($document);
         return $this->fixDuplicateLabelVisibility($document);
     }
 
@@ -259,6 +260,20 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
                     )
                 );
 
+                return $json;
+            }
+        );
+    }
+
+    private function fixMainImage(JsonDocument $jsonDocument): JsonDocument
+    {
+        return $jsonDocument->applyAssoc(
+            function (array $json) {
+                if (isset($json['mediaObject']) && is_array($json['mediaObject'])) {
+                    return $json;
+                }
+
+                unset($json['image']);
                 return $json;
             }
         );

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -38,7 +38,7 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
         $document = $this->removeObsoleteProperties($document);
         $document = $this->removeNullLabels($document);
         $document = $this->removeThemes($document);
-        $document = $this->fixMainImage($document);
+        $document = $this->removeMainImageWhenMediaObjectIsEmpty($document);
         return $this->fixDuplicateLabelVisibility($document);
     }
 
@@ -265,7 +265,7 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
         );
     }
 
-    private function fixMainImage(JsonDocument $jsonDocument): JsonDocument
+    private function removeMainImageWhenMediaObjectIsEmpty(JsonDocument $jsonDocument): JsonDocument
     {
         return $jsonDocument->applyAssoc(
             function (array $json) {

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -738,6 +738,32 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
             ->assertReturnedDocumentDoesNotContainKey('hiddenLabels');
     }
 
+    public function it_should_keep_main_image_if_media_objects_are_present(): void
+    {
+        $this->given(
+            [
+                'mediaObject' => [
+                    [
+                        '@id' => 'https://io.uitdatabank.dev/images/0fd31560-4af1-4f60-9e10-cd0a5e4ee081',
+                        'id' => '0fd31560-4af1-4f60-9e10-cd0a5e4ee081',
+                    ],
+                ],
+                'image' => 'https://images.uitdatabank.be/0fd31560-4af1-4f60-9e10-cd0a5e4ee081.png',
+            ]
+        )
+            ->assertReturnedDocumentContains(['image' => 'https://images.uitdatabank.be/0fd31560-4af1-4f60-9e10-cd0a5e4ee081.png']);
+    }
+
+    public function it_should_remove_main_image_if_no_media_objects_are_present(): void
+    {
+        $this->given(
+            [
+                'image' => 'https://images.uitdatabank.be/0fd31560-4af1-4f60-9e10-cd0a5e4ee081.png',
+            ]
+        )
+        ->assertReturnedDocumentDoesNotContainKey('image');
+    }
+
     private function given(array $given): self
     {
         $this->repository->save(


### PR DESCRIPTION
### Added

- Polyfill to remove `image` from `json` if no `mediaObjects` are present
- tests for new Polyfill

### Note
- This does not handle the edge case where an a legacy `mainImage` is removed but the `json` still contains other images.


---
Ticket: https://jira.uitdatabank.be/browse/III-5544
