### PR TITLE
III-5581 Invalid ErrorResponse for Urls with triple slashes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-uitdatabank/III-5581-error-invalid-url",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/III-5581-error-invalid-url",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd8d4a318e7bfd987fae39d54d2f5884",
+    "content-hash": "740fb7c8a496522c086e61d4dbd50bda",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5634,19 +5634,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/III-5581-error-invalid-url",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "e32275e18b5b0019a7fa7670a6c7030aa76a9713"
+                "reference": "e633d58408ac68db21411ac1d7b2dfcd5164f1b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/e32275e18b5b0019a7fa7670a6c7030aa76a9713",
-                "reference": "e32275e18b5b0019a7fa7670a6c7030aa76a9713",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/e633d58408ac68db21411ac1d7b2dfcd5164f1b1",
+                "reference": "e633d58408ac68db21411ac1d7b2dfcd5164f1b1",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5661,9 +5660,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5581-error-invalid-url"
             },
-            "time": "2023-03-31T09:39:49+00:00"
+            "time": "2023-04-27T12:04:10+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "740fb7c8a496522c086e61d4dbd50bda",
+    "content-hash": "bd8d4a318e7bfd987fae39d54d2f5884",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5634,7 +5634,7 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-uitdatabank/III-5581-error-invalid-url",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
@@ -5646,6 +5646,7 @@
                 "reference": "e633d58408ac68db21411ac1d7b2dfcd5164f1b1",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5660,7 +5661,7 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5581-error-invalid-url"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
             "time": "2023-04-27T12:04:10+00:00"
         },

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -3028,7 +3028,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/onlineUrl',
-                'The string should match pattern: ^http[s]?:\/\/'
+                'The string should match pattern: ^http[s]?:\/\/\w'
             ),
         ];
 

--- a/tests/Http/Event/UpdateOnlineUrlRequestHandlerTest.php
+++ b/tests/Http/Event/UpdateOnlineUrlRequestHandlerTest.php
@@ -94,7 +94,7 @@ final class UpdateOnlineUrlRequestHandlerTest extends TestCase
                 [
                     'onlineUrl' => 'rtp://www.publiq.be/livestream',
                 ],
-                new SchemaError('/onlineUrl', 'The string should match pattern: ^http[s]?:\/\/'),
+                new SchemaError('/onlineUrl', 'The string should match pattern: ^http[s]?:\/\/\w'),
             ],
         ];
     }

--- a/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
@@ -173,8 +173,8 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
                 'urlLabel' => ['nl' => 'Publiq vzw'],
                 'phone' => '02/1232323',
                 'email' => 'info@publiq.be',
-                'availabilityStarts' => '2028-01-01T00:00:00+01:00',
-                'availabilityEnds' => '2023-01-31T23:59:59+01:00',
+                'availabilityStarts' => '2023-01-01T00:00:00+01:00',
+                'availabilityEnds' => '2028-01-31T23:59:59+01:00',
             ],
             'schemaErrors' => [
                 new SchemaError(

--- a/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
@@ -166,5 +166,22 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
                 ),
             ],
         ];
+
+        yield 'url with triple slashes' => [
+            'input' => [
+                'url' => 'https:///www.publiq.be/',
+                'urlLabel' => ['nl' => 'Publiq vzw'],
+                'phone' => '02/1232323',
+                'email' => 'info@publiq.be',
+                'availabilityStarts' => '2028-01-01T00:00:00+01:00',
+                'availabilityEnds' => '2023-01-31T23:59:59+01:00',
+            ],
+            'schemaErrors' => [
+                new SchemaError(
+                    '/url',
+                    'The string should match pattern: ^http[s]?:\/\/\w'
+                ),
+            ],
+        ];
     }
 }

--- a/tests/Http/Organizer/UpdateContactPointRequestHandlerTest.php
+++ b/tests/Http/Organizer/UpdateContactPointRequestHandlerTest.php
@@ -19,7 +19,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Organizer\Commands\UpdateContactPoint;
 use PHPUnit\Framework\TestCase;
 
-class UpdateContactPointRequestHandlerTest extends TestCase
+final class UpdateContactPointRequestHandlerTest extends TestCase
 {
     use AssertApiProblemTrait;
 

--- a/tests/Http/Organizer/UpdateContactPointRequestHandlerTest.php
+++ b/tests/Http/Organizer/UpdateContactPointRequestHandlerTest.php
@@ -216,7 +216,7 @@ class UpdateContactPointRequestHandlerTest extends TestCase
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidData(
-                new SchemaError('/url/0', 'The string should match pattern: ^http[s]?:\/\/')
+                new SchemaError('/url/0', 'The string should match pattern: ^http[s]?:\/\/\w')
             ),
             fn () => $this->updateContactPointRequestHandler->handle($updateUrlRequest)
         );


### PR DESCRIPTION
### Added

- Test in `UpdateBookingInfoRequestHandlerTest` for invalid `Url` with triple slashes.

### Changed

- Updated `publiq/udb3-json-schemas` in `composer`
- `ImportEventRequestHandlerTest`, `UpdateOnlineUrlRequestHandlerTest` & `UpdateContactPointRequestHandlerTest`: use new regex in test

### Fixed

- A correct Error Response is now generated when a triple slashed `Url` (e.g., https:///publiq.be) is used.

---
Ticket: https://jira.uitdatabank.be/browse/III-5581
