### PR TITLE
III-5574 Fix crash when modifying description on RDF

### DIFF
--- a/src/RDF/Editor/GraphEditor.php
+++ b/src/RDF/Editor/GraphEditor.php
@@ -85,6 +85,7 @@ final class GraphEditor
         // Get all literal values for the property, and key them by their language tag.
         // This will be an empty list if no value(s) were set before for this property.
         $literalValues = $resource->allLiterals($property);
+        $literalValues = array_filter($literalValues, fn (Literal $literal): bool => $literal->getLang() !== null);
         $languages = array_map(fn (Literal $literal): string => $literal->getLang(), $literalValues);
         $literalValuePerLanguage = array_combine($languages, $literalValues);
 

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -230,6 +230,23 @@ class RdfProjectorTest extends TestCase
     /**
      * @test
      */
+    public function it_handles_description_updated_with_empty_string(): void
+    {
+        $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+
+        $this->project($eventId, [
+            $this->getEventCreated($eventId),
+            new DescriptionUpdated($eventId, new Description('Dit is het laatste concert van Faith no more')),
+            new DescriptionUpdated($eventId, new Description('')),
+            new DescriptionUpdated($eventId, new Description('Ze geven nog een extra concert')),
+        ]);
+
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/description-updated.ttl'));
+    }
+
+    /**
+     * @test
+     */
     public function it_handles_description_translated(): void
     {
         $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';


### PR DESCRIPTION
### Fixed
- Fixed crash when modifying description without language on RDF.

### Note
- This was not reproducible with unit tests.

---
Ticket: https://jira.uitdatabank.be/browse/III-5574
