### PR TITLE
III-5351 Bugfix for legacy Places without street and/or housenr

### DIFF
--- a/src/Address/FullAddressFormatter.php
+++ b/src/Address/FullAddressFormatter.php
@@ -10,10 +10,15 @@ final class FullAddressFormatter implements AddressFormatter
 
     public function format(Address $address): string
     {
-        return implode(self::LINE_SEPARATOR, [
-            $address->getStreetAddress()->toNative(),
-            $address->getPostalCode()->toNative() . ' ' . $address->getLocality()->toNative(),
-            $address->getCountryCode()->toString(),
-        ]);
+        return implode(
+            self::LINE_SEPARATOR,
+            array_filter(
+                [
+                    $address->getStreetAddress()->toNative(),
+                    $address->getPostalCode()->toNative() . ' ' . $address->getLocality()->toNative(),
+                    $address->getCountryCode()->toString(),
+                ]
+            )
+        );
     }
 }

--- a/src/Place/Events/PlaceFromUDB2.php
+++ b/src/Place/Events/PlaceFromUDB2.php
@@ -38,7 +38,7 @@ trait PlaceFromUDB2
         $granularEvents[] = new AddressUpdated(
             $this->actorId,
             new Address(
-                new Street($addressFromXml['street'][0]['_text'] . ' ' . $addressFromXml['housenr'][0]['_text']),
+                new Street($this->getStreet($addressFromXml)),
                 new PostalCode($addressFromXml['zipcode'][0]['_text']),
                 new Locality($addressFromXml['city'][0]['_text']),
                 new CountryCode($addressFromXml['country'][0]['_text'])

--- a/src/Place/Events/PlaceFromUDB2.php
+++ b/src/Place/Events/PlaceFromUDB2.php
@@ -63,4 +63,15 @@ trait PlaceFromUDB2
         }
         return $actorAsArray['actor'];
     }
+
+    private function getStreet(array $addressFromXml): string
+    {
+        if (!isset($addressFromXml['street'][0]['_text'])) {
+            return '';
+        }
+        if (!isset($addressFromXml['housenr'][0]['_text'])) {
+            return $addressFromXml['street'][0]['_text'];
+        }
+        return $addressFromXml['street'][0]['_text'] . ' ' . $addressFromXml['housenr'][0]['_text'];
+    }
 }

--- a/tests/Address/DefaultAddressFormatterTest.php
+++ b/tests/Address/DefaultAddressFormatterTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Address;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use PHPUnit\Framework\TestCase;
 
