### PR TITLE
III-5425 Remove `generiek` part of identificator

### DIFF
--- a/src/Event/ReadModel/RDF/RdfProjector.php
+++ b/src/Event/ReadModel/RDF/RdfProjector.php
@@ -57,8 +57,6 @@ final class RdfProjector implements EventListener
         GraphEditor::for($graph)->setGeneralProperties(
             $uri,
             self::TYPE_ACTIVITEIT,
-            $this->iriGenerator->iri(''),
-            $domainMessage->getId(),
             $domainMessage->getRecordedOn()->toNative()->format(DateTime::ATOM)
         );
 

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -85,8 +85,6 @@ final class RdfProjector implements EventListener
         GraphEditor::for($graph)->setGeneralProperties(
             $uri,
             self::TYPE_LOCATIE,
-            $this->iriGenerator->iri(''),
-            $domainMessage->getId(),
             $domainMessage->getRecordedOn()->toNative()->format(DateTime::ATOM)
         );
 

--- a/src/RDF/Editor/GraphEditor.php
+++ b/src/RDF/Editor/GraphEditor.php
@@ -22,9 +22,6 @@ final class GraphEditor
     private const PROPERTY_IDENTIFICATOR_NOTATION = 'skos:notation';
     private const PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR = 'dcterms:creator';
     private const PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT = 'https://fixme.com/example/dataprovider/publiq';
-    private const PROPERTY_IDENTIFICATOR_NAAMRUIMTE = 'generiek:naamruimte';
-    private const PROPERTY_IDENTIFICATOR_LOKALE_IDENTIFICATOR = 'generiek:lokaleIdentificator';
-    private const PROPERTY_IDENTIFICATOR_VERSIE_ID = 'generiek:versieIdentificator';
 
     private function __construct(Graph $graph)
     {
@@ -39,8 +36,6 @@ final class GraphEditor
     public function setGeneralProperties(
         string $resourceUri,
         string $type,
-        string $namespace,
-        string $id,
         string $recordedOn
     ): self {
         $resource = $this->graph->resource($resourceUri);
@@ -77,14 +72,8 @@ final class GraphEditor
             $identificator->setType(self::TYPE_IDENTIFICATOR);
             $identificator->add(self::PROPERTY_IDENTIFICATOR_NOTATION, new Literal($resourceUri, null, 'xsd:anyUri'));
             $identificator->add(self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR, new Resource(self::PROPERTY_IDENTIFICATOR_TOEGEKEND_DOOR_AGENT));
-            $identificator->add(self::PROPERTY_IDENTIFICATOR_NAAMRUIMTE, new Literal($namespace, null, 'xsd:string'));
-            $identificator->add(self::PROPERTY_IDENTIFICATOR_LOKALE_IDENTIFICATOR, new Literal($id, null, 'xsd:string'));
             $resource->add(self::PROPERTY_IDENTIFICATOR, $identificator);
         }
-
-        // Add/update the generiek:versieIdentificator inside the linked adms:Identifier on every change.
-        $identificator = $resource->getResource(self::PROPERTY_IDENTIFICATOR);
-        $identificator->set(self::PROPERTY_IDENTIFICATOR_VERSIE_ID, new Literal($recordedOn, null, 'xsd:string'));
 
         return $this;
     }

--- a/tests/Event/ReadModel/RDF/data/approved.ttl
+++ b/tests/Event/ReadModel/RDF/data/approved.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -12,10 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/events/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   dcterms:title "Faith no more"@nl ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/deleted.ttl
+++ b/tests/Event/ReadModel/RDF/data/deleted.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -12,10 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/events/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   dcterms:title "Faith no more"@nl ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/published.ttl
+++ b/tests/Event/ReadModel/RDF/data/published.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -12,10 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/events/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   dcterms:title "Faith no more"@nl ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/rejected.ttl
+++ b/tests/Event/ReadModel/RDF/data/rejected.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -12,10 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/events/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   dcterms:title "Faith no more"@nl ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Event/ReadModel/RDF/data/title-translated.ttl
@@ -4,7 +4,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a cidoc:E7_Activity ;
@@ -13,10 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/events/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   dcterms:title "Faith no more"@nl, "Faith no more im Konzert"@de .

--- a/tests/Event/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Event/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -4,7 +4,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a cidoc:E7_Activity ;
@@ -13,10 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/events/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-05T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   dcterms:modified "2023-01-05T12:30:15+01:00"^^xsd:dateTime ;
   dcterms:title "Faith no more in concert [UPDATED]"@nl, "Faith no more im Konzert [UPDATED]"@de .

--- a/tests/Event/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Event/ReadModel/RDF/data/title-updated.ttl
@@ -4,7 +4,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a cidoc:E7_Activity ;
@@ -13,10 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/events/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   dcterms:title "Faith no more in concert"@nl .

--- a/tests/Place/ReadModel/RDF/data/address-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-translated.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -13,10 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [

--- a/tests/Place/ReadModel/RDF/data/address-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/address-updated.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -13,10 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [

--- a/tests/Place/ReadModel/RDF/data/geo-coordinates-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/geo-coordinates-updated.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 @prefix geosparql: <http://www.opengis.net/ont/geosparql#> .
 
@@ -14,10 +13,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [

--- a/tests/Place/ReadModel/RDF/data/place-approved.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-approved.ttl
@@ -2,7 +2,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 @prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 
@@ -12,10 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [

--- a/tests/Place/ReadModel/RDF/data/place-created.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-created.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -14,10 +13,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-01T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [

--- a/tests/Place/ReadModel/RDF/data/place-deleted.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-deleted.ttl
@@ -2,7 +2,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 @prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 
@@ -12,10 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [

--- a/tests/Place/ReadModel/RDF/data/place-published.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-published.ttl
@@ -2,7 +2,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 @prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 
@@ -12,10 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [

--- a/tests/Place/ReadModel/RDF/data/place-rejected.ttl
+++ b/tests/Place/ReadModel/RDF/data/place-rejected.ttl
@@ -2,7 +2,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 @prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 
@@ -12,10 +11,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:locatorName "Voorbeeld titel"@nl ;
   locn:address [

--- a/tests/Place/ReadModel/RDF/data/title-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-translated.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -13,10 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:address [
     a locn:Address ;

--- a/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated-and-translated.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -13,10 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-05T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:address [
     a locn:Address ;

--- a/tests/Place/ReadModel/RDF/data/title-updated.ttl
+++ b/tests/Place/ReadModel/RDF/data/title-updated.ttl
@@ -3,7 +3,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix generiek: <https://data.vlaanderen.be/ns/generiek/#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 
 <https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -13,10 +12,7 @@
   adms:identifier [
     a adms:Identifier ;
     skos:notation "https://mock.data.publiq.be/places/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
-    dcterms:creator <https://fixme.com/example/dataprovider/publiq> ;
-    generiek:naamruimte "https://mock.data.publiq.be/places/"^^xsd:string ;
-    generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:string ;
-    generiek:versieIdentificator "2023-01-02T12:30:15+01:00"^^xsd:string
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
   ] ;
   locn:address [
     a locn:Address ;


### PR DESCRIPTION
### Removed
- Removed `generiek` part of identificator

---
Ticket: https://jira.uitdatabank.be/browse/III-5425
