### PR TITLE
III-5351 FullAddressFormatter for Empty street

### DIFF
--- a/src/Address/FullAddressFormatter.php
+++ b/src/Address/FullAddressFormatter.php
@@ -10,10 +10,15 @@ final class FullAddressFormatter implements AddressFormatter
 
     public function format(Address $address): string
     {
-        return implode(self::LINE_SEPARATOR, [
-            $address->getStreetAddress()->toNative(),
-            $address->getPostalCode()->toNative() . ' ' . $address->getLocality()->toNative(),
-            $address->getCountryCode()->toString(),
-        ]);
+        return implode(
+            self::LINE_SEPARATOR,
+            array_filter(
+                [
+                    $address->getStreetAddress()->toNative(),
+                    $address->getPostalCode()->toNative() . ' ' . $address->getLocality()->toNative(),
+                    $address->getCountryCode()->toString(),
+                ]
+            )
+        );
     }
 }

--- a/tests/Address/DefaultAddressFormatterTest.php
+++ b/tests/Address/DefaultAddressFormatterTest.php
@@ -27,4 +27,23 @@ final class DefaultAddressFormatterTest extends TestCase
 
         $this->assertEquals($expectedString, $formatter->format($address));
     }
+
+    /**
+     * @test
+     */
+    public function it_formats_addresses_with_empty_street()
+    {
+        $formatter = new FullAddressFormatter();
+
+        $address = new Address(
+            new Street(''),
+            new PostalCode('3000'),
+            new Locality('Leuven'),
+            new CountryCode('BE')
+        );
+
+        $expectedString = '3000 Leuven, BE';
+
+        $this->assertEquals($expectedString, $formatter->format($address));
+    }
 }

--- a/tests/Address/DefaultAddressFormatterTest.php
+++ b/tests/Address/DefaultAddressFormatterTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Address;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use PHPUnit\Framework\TestCase;
 
-class DefaultAddressFormatterTest extends TestCase
+final class DefaultAddressFormatterTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
### Changed

- Remove `street` if it is empty in `FullAddressFormatter`
- test for `FullAddressFormatter` with empty `street` 

### Fixed

- Avoid a leading comma when a formatting a legacy Place from `CdbXml` without a `streetAdress`

---
Ticket: https://jira.uitdatabank.be/browse/III-5351