-class DefaultAddressFormatterTest extends TestCase
+final class DefaultAddressFormatterTest extends TestCase
 {
     /**
      * @test
@@ -24,6 +24,25 @@ class DefaultAddressFormatterTest extends TestCase
         );
 
         $expectedString = 'Martelarenlaan 1, 3000 Leuven, BE';
+
+        $this->assertEquals($expectedString, $formatter->format($address));
+    }
+
+    /**
+     * @test
+     */
+    public function it_formats_addresses_with_empty_street()
+    {
+        $formatter = new FullAddressFormatter();
+
+        $address = new Address(
+            new Street(''),
+            new PostalCode('3000'),
+            new Locality('Leuven'),
+            new CountryCode('BE')
+        );
+
+        $expectedString = '3000 Leuven, BE';
 
         $this->assertEquals($expectedString, $formatter->format($address));
     }

--- a/tests/Place/Events/PlaceImportedFromUDB2Test.php
+++ b/tests/Place/Events/PlaceImportedFromUDB2Test.php
@@ -92,6 +92,64 @@ final class PlaceImportedFromUDB2Test extends TestCase
 
     /**
      * @test
+     */
+    public function it_can_convert_places_without_a_street_to_granular_events(): void
+    {
+        $placeId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $placeImportedFromUDB2 = new PlaceImportedFromUDB2(
+            $placeId,
+            file_get_contents(__DIR__ . '/../actor_without_street.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            [
+                new TitleUpdated($placeId, new Title('CC Palethe')),
+                new AddressUpdated(
+                    '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3',
+                    new Address(
+                        new Street(''),
+                        new PostalCode('3900'),
+                        new Locality('Overpelt'),
+                        new CountryCode('BE')
+                    )
+                ),
+            ],
+            $placeImportedFromUDB2->toGranularEvents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_convert_places_without_a_housenr_to_granular_events(): void
+    {
+        $placeId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $placeImportedFromUDB2 = new PlaceImportedFromUDB2(
+            $placeId,
+            file_get_contents(__DIR__ . '/../actor_without_housnr.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            [
+                new TitleUpdated($placeId, new Title('CC Palethe')),
+                new AddressUpdated(
+                    '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3',
+                    new Address(
+                        new Street('Jeugdlaan'),
+                        new PostalCode('3900'),
+                        new Locality('Overpelt'),
+                        new CountryCode('BE')
+                    )
+                ),
+            ],
+            $placeImportedFromUDB2->toGranularEvents()
+        );
+    }
+
+    /**
+     * @test
      * @dataProvider variousCdbxmlFormatsDataProvider
      */
     public function it_can_convert_various_cdbxml_formats(

--- a/tests/Place/Events/PlaceUpdatedFromUDB2Test.php
+++ b/tests/Place/Events/PlaceUpdatedFromUDB2Test.php
@@ -73,4 +73,62 @@ final class PlaceUpdatedFromUDB2Test extends TestCase
             $placeUpdatedFromUDB2->toGranularEvents()
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_can_convert_places_without_a_street_to_granular_events(): void
+    {
+        $placeId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $placeUpdatedFromUDB2 = new PlaceUpdatedFromUDB2(
+            $placeId,
+            file_get_contents(__DIR__ . '/../actor_without_street.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            [
+                new TitleUpdated($placeId, new Title('CC Palethe')),
+                new AddressUpdated(
+                    '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3',
+                    new Address(
+                        new Street(''),
+                        new PostalCode('3900'),
+                        new Locality('Overpelt'),
+                        new CountryCode('BE')
+                    )
+                ),
+            ],
+            $placeUpdatedFromUDB2->toGranularEvents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_convert_places_without_a_housenr_to_granular_events(): void
+    {
+        $placeId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $placeUpdatedFromUDB2 = new PlaceUpdatedFromUDB2(
+            $placeId,
+            file_get_contents(__DIR__ . '/../actor_without_housnr.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            [
+                new TitleUpdated($placeId, new Title('CC Palethe')),
+                new AddressUpdated(
+                    '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3',
+                    new Address(
+                        new Street('Jeugdlaan'),
+                        new PostalCode('3900'),
+                        new Locality('Overpelt'),
+                        new CountryCode('BE')
+                    )
+                ),
+            ],
+            $placeUpdatedFromUDB2->toGranularEvents()
+        );
+    }
 }

--- a/tests/Place/actor_without_housnr.xml
+++ b/tests/Place/actor_without_housnr.xml
@@ -1,0 +1,62 @@
+<cdb:actor xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL"
+           asset="true" availablefrom="2013-07-18T09:04:07"
+           availableto="2100-01-01T00:00:00" createdby="cultuurnet001"
+           creationdate="2010-01-06T13:33:06"
+           cdbid="318F2ACB-F612-6F75-0037C9C29F44087A"
+           externalid="Cultuurnet:organisation_1565"
+           lastupdated="2013-07-18T09:04:37" lastupdatedby="lotte@cultuurnet.be"
+           owner="Invoerders Algemeen ">
+    <cdb:actordetails>
+        <cdb:actordetail lang="nl">
+            <cdb:calendarsummary>
+                Bij voorstellingen is de balie van CC Palethe één uur voor
+                aanvang geopend.
+            </cdb:calendarsummary>
+            <cdb:media>
+                <cdb:file creationdate="5/11/2014 13:26:54" main="true">
+                    <cdb:copyright>'Bekend met Gent' - quiz</cdb:copyright>
+                    <cdb:filename>ed466c72-451f-4079-94d3-4ab2e0be7b15.jpg</cdb:filename>
+                    <cdb:filetype>jpeg</cdb:filetype>
+                    <cdb:hlink>//media.uitdatabank.be/20141105/ed466c72-451f-4079-94d3-4ab2e0be7b15.jpg</cdb:hlink>
+                    <cdb:mediatype>photo</cdb:mediatype>
+                </cdb:file>
+            </cdb:media>
+            <cdb:shortdescription>Cultuurcentrum van de gemeente Overpelt.</cdb:shortdescription>
+            <cdb:title>CC Palethe</cdb:title>
+        </cdb:actordetail>
+    </cdb:actordetails>
+    <cdb:categories>
+        <cdb:category catid="8.15.0.0.0" type="actortype">Locatie</cdb:category>
+        <cdb:category catid="8.11.0.0.0" type="actortype">Organisator(en)
+        </cdb:category>
+        <cdb:category catid="6.2.0.0.0" type="publicscope">Regionaal
+        </cdb:category>
+        <cdb:category catid="8.6.0.0.0" type="actortype">Cultuur, gemeenschaps
+            of ontmoetingscentrum
+        </cdb:category>
+    </cdb:categories>
+    <cdb:contactinfo>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Overpelt</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>5.427752</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.211603</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:street>Jeugdlaan</cdb:street>
+                <cdb:zipcode>3900</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:mail reservation="true">reservaties@palethe.be</cdb:mail>
+        <cdb:phone reservation="true" type="phone">+32 11 645952</cdb:phone>
+        <cdb:phone type="fax">+32 11 644504</cdb:phone>
+        <cdb:url>
+            http://toevla.vlaanderen.be/publiek/nl/register/detail/19
+        </cdb:url>
+        <cdb:url main="true">http://www.palethe.be/</cdb:url>
+    </cdb:contactinfo>
+    <cdb:keywords>
+        Aanvaarden van SABAM-cultuurchèques;Toevlalocatie;toevlalocatie
+    </cdb:keywords>
+</cdb:actor>

--- a/tests/Place/actor_without_street.xml
+++ b/tests/Place/actor_without_street.xml
@@ -1,0 +1,61 @@
+<cdb:actor xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL"
+           asset="true" availablefrom="2013-07-18T09:04:07"
+           availableto="2100-01-01T00:00:00" createdby="cultuurnet001"
+           creationdate="2010-01-06T13:33:06"
+           cdbid="318F2ACB-F612-6F75-0037C9C29F44087A"
+           externalid="Cultuurnet:organisation_1565"
+           lastupdated="2013-07-18T09:04:37" lastupdatedby="lotte@cultuurnet.be"
+           owner="Invoerders Algemeen ">
+    <cdb:actordetails>
+        <cdb:actordetail lang="nl">
+            <cdb:calendarsummary>
+                Bij voorstellingen is de balie van CC Palethe één uur voor
+                aanvang geopend.
+            </cdb:calendarsummary>
+            <cdb:media>
+                <cdb:file creationdate="5/11/2014 13:26:54" main="true">
+                    <cdb:copyright>'Bekend met Gent' - quiz</cdb:copyright>
+                    <cdb:filename>ed466c72-451f-4079-94d3-4ab2e0be7b15.jpg</cdb:filename>
+                    <cdb:filetype>jpeg</cdb:filetype>
+                    <cdb:hlink>//media.uitdatabank.be/20141105/ed466c72-451f-4079-94d3-4ab2e0be7b15.jpg</cdb:hlink>
+                    <cdb:mediatype>photo</cdb:mediatype>
+                </cdb:file>
+            </cdb:media>
+            <cdb:shortdescription>Cultuurcentrum van de gemeente Overpelt.</cdb:shortdescription>
+            <cdb:title>CC Palethe</cdb:title>
+        </cdb:actordetail>
+    </cdb:actordetails>
+    <cdb:categories>
+        <cdb:category catid="8.15.0.0.0" type="actortype">Locatie</cdb:category>
+        <cdb:category catid="8.11.0.0.0" type="actortype">Organisator(en)
+        </cdb:category>
+        <cdb:category catid="6.2.0.0.0" type="publicscope">Regionaal
+        </cdb:category>
+        <cdb:category catid="8.6.0.0.0" type="actortype">Cultuur, gemeenschaps
+            of ontmoetingscentrum
+        </cdb:category>
+    </cdb:categories>
+    <cdb:contactinfo>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Overpelt</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>5.427752</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.211603</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:zipcode>3900</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:mail reservation="true">reservaties@palethe.be</cdb:mail>
+        <cdb:phone reservation="true" type="phone">+32 11 645952</cdb:phone>
+        <cdb:phone type="fax">+32 11 644504</cdb:phone>
+        <cdb:url>
+            http://toevla.vlaanderen.be/publiek/nl/register/detail/19
+        </cdb:url>
+        <cdb:url main="true">http://www.palethe.be/</cdb:url>
+    </cdb:contactinfo>
+    <cdb:keywords>
+        Aanvaarden van SABAM-cultuurchèques;Toevlalocatie;toevlalocatie
+    </cdb:keywords>
+</cdb:actor>


### PR DESCRIPTION
### Added

- `getStreet()` to return streetAddress regardless if it is missing in `CdbXml` in `PlaceFromUDB2`
- test-`CdbXml` with places without `street` and `housenr`
- test for `PlaceImportedFromUDB2` with `CdbXml` without missing `street` & `housenr`
- test for `PlaceUpdatedFromUDB2` with `CdbXml` without missing `street` & `housenr`

### Fixed
- `TypeError` during replay

---
Ticket: https://jira.uitdatabank.be/browse/III-5351
