### PR TITLE
III-5363 Handle `calendarUpdated` on event (single/multiple/periodic)

### DIFF
--- a/app/Event/EventRdfServiceProvider.php
+++ b/app/Event/EventRdfServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use CultuurNet\UDB3\Event\ReadModel\RDF\CacheLocationIdRepository;
 use CultuurNet\UDB3\Event\ReadModel\RDF\RdfProjector;
 use CultuurNet\UDB3\RDF\MainLanguageRepository;
 use CultuurNet\UDB3\RDF\RdfServiceProvider;
@@ -25,6 +26,7 @@ final class EventRdfServiceProvider extends AbstractServiceProvider
             fn (): RdfProjector => new RdfProjector(
                 $this->container->get(MainLanguageRepository::class),
                 RdfServiceProvider::createGraphStoreRepository($this->container->get('config')['rdf']['eventsGraphStoreUrl']),
+                new CacheLocationIdRepository($this->container->get('cache')('rdf_location_id')),
                 RdfServiceProvider::createIriGenerator($this->container->get('config')['rdf']['eventsRdfBaseUri']),
                 RdfServiceProvider::createIriGenerator($this->container->get('config')['rdf']['placesRdfBaseUri']),
             )

--- a/src/Event/ReadModel/RDF/CacheLocationIdRepository.php
+++ b/src/Event/ReadModel/RDF/CacheLocationIdRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\ReadModel\RDF;
+
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use Doctrine\Common\Cache\Cache;
+
+final class CacheLocationIdRepository implements LocationIdRepository
+{
+    private Cache $cache;
+
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function save(string $resourceId, LocationId $locationId): void
+    {
+        $this->cache->save($resourceId, $locationId->toString());
+    }
+
+    public function get(string $resourceId): ?LocationId
+    {
+        $value = $this->cache->fetch($resourceId);
+        if ($value === false) {
+            return null;
+        }
+        return new LocationId($value);
+    }
+}

--- a/src/Event/ReadModel/RDF/InMemoryLocationIdRepository.php
+++ b/src/Event/ReadModel/RDF/InMemoryLocationIdRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\ReadModel\RDF;
+
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+
+final class InMemoryLocationIdRepository implements LocationIdRepository
+{
+    private array $locations;
+
+    public function save(string $resourceId, LocationId $locationId): void
+    {
+        $this->locations[$resourceId] = $locationId->toString();
+    }
+
+    public function get(string $resourceId): ?LocationId
+    {
+        return $this->locations[$resourceId] ? new LocationId($this->locations[$resourceId]) : null;
+    }
+}

--- a/src/Event/ReadModel/RDF/LocationIdRepository.php
+++ b/src/Event/ReadModel/RDF/LocationIdRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\ReadModel\RDF;
+
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+
+interface LocationIdRepository
+{
+    public function save(string $resourceId, LocationId $locationId): void;
+    public function get(string $resourceId): ?LocationId;
+}

