### PR TITLE
III-5548 geopunt zipcode null

### DIFF
--- a/src/Address/GeopuntAddressParser.php
+++ b/src/Address/GeopuntAddressParser.php
@@ -69,7 +69,12 @@ final class GeopuntAddressParser implements AddressParser, LoggerAwareInterface
                         'type' => 'object',
                         'properties' => [
                             'Municipality' => ['type' => 'string'],
-                            'Zipcode' => ['type' => 'string'],
+                            'Zipcode' => [
+                                'anyOf' => [
+                                    ['type' => 'string'],
+                                    ['type' => 'null'],
+                                ],
+                            ],
                             'Thoroughfarename' => ['type' => 'string'],
                             'Housenumber' => [
                                 'anyOf' => [

--- a/src/Address/GeopuntAddressParser.php
+++ b/src/Address/GeopuntAddressParser.php
@@ -112,6 +112,11 @@ final class GeopuntAddressParser implements AddressParser, LoggerAwareInterface
         }
         $result = $data->LocationResult[0];
 
+        if ($result->Thoroughfarename === null) {
+            $this->logger->info('Response body did not contain a thoroughfarename inside "LocationResult" property. The address is not precise enough.');
+            return null;
+        }
+
         $this->logger->info('Successfully parsed response body.');
         return new ParsedAddress(
             $result->Thoroughfarename,

--- a/src/Address/GeopuntAddressParser.php
+++ b/src/Address/GeopuntAddressParser.php
@@ -112,11 +112,6 @@ final class GeopuntAddressParser implements AddressParser, LoggerAwareInterface
         }
         $result = $data->LocationResult[0];
 
-        if ($result->Thoroughfarename === null) {
-            $this->logger->info('Response body did not contain a thoroughfarename inside "LocationResult" property. The address is not precise enough.');
-            return null;
-        }
-
         $this->logger->info('Successfully parsed response body.');
         return new ParsedAddress(
             $result->Thoroughfarename,

--- a/src/Address/GeopuntAddressParser.php
+++ b/src/Address/GeopuntAddressParser.php
@@ -75,7 +75,12 @@ final class GeopuntAddressParser implements AddressParser, LoggerAwareInterface
                                     ['type' => 'null'],
                                 ],
                             ],
-                            'Thoroughfarename' => ['type' => 'string'],
+                            'Thoroughfarename' => [
+                                'anyOf' => [
+                                    ['type' => 'string'],
+                                    ['type' => 'null'],
+                                ],
+                            ],
                             'Housenumber' => [
                                 'anyOf' => [
                                     ['type' => 'string'],

--- a/src/Address/ParsedAddress.php
+++ b/src/Address/ParsedAddress.php
@@ -6,12 +6,12 @@ namespace CultuurNet\UDB3\Address;
 
 final class ParsedAddress
 {
-    private string $thoroughfare;
+    private ?string $thoroughfare;
     private ?string $houseNumber;
-    private string $postalCode;
+    private ?string $postalCode;
     private string $municipality;
 
-    public function __construct(string $thoroughfare, ?string $houseNumber, string $postalCode, string $municipality)
+    public function __construct(?string $thoroughfare, ?string $houseNumber, ?string $postalCode, string $municipality)
     {
         $this->thoroughfare = $thoroughfare;
         $this->houseNumber = $houseNumber;
@@ -19,7 +19,7 @@ final class ParsedAddress
         $this->municipality = $municipality;
     }
 
-    public function getThoroughfare(): string
+    public function getThoroughfare(): ?string
     {
         return $this->thoroughfare;
     }
@@ -29,7 +29,7 @@ final class ParsedAddress
         return $this->houseNumber;
     }
 
-    public function getPostalCode(): string
+    public function getPostalCode(): ?string
     {
         return $this->postalCode;
     }

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -237,7 +237,7 @@ final class RdfProjector implements EventListener
         // original Address, because locn:thoroughfare MUST NOT contain a house number. If there is no ParsedAddress
         // remove the value for the given language instead since it will probably be outdated (if set previously).
         // Keep in mind that locn:thoroughfare is optional.
-        if ($parsedAddress) {
+        if ($parsedAddress && $parsedAddress->getThoroughfare() !== null) {
             $graphEditor->replaceLanguageValue(
                 $addressResource->getUri(),
                 self::PROPERTY_ADRES_STRAATNAAM,

--- a/tests/Address/GeopuntAddressParserTest.php
+++ b/tests/Address/GeopuntAddressParserTest.php
@@ -265,11 +265,9 @@ class GeopuntAddressParserTest extends TestCase
                     '/LocationResult/0/Municipality' => [
                         0 => 'The data (integer) must match the type: string',
                     ],
-                    '/LocationResult/0/Zipcode' => [
-                        0 => 'The data (null) must match the type: string',
-                    ],
                     '/LocationResult/0/Thoroughfarename' => [
                         0 => 'The data (boolean) must match the type: string',
+                        1 => 'The data (boolean) must match the type: null',
                     ],
                     '/LocationResult/0/Housenumber' => [
                         0 => 'The data (array) must match the type: string',

--- a/tests/Address/GeopuntAddressParserTest.php
+++ b/tests/Address/GeopuntAddressParserTest.php
@@ -376,7 +376,7 @@ class GeopuntAddressParserTest extends TestCase
             'LocationResult' => [
                 [
                     'Municipality' => 'Bruxelles',
-                    'Zipcode' => null,
+                    'Zipcode' => '1000',
                     'Thoroughfarename' => null,
                     'Housenumber' => null,
                 ],
@@ -390,12 +390,19 @@ class GeopuntAddressParserTest extends TestCase
             ->with($expectedRequest)
             ->willReturn($mockResponse);
 
-        $this->expectedLogs->info('GET https://loc.geopunt.be/v4/Location?q=Marguerite%20Durassquare,%201000%20Brussel,%20BE responded with status code 200 and body {"LocationResult":[{"Municipality":"Bruxelles","Zipcode":null,"Thoroughfarename":null,"Housenumber":null}]}');
-        $this->expectedLogs->info('Response body did not contain a thoroughfarename inside "LocationResult" property. The address is not precise enough.');
+        $this->expectedLogs->info('GET https://loc.geopunt.be/v4/Location?q=Marguerite%20Durassquare,%201000%20Brussel,%20BE responded with status code 200 and body {"LocationResult":[{"Municipality":"Bruxelles","Zipcode":"1000","Thoroughfarename":null,"Housenumber":null}]}');
+        $this->expectedLogs->info('Successfully parsed response body.');
+
+        $expectedParsedAddress = new ParsedAddress(
+            null,
+            null,
+            '1000',
+            'Bruxelles'
+        );
 
         $actualParsedAddress = $this->geopuntAddressParser->parse($address);
 
-        $this->assertNull($actualParsedAddress);
+        $this->assertEquals($expectedParsedAddress, $actualParsedAddress);
         $this->assertLogs();
     }
 


### PR DESCRIPTION
### Added

- `GeopuntAddressParser`: test for empty `Zipcode`
- `GeopuntAddressParser`: test for empty `Thoroughfarename`

### Changed

- `GeopuntAddressParser`: changed `jsonSchema`, make `Zipcode` & `Thoroughfarename`  nullable
- `GeopuntAddressParser`: expected result in test for incorrect property values
- `ParsedAddress`: make `thoroughfare` & `postalCode` nullable
- `RdfProjector`: add check if `thoroughfare` is not null.

---
Ticket: https://jira.uitdatabank.be/browse/III-5548
