### PR TITLE
III-5281 Add extra logging to monitor published

### DIFF
--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -151,7 +151,7 @@ final class EventJSONLDServiceProvider extends AbstractServiceProvider
         $container->addShared(
             self::PROJECTOR,
             function () use ($container): EventLDProjector {
-                return new EventLDProjector(
+                $eventLDProjector = new EventLDProjector(
                     $container->get('event_jsonld_repository'),
                     $container->get('event_iri_generator'),
                     $container->get('place_iri_generator'),
@@ -165,6 +165,10 @@ final class EventJSONLDServiceProvider extends AbstractServiceProvider
                     $container->get('config')['base_price_translations'],
                     new VideoNormalizer($container->get('config')['media']['video_default_copyright']),
                 );
+
+                $eventLDProjector->setLogger(LoggerFactory::create($container, LoggerName::forWeb()));
+
+                return $eventLDProjector;
             }
         );
 

--- a/src/Doctrine/ReadModel/CacheDocumentRepository.php
+++ b/src/Doctrine/ReadModel/CacheDocumentRepository.php
@@ -42,6 +42,8 @@ final class CacheDocumentRepository implements DocumentRepository
 
     public function save(JsonDocument $document, int $attempts = null): void
     {
+        $this->logger->info('Method "save" called for document ' . $document->getId());
+
         if ($attempts === null) {
             $attempts = $this->allowedRetries;
         }

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -59,9 +59,13 @@ use CultuurNet\UDB3\ReadModel\MultilingualJsonLDProjectorTrait;
 use CultuurNet\UDB3\RecordedOn;
 use CultuurNet\UDB3\SluggerInterface;
 use DateTimeInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 
 abstract class OfferLDProjector implements OrganizerServiceInterface
 {
+    use LoggerAwareTrait;
+
     use MultilingualJsonLDProjectorTrait;
     use DelegateEventHandlingToSpecificMethodTrait {
         DelegateEventHandlingToSpecificMethodTrait::handle as handleUnknownEvents;
@@ -110,6 +114,8 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         $this->videoNormalizer = $videoNormalizer;
 
         $this->slugger = new CulturefeedSlugger();
+
+        $this->logger = new NullLogger();
     }
 
     public function handle(DomainMessage $domainMessage): void

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -702,6 +702,8 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
 
     protected function applyPublished(AbstractPublished $published): JsonDocument
     {
+        $this->logger->info('Method "applyPublished" called for document ' . $published->getItemId());
+
         $document = $this->loadDocumentFromRepository($published);
 
         $offerLd = $document->getBody();


### PR DESCRIPTION
### Added
- Added log for `applyPublished` method of `EventLDProjector`
- Added log for `save` method of `CacheDocumentRepository`

---
Ticket: https://jira.uitdatabank.be/browse/III-5281