--- a/src/Event/ReadModel/RDF/RdfProjector.php
+++ b/src/Event/ReadModel/RDF/RdfProjector.php
@@ -204,11 +204,20 @@ final class RdfProjector implements EventListener
 
     private function handleCalendarUpdated(CalendarUpdated $event, string $uri, Graph $graph): void
     {
-        if ($event->getCalendar()->getType()->sameAs(CalendarType::SINGLE()) ||
-            $event->getCalendar()->getType()->sameAs(CalendarType::MULTIPLE())) {
+        $calendar = $event->getCalendar();
+
+        $timestamps = $event->getCalendar()->getTimestamps();
+        if ($calendar->getType()->sameAs(CalendarType::PERIODIC())) {
+            $timestamps[] = new Timestamp(
+                $calendar->getStartDate(),
+                $calendar->getEndDate()
+            );
+        }
+
+        if (!empty($timestamps)) {
             $this->deleteAllSpaceTimeResources($uri, $graph);
 
-            foreach ($event->getCalendar()->getTimestamps() as $timestamp) {
+            foreach ($timestamps as $timestamp) {
                 $spaceTimeResource = $this->createSpaceTimeResource($uri, $graph);
 
                 $this->addLocation($spaceTimeResource);

--- a/src/RDF/RdfNamespaces.php
+++ b/src/RDF/RdfNamespaces.php
@@ -21,5 +21,6 @@ final class RdfNamespaces
         RdfNamespace::set('geosparql', 'http://www.opengis.net/ont/geosparql#');
         RdfNamespace::set('cidoc', 'http://www.cidoc-crm.org/cidoc-crm/');
         RdfNamespace::set('cpa', 'https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.');
+        RdfNamespace::set('m8g', 'http://data.europa.eu/m8g/');
     }
 }

--- a/src/RDF/RdfNamespaces.php
+++ b/src/RDF/RdfNamespaces.php
@@ -22,5 +22,6 @@ final class RdfNamespaces
         RdfNamespace::set('cidoc', 'http://www.cidoc-crm.org/cidoc-crm/');
         RdfNamespace::set('cpa', 'https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.');
         RdfNamespace::set('m8g', 'http://data.europa.eu/m8g/');
+        RdfNamespace::set('cp', 'https://data.vlaanderen.be/ns/cultuurparticipatie#');
     }
 }

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -10,6 +10,7 @@ use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Description;
+use CultuurNet\UDB3\Event\Events\CalendarUpdated;
 use CultuurNet\UDB3\Event\Events\DescriptionTranslated;
 use CultuurNet\UDB3\Event\Events\DescriptionUpdated;
 use CultuurNet\UDB3\Event\Events\EventCreated;
@@ -31,8 +32,10 @@ use CultuurNet\UDB3\RDF\InMemoryGraphRepository;
 use CultuurNet\UDB3\RDF\InMemoryMainLanguageRepository;
 use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Theme;
+use CultuurNet\UDB3\Timestamp;
 use CultuurNet\UDB3\Title;
 use DateTime;
+use DateTimeImmutable;
 use EasyRdf\Serialiser\Turtle;
 use PHPUnit\Framework\TestCase;
 
@@ -250,6 +253,34 @@ class RdfProjectorTest extends TestCase
         ]);
 
         $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/location-updated.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_calendar_updated_to_single(): void
+    {
+        $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+
+        $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
+        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
+
+        $this->project($eventId, [
+            $this->getEventCreated($eventId),
+            new CalendarUpdated(
+                $eventId,
+                new Calendar(
+                    CalendarType::SINGLE(),
+                    $startDate,
+                    $endDate,
+                    [
+                        new Timestamp($startDate, $endDate),
+                    ]
+                ),
+            ),
+        ]);
+
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/calendar-updated-single.ttl'));
     }
 
     private function getEventCreated(string $eventId): EventCreated

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -283,6 +283,84 @@ class RdfProjectorTest extends TestCase
         $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/calendar-updated-single.ttl'));
     }
 
