### PR TITLE
Cast start id to int

### DIFF
--- a/app/Console/Command/ReplayCommand.php
+++ b/app/Console/Command/ReplayCommand.php
@@ -117,7 +117,7 @@ final class ReplayCommand extends AbstractCommand
         $startId = $input->getOption(self::OPTION_START_ID);
         $cdbids = $input->getOption(self::OPTION_CDBID);
 
-        $stream = $this->getEventStream($startId, $aggregateType, $cdbids);
+        $stream = $this->getEventStream((int) $startId, $aggregateType, $cdbids);
 
         ReplayFlaggingMiddleware::startReplayMode();
         InterceptingMiddleware::startIntercepting(


### PR DESCRIPTION
### Fixed

- Start id is casted to int before being passed to `getEventStream()`, as all arguments/options are always strings (since the whole command is basically a single string)

---

Discovered by @willaerk while doing a partial replay on acc:

```
root@udb3-web-acc02:/var/www/udb3-backend# bin/udb3.php replay --start-id 10500213
Are you sure you want to replay events ( start id: 10500213 )? [y/N]y
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to CultuurNet\UDB3\Console\Command\ReplayCommand::getEventStream() must be of the type int or null, string given, called in /var/www/udb3-backend/app/Console/Command/ReplayCommand.php on line 120 and defined in /var/www/udb3-backend/app/Console/Command/ReplayCommand.php:201
Stack trace:
#0 /var/www/udb3-backend/app/Console/Command/ReplayCommand.php(120): CultuurNet\UDB3\Console\Command\ReplayCommand->getEventStream()
#1 /var/www/udb3-backend/vendor/symfony/console/Command/Command.php(255): CultuurNet\UDB3\Console\Command\ReplayCommand->execute()
#2 /var/www/udb3-backend/vendor/symfony/console/Application.php(917): Symfony\Component\Console\Command\Command->run()
#3 /var/www/udb3-backend/vendor/symfony/console/Application.php(269): Symfony\Component\Console\Application->doRunCommand()
#4 /var/www/udb3-backend/vendor/symfony/console/Application.php(145): Symfony\Component\Console\Application->doRun()
#5 /var/www/udb3-backend/bin/udb3.php(43): Symfony\Component\Console\Appli in /var/www/udb3-backend/app/Console/Command/ReplayCommand.php on line 201
```