+    /**
+     * @test
+     */
+    public function it_handles_calendar_updated_to_multiple(): void
+    {
+        $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+
+        $this->project($eventId, [
+            $this->getEventCreated($eventId),
+            new CalendarUpdated(
+                $eventId,
+                new Calendar(
+                    CalendarType::MULTIPLE(),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00'),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-02T17:00:00+01:00'),
+                    [
+                        new Timestamp(
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00'),
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        ),
+                        new Timestamp(
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T12:00:00+01:00'),
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T17:00:00+01:00')
+                        ),
+                    ]
+                ),
+            ),
+            new CalendarUpdated(
+                $eventId,
+                new Calendar(
+                    CalendarType::SINGLE(),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T12:00:00+01:00'),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00'),
+                    [
+                        new Timestamp(
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T12:00:00+01:00'),
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
+                        ),
+                    ]
+                ),
+            ),
+        ]);
+
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/calendar-updated-single.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_multiple_calendar_updated(): void
+    {
+        $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+
+        $this->project($eventId, [
+            $this->getEventCreated($eventId),
+            new CalendarUpdated(
+                $eventId,
+                new Calendar(
+                    CalendarType::MULTIPLE(),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00'),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-02T17:00:00+01:00'),
+                    [
+                        new Timestamp(
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00'),
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        ),
+                        new Timestamp(
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T12:00:00+01:00'),
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T17:00:00+01:00')
+                        ),
+                    ]
+                ),
+            ),
+        ]);
+
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/calendar-updated-multiple.ttl'));
+    }
+
     private function getEventCreated(string $eventId): EventCreated
     {
         return new EventCreated(

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -258,6 +258,33 @@ class RdfProjectorTest extends TestCase
     /**
      * @test
      */
+    public function it_handles_event_created_with_single_calendar(): void
+    {
+        $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+
+        $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
+        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00');
+
+        $this->project($eventId, [
+            $this->getEventCreated(
+                $eventId,
+                new Calendar(
+                    CalendarType::SINGLE(),
+                    $startDate,
+                    $endDate,
+                    [
+                        new Timestamp($startDate, $endDate),
+                    ]
+                ),
+            ),
+        ]);
+
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/created-with-calendar-single.ttl'));
+    }
+
+    /**
+     * @test
+     */
     public function it_handles_calendar_updated_to_single(): void
     {
         $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
@@ -361,7 +388,7 @@ class RdfProjectorTest extends TestCase
         $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/various-calendar-updated.ttl'));
     }
 
-    private function getEventCreated(string $eventId): EventCreated
+    private function getEventCreated(string $eventId, ?Calendar $calendar = null): EventCreated
     {
         return new EventCreated(
             $eventId,
@@ -369,7 +396,7 @@ class RdfProjectorTest extends TestCase
             new Title('Faith no more'),
             new EventType('0.50.4.0.0', 'Concert'),
             new LocationId('bfc60a14-6208-4372-942e-86e63744769a'),
-            new Calendar(CalendarType::PERMANENT()),
+            $calendar ?: new Calendar(CalendarType::PERMANENT()),
             new Theme('1.8.1.0.0', 'Rock')
         );
     }

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -258,6 +258,27 @@ class RdfProjectorTest extends TestCase
     /**
      * @test
      */
+    public function it_handles_event_created_with_periodic_calendar(): void
+    {
+        $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+
+        $this->project($eventId, [
+            $this->getEventCreated(
+                $eventId,
+                new Calendar(
+                    CalendarType::PERIODIC(),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00'),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2022-01-01T17:00:00+01:00'),
+                ),
+            ),
+        ]);
+
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/created-with-calendar-periodic.ttl'));
+    }
+
+    /**
+     * @test
+     */
     public function it_handles_event_created_with_single_calendar(): void
     {
         $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
@@ -311,6 +332,28 @@ class RdfProjectorTest extends TestCase
         ]);
 
         $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/created-with-calendar-multiple.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_calendar_updated_to_periodic(): void
+    {
+        $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+
+        $this->project($eventId, [
+            $this->getEventCreated($eventId),
+            new CalendarUpdated(
+                $eventId,
+                new Calendar(
+                    CalendarType::PERIODIC(),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00'),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2022-01-01T17:00:00+01:00'),
+                ),
+            ),
+        ]);
+
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/calendar-updated-periodic.ttl'));
     }
 
     /**

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -263,7 +263,7 @@ class RdfProjectorTest extends TestCase
         $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
 
         $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
-        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
+        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00');
 
         $this->project($eventId, [
             $this->getEventCreated($eventId),
@@ -310,29 +310,15 @@ class RdfProjectorTest extends TestCase
                     ]
                 ),
             ),
-            new CalendarUpdated(
-                $eventId,
-                new Calendar(
-                    CalendarType::SINGLE(),
-                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T12:00:00+01:00'),
-                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00'),
-                    [
-                        new Timestamp(
-                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T12:00:00+01:00'),
-                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
-                        ),
-                    ]
-                ),
-            ),
         ]);
 
-        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/calendar-updated-single.ttl'));
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/calendar-updated-multiple.ttl'));
     }
 
     /**
      * @test
      */
-    public function it_handles_multiple_calendar_updated(): void
+    public function it_handles_various_calendar_updated(): void
     {
         $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
 
@@ -342,23 +328,37 @@ class RdfProjectorTest extends TestCase
                 $eventId,
                 new Calendar(
                     CalendarType::MULTIPLE(),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T12:00:00+01:00'),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-03T17:00:00+01:00'),
+                    [
+                        new Timestamp(
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T12:00:00+01:00'),
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T17:00:00+01:00')
+                        ),
+                        new Timestamp(
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T12:00:00+01:00'),
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
+                        ),
+                    ]
+                ),
+            ),
+            new CalendarUpdated(
+                $eventId,
+                new Calendar(
+                    CalendarType::SINGLE(),
                     DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00'),
-                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-02T17:00:00+01:00'),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00'),
                     [
                         new Timestamp(
                             DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00'),
                             DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
-                        ),
-                        new Timestamp(
-                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T12:00:00+01:00'),
-                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T17:00:00+01:00')
                         ),
                     ]
                 ),
             ),
         ]);
 
-        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/calendar-updated-multiple.ttl'));
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/various-calendar-updated.ttl'));
     }
 
     private function getEventCreated(string $eventId): EventCreated

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -285,6 +285,37 @@ class RdfProjectorTest extends TestCase
     /**
      * @test
      */
+    public function it_handles_event_created_with_multiple_calendar(): void
+    {
+        $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+
+        $this->project($eventId, [
+            $this->getEventCreated(
+                $eventId,
+                new Calendar(
+                    CalendarType::MULTIPLE(),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00'),
+                    DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-02T17:00:00+01:00'),
+                    [
+                        new Timestamp(
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00'),
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        ),
+                        new Timestamp(
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T12:00:00+01:00'),
+                            DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-02T17:00:00+01:00')
+                        ),
+                    ]
+                ),
+            ),
+        ]);
+
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/created-with-calendar-multiple.ttl'));
+    }
+
+    /**
+     * @test
+     */
     public function it_handles_calendar_updated_to_single(): void
     {
         $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -52,6 +52,7 @@ class RdfProjectorTest extends TestCase
         $this->rdfProjector = new RdfProjector(
             new InMemoryMainLanguageRepository(),
             $this->graphRepository,
+            new InMemoryLocationIdRepository(),
             new CallableIriGenerator(fn (string $item): string => 'https://mock.data.publiq.be/events/' . $item),
             new CallableIriGenerator(fn (string $item): string => 'https://mock.data.publiq.be/places/' . $item),
         );

--- a/tests/Event/ReadModel/RDF/data/calendar-updated-multiple.ttl
+++ b/tests/Event/ReadModel/RDF/data/calendar-updated-multiple.ttl
@@ -22,7 +22,7 @@
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   cp:ruimtetijd [
     a cidoc:E92 ;
-    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P161 <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
     cidoc:P160 [
       a m8g:PeriodOfTime ;
       m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;
@@ -30,7 +30,7 @@
     ]
   ], [
     a cidoc:E92 ;
-    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P161 <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
     cidoc:P160 [
       a m8g:PeriodOfTime ;
       m8g:startTime "2018-01-02T12:00:00+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/calendar-updated-multiple.ttl
+++ b/tests/Event/ReadModel/RDF/data/calendar-updated-multiple.ttl
@@ -1,0 +1,39 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
+@prefix cp: <https://data.vlaanderen.be/ns/cultuurparticipatie#> .
+@prefix m8g: <http://data.europa.eu/m8g/> .
+
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a cidoc:E7_Activity ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
+  ] ;
+  dcterms:title "Faith no more"@nl ;
+  cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
+  cp:ruimtetijd [
+    a cidoc:E92 ;
+    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P160 [
+      a m8g:PeriodOfTime ;
+      m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;
+      m8g:endTime "2018-01-01T17:00:00+01:00"^^xsd:dateTime
+    ]
+  ], [
+    a cidoc:E92 ;
+    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P160 [
+      a m8g:PeriodOfTime ;
+      m8g:startTime "2018-01-02T12:00:00+01:00"^^xsd:dateTime ;
+      m8g:endTime "2018-01-02T17:00:00+01:00"^^xsd:dateTime
+    ]
+  ] .

--- a/tests/Event/ReadModel/RDF/data/calendar-updated-periodic.ttl
+++ b/tests/Event/ReadModel/RDF/data/calendar-updated-periodic.ttl
@@ -22,7 +22,7 @@
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   cp:ruimtetijd [
     a cidoc:E92 ;
-    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P161 <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
     cidoc:P160 [
       a m8g:PeriodOfTime ;
       m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/calendar-updated-periodic.ttl
+++ b/tests/Event/ReadModel/RDF/data/calendar-updated-periodic.ttl
@@ -1,0 +1,31 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
+@prefix cp: <https://data.vlaanderen.be/ns/cultuurparticipatie#> .
+@prefix m8g: <http://data.europa.eu/m8g/> .
+
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a cidoc:E7_Activity ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
+  ] ;
+  dcterms:title "Faith no more"@nl ;
+  cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
+  cp:ruimtetijd [
+    a cidoc:E92 ;
+    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P160 [
+      a m8g:PeriodOfTime ;
+      m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;
+      m8g:endTime "2022-01-01T17:00:00+01:00"^^xsd:dateTime
+    ]
+  ] .

--- a/tests/Event/ReadModel/RDF/data/calendar-updated-single.ttl
+++ b/tests/Event/ReadModel/RDF/data/calendar-updated-single.ttl
@@ -22,7 +22,7 @@
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
   cp:ruimtetijd [
     a cidoc:E92 ;
-    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P161 <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
     cidoc:P160 [
       a m8g:PeriodOfTime ;
       m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/calendar-updated-single.ttl
+++ b/tests/Event/ReadModel/RDF/data/calendar-updated-single.ttl
@@ -1,0 +1,26 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
+@prefix m8g: <http://data.europa.eu/m8g/> .
+
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a cidoc:E7_Activity ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
+  ] ;
+  dcterms:title "Faith no more"@nl ;
+  cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
+  cidoc:P4_has_time-span [
+    a m8g:PeriodOfTime ;
+    m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;
+    m8g:endTime "2020-01-01T12:00:00+01:00"^^xsd:dateTime
+  ] .

--- a/tests/Event/ReadModel/RDF/data/calendar-updated-single.ttl
+++ b/tests/Event/ReadModel/RDF/data/calendar-updated-single.ttl
@@ -5,6 +5,7 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
+@prefix cp: <https://data.vlaanderen.be/ns/cultuurparticipatie#> .
 @prefix m8g: <http://data.europa.eu/m8g/> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -19,8 +20,12 @@
   dcterms:title "Faith no more"@nl ;
   cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
-  cidoc:P4_has_time-span [
-    a m8g:PeriodOfTime ;
-    m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;
-    m8g:endTime "2020-01-01T12:00:00+01:00"^^xsd:dateTime
+  cp:ruimtetijd [
+    a cidoc:E92 ;
+    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P160 [
+      a m8g:PeriodOfTime ;
+      m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;
+      m8g:endTime "2020-01-01T12:00:00+01:00"^^xsd:dateTime
+    ]
   ] .

--- a/tests/Event/ReadModel/RDF/data/created-with-calendar-multiple.ttl
+++ b/tests/Event/ReadModel/RDF/data/created-with-calendar-multiple.ttl
@@ -22,7 +22,7 @@
   cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   cp:ruimtetijd [
     a cidoc:E92 ;
-    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P161 <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
     cidoc:P160 [
       a m8g:PeriodOfTime ;
       m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;
@@ -30,7 +30,7 @@
     ]
   ], [
     a cidoc:E92 ;
-    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P161 <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
     cidoc:P160 [
       a m8g:PeriodOfTime ;
       m8g:startTime "2018-01-02T12:00:00+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/created-with-calendar-multiple.ttl
+++ b/tests/Event/ReadModel/RDF/data/created-with-calendar-multiple.ttl
@@ -1,0 +1,39 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
+@prefix cp: <https://data.vlaanderen.be/ns/cultuurparticipatie#> .
+@prefix m8g: <http://data.europa.eu/m8g/> .
+
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a cidoc:E7_Activity ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
+  ] ;
+  dcterms:title "Faith no more"@nl ;
+  cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
+  cp:ruimtetijd [
+    a cidoc:E92 ;
+    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P160 [
+      a m8g:PeriodOfTime ;
+      m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;
+      m8g:endTime "2018-01-01T17:00:00+01:00"^^xsd:dateTime
+    ]
+  ], [
+    a cidoc:E92 ;
+    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P160 [
+      a m8g:PeriodOfTime ;
+      m8g:startTime "2018-01-02T12:00:00+01:00"^^xsd:dateTime ;
+      m8g:endTime "2018-01-02T17:00:00+01:00"^^xsd:dateTime
+    ]
+  ] .

--- a/tests/Event/ReadModel/RDF/data/created-with-calendar-periodic.ttl
+++ b/tests/Event/ReadModel/RDF/data/created-with-calendar-periodic.ttl
@@ -22,7 +22,7 @@
   cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   cp:ruimtetijd [
     a cidoc:E92 ;
-    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P161 <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
     cidoc:P160 [
       a m8g:PeriodOfTime ;
       m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/created-with-calendar-periodic.ttl
+++ b/tests/Event/ReadModel/RDF/data/created-with-calendar-periodic.ttl
@@ -1,0 +1,31 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
+@prefix cp: <https://data.vlaanderen.be/ns/cultuurparticipatie#> .
+@prefix m8g: <http://data.europa.eu/m8g/> .
+
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a cidoc:E7_Activity ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
+  ] ;
+  dcterms:title "Faith no more"@nl ;
+  cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
+  cp:ruimtetijd [
+    a cidoc:E92 ;
+    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P160 [
+      a m8g:PeriodOfTime ;
+      m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;
+      m8g:endTime "2022-01-01T17:00:00+01:00"^^xsd:dateTime
+    ]
+  ] .

--- a/tests/Event/ReadModel/RDF/data/created-with-calendar-single.ttl
+++ b/tests/Event/ReadModel/RDF/data/created-with-calendar-single.ttl
@@ -1,0 +1,31 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
+@prefix cp: <https://data.vlaanderen.be/ns/cultuurparticipatie#> .
+@prefix m8g: <http://data.europa.eu/m8g/> .
+
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a cidoc:E7_Activity ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
+  ] ;
+  dcterms:title "Faith no more"@nl ;
+  cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
+  cp:ruimtetijd [
+    a cidoc:E92 ;
+    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P160 [
+      a m8g:PeriodOfTime ;
+      m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;
+      m8g:endTime "2018-01-01T17:00:00+01:00"^^xsd:dateTime
+    ]
+  ] .

--- a/tests/Event/ReadModel/RDF/data/created-with-calendar-single.ttl
+++ b/tests/Event/ReadModel/RDF/data/created-with-calendar-single.ttl
@@ -22,7 +22,7 @@
   cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   cp:ruimtetijd [
     a cidoc:E92 ;
-    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P161 <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
     cidoc:P160 [
       a m8g:PeriodOfTime ;
       m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/various-calendar-updated.ttl
+++ b/tests/Event/ReadModel/RDF/data/various-calendar-updated.ttl
@@ -22,7 +22,7 @@
   dcterms:modified "2023-01-03T12:30:15+01:00"^^xsd:dateTime ;
   cp:ruimtetijd [
     a cidoc:E92 ;
-    cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;
+    cidoc:P161 <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
     cidoc:P160 [
       a m8g:PeriodOfTime ;
       m8g:startTime "2018-01-01T12:00:00+01:00"^^xsd:dateTime ;

--- a/tests/Event/ReadModel/RDF/data/various-calendar-updated.ttl
+++ b/tests/Event/ReadModel/RDF/data/various-calendar-updated.ttl
@@ -19,7 +19,7 @@
   ] ;
   dcterms:title "Faith no more"@nl ;
   cpa:locatie <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
-  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
+  dcterms:modified "2023-01-03T12:30:15+01:00"^^xsd:dateTime ;
   cp:ruimtetijd [
     a cidoc:E92 ;
     cidoc:P161 <https://mock.data.publiq.be/places/TODO> ;


### PR DESCRIPTION
### Added
- Added handler for `CalendarUpdated` on event for single calendar type.
- Added repo to store the `LocationId` when `LocationUpdated` is handled so it can be used when `CalendarUpdated` is handled.

### Note
- For the `periodic` calendar the opening hours are ignored.

---
Ticket: https://jira.uitdatabank.be/browse/III-5363
