### PR TITLE
III-5528 Store playhead inside JSON projection

### DIFF
--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -827,7 +827,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
             $document = $this->repository->fetch($itemId);
 
             $body = $document->getBody();
-            if ($this->playhead !== null && $this->playhead > 0 && isset($body->playhead) && $body->playhead !== $this->playhead - 1) {
+            if (isset($this->playhead) && $this->playhead > 0 && isset($body->playhead) && $body->playhead !== $this->playhead - 1) {
                 $this->logger->error(
                     'Playhead mismatch for document ' . $itemId . '. Expected ' . ($this->playhead - 1) . ' but found ' . $body->playhead
                 );

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -825,6 +825,13 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
     {
         try {
             $document = $this->repository->fetch($itemId);
+
+            $body = $document->getBody();
+            if ($this->playhead !== null && $this->playhead > 0 && isset($body->playhead) && $body->playhead !== $this->playhead - 1) {
+                $this->logger->error(
+                    'Playhead mismatch for document ' . $itemId . '. Expected ' . ($this->playhead - 1) . ' but found ' . $body->playhead
+                );
+            }
         } catch (DocumentDoesNotExist $e) {
             return $this->newDocument($itemId);
         }

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -93,6 +93,8 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
 
     protected VideoNormalizer $videoNormalizer;
 
+    private ?int $playhead = null;
+
     /**
      * @param string[] $basePriceTranslations
      */
@@ -120,6 +122,8 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
 
     public function handle(DomainMessage $domainMessage): void
     {
+        $this->playhead = $domainMessage->getPlayhead();
+
         $event = $domainMessage->getPayload();
 
         $eventName = get_class($event);

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -149,6 +149,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         foreach ($jsonDocuments as $jsonDocument) {
             $jsonDocument = $this->jsonDocumentMetaDataEnricher->enrich($jsonDocument, $domainMessage->getMetadata());
             $jsonDocument = $this->updateModified($jsonDocument, $domainMessage);
+            $jsonDocument = $this->updatePlayhead($jsonDocument, $domainMessage);
 
             $this->repository->save($jsonDocument);
         }
@@ -853,6 +854,15 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
 
         $recordedDateTime = RecordedOn::fromDomainMessage($domainMessage);
         $body->modified = $recordedDateTime->toString();
+
+        return $jsonDocument->withBody($body);
+    }
+
+    private function updatePlayhead(JsonDocument $jsonDocument, DomainMessage $domainMessage): JsonDocument
+    {
+        $body = $jsonDocument->getBody();
+
+        $body->playhead = $domainMessage->getPlayhead();
 
         return $jsonDocument->withBody($body);
     }

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -192,6 +192,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             ],
         ];
         $jsonLD->typicalAgeRange = '-';
+        $jsonLD->playhead = 1;
 
         $this->mockPlaceService();
 
@@ -248,6 +249,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $jsonLD = json_decode(file_get_contents(__DIR__ . '/copied_event_with_place_type.json'));
         $jsonLD->created = $recordedOn;
         $jsonLD->modified = $recordedOn;
+        $jsonLD->playhead = 1;
 
         $body = $this->project(
             $eventCopied,
@@ -288,6 +290,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             ],
         ];
         $jsonLD->typicalAgeRange = '-';
+        $jsonLD->playhead = 1;
 
         $this->mockPlaceService();
 
@@ -335,6 +338,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         ];
         $jsonLD->typicalAgeRange = '-';
         $jsonLD->creator = $expectedCreator;
+        $jsonLD->playhead = 1;
 
         $this->mockPlaceService();
 
@@ -646,6 +650,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             ],
         ];
         $jsonLD->typicalAgeRange = '-';
+        $jsonLD->playhead = 1;
 
         $this->mockPlaceService();
 
@@ -966,6 +971,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $expectedBody->bar = 'stool';
         $expectedBody->labels = ['label B'];
         $expectedBody->modified = $this->recordedOn->toString();
+        $expectedBody->playhead = 1;
 
         $this->assertEquals(
             $expectedBody,
@@ -1051,6 +1057,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $expectedJsonLD->bookingAvailability = (object)[
             'type' => 'Available',
         ];
+        $expectedJsonLD->playhead = 1;
 
         $body = $this->project($majorInfoUpdated, $id, null, $this->recordedOn->toBroadwayDateTime());
 
@@ -1094,6 +1101,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $expectedJsonLD->bookingAvailability = (object) [
             'type' => 'Available',
         ];
+        $expectedJsonLD->playhead = 1;
 
         $body = $this->project($calendarUpdated, $eventId, null, $this->recordedOn->toBroadwayDateTime());
 
@@ -1133,6 +1141,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             '@id' => 'http://example.com/entity/395fe7eb-9bac-4647-acae-316b6446a85e',
         ];
         $expectedJsonLD->modified = $this->recordedOn->toString();
+        $expectedJsonLD->playhead = 1;
 
         $body = $this->project($locationUpdated, $eventId, null, $this->recordedOn->toBroadwayDateTime());
 
@@ -1191,6 +1200,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             ],
             'modified' => $this->recordedOn->toString(),
         ];
+        $expectedBody->playhead = 1;
 
         $body = $this->project($coordinatesUpdated, $id, null, $this->recordedOn->toBroadwayDateTime());
         $this->assertEquals($expectedBody, $body);
@@ -1323,6 +1333,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             '@context' => '/contexts/event',
             'attendanceMode' => AttendanceMode::online()->toString(),
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->assertEquals($expectedJson, $body);
@@ -1344,6 +1355,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             '@context' => '/contexts/event',
             'onlineUrl' => 'https://www.publiq.be/livestream',
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->assertEquals($expectedJson, $body);
@@ -1373,6 +1385,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             '@id' => 'http://example.com/entity/' . $eventId,
             '@context' => '/contexts/event',
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->assertEquals($expectedJson, $body);
@@ -1397,6 +1410,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 '@context' => '/contexts/event',
                 'audience' => (object) ['audienceType' => 'education'],
                 'modified' => $this->recordedOn->toString(),
+                'playhead' => 1,
             ];
 
         $this->assertEquals($expectedJson, $body);
@@ -1418,6 +1432,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             '@context' => '/contexts/event',
             'workflowStatus' => 'DELETED',
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->assertEquals($expectedJson, $body);

--- a/tests/Event/ReadModel/JSONLD/copied_event.json
+++ b/tests/Event/ReadModel/JSONLD/copied_event.json
@@ -61,5 +61,6 @@
   },
   "bookingAvailability": {
     "type": "Available"
-  }
+  },
+  "playhead": 1
 }

--- a/tests/Event/ReadModel/JSONLD/copied_event_without_working_hours.json
+++ b/tests/Event/ReadModel/JSONLD/copied_event_without_working_hours.json
@@ -35,5 +35,6 @@
   },
   "bookingAvailability": {
     "type": "Available"
-  }
+  },
+  "playhead": 1
 }

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -212,6 +212,7 @@ class OfferLDProjectorTest extends TestCase
                 'labels' => ['label A'],
                 'hiddenLabels' => ['label B'],
                 'modified' => $this->recordedOn->toString(),
+                'playhead' => 1,
             ],
             $body
         );
@@ -271,6 +272,7 @@ class OfferLDProjectorTest extends TestCase
             (object) [
                 'labels' => ['label A', 'label B'],
                 'modified' => $this->recordedOn->toString(),
+                'playhead' => 1,
             ],
             $body
         );
@@ -301,6 +303,7 @@ class OfferLDProjectorTest extends TestCase
         $expectedBody->bar = 'stool';
         $expectedBody->labels = ['label B'];
         $expectedBody->modified = $this->recordedOn->toString();
+        $expectedBody->playhead = 1;
 
         $this->assertEquals(
             $expectedBody,
@@ -338,6 +341,7 @@ class OfferLDProjectorTest extends TestCase
                     'en'=> 'A cycling adventure',
                 ],
                 'modified' => $this->recordedOn->toString(),
+                'playhead' => 1,
             ])
         );
 
@@ -390,6 +394,7 @@ class OfferLDProjectorTest extends TestCase
                     'nl' => 'Omschrijving',
                 ],
                 'modified' => $this->recordedOn->toString(),
+                'playhead' => 1,
             ],
             $body
         );
@@ -432,6 +437,7 @@ class OfferLDProjectorTest extends TestCase
                     'en' => 'English description',
                 ],
                 'modified' => $this->recordedOn->toString(),
+                'playhead' => 1,
             ],
             $body
         );
@@ -507,6 +513,7 @@ class OfferLDProjectorTest extends TestCase
                 ],
             ],
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->documentRepository->save($initialDocument);
@@ -622,6 +629,7 @@ class OfferLDProjectorTest extends TestCase
                 ],
             ],
             'modified' => '2018-01-01T08:30:00+01:00',
+            'playhead' => 1,
         ];
 
         $expectedWithoutFirstImage = (object) [
@@ -638,6 +646,7 @@ class OfferLDProjectorTest extends TestCase
                 ],
             ],
             'modified' => '2018-01-01T08:30:00+01:00',
+            'playhead' => 1,
         ];
 
 
@@ -1194,6 +1203,7 @@ class OfferLDProjectorTest extends TestCase
                         'copyrightHolder' => 'Creative Commons',
                     ],
                 ],
+                'playhead' => 1,
             ],
             $eventBody
         );
@@ -1260,6 +1270,7 @@ class OfferLDProjectorTest extends TestCase
                         'copyrightHolder' => 'Public Domain',
                     ],
                 ],
+                'playhead' => 1,
             ],
             $eventBody
         );
@@ -1307,6 +1318,7 @@ class OfferLDProjectorTest extends TestCase
                         'copyrightHolder' => 'Copyright afgehandeld door YouTube',
                     ],
                 ],
+                'playhead' => 1,
             ],
             $eventBody
         );
@@ -1374,6 +1386,7 @@ class OfferLDProjectorTest extends TestCase
                         'embedUrl' => 'https://www.youtube.com/embed/4335',
                     ],
                 ],
+                'playhead' => 1,
             ],
             $eventBody
         );
@@ -1415,6 +1428,7 @@ class OfferLDProjectorTest extends TestCase
                 'name' => (object)[
                     'nl' => 'Titel',
                 ],
+                'playhead' => 1,
             ],
             $eventBody
         );
@@ -1501,6 +1515,7 @@ class OfferLDProjectorTest extends TestCase
                         'embedUrl' => 'https://www.youtube.com/embed/4335',
                     ],
                 ],
+                'playhead' => 1,
             ],
             $eventBody
         );
@@ -1547,6 +1562,7 @@ class OfferLDProjectorTest extends TestCase
                 '@id' => 'http://example.com/entity/' . $organizerId,
             ],
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->assertEquals($expectedBody, $body);
@@ -1581,6 +1597,7 @@ class OfferLDProjectorTest extends TestCase
                 'name' => 'name',
             ],
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $body = $this->project($organizerUpdated, $id, null, $this->recordedOn->toBroadwayDateTime());
@@ -1612,7 +1629,13 @@ class OfferLDProjectorTest extends TestCase
 
         $body = $this->project($organizerDeleted, $id, null, $this->recordedOn->toBroadwayDateTime());
 
-        $this->assertEquals((object)['modified' => $this->recordedOn->toString()], $body);
+        $this->assertEquals(
+            (object)[
+                'modified' => $this->recordedOn->toString(),
+                'playhead' => 1,
+            ],
+            $body
+        );
     }
 
     /**
@@ -1637,6 +1660,7 @@ class OfferLDProjectorTest extends TestCase
             'availableFrom' => '2030-10-10T11:00:00+00:00',
             'workflowStatus' => 'DRAFT',
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->documentRepository->save($itemDocumentReadyDraft);
@@ -1677,6 +1701,7 @@ class OfferLDProjectorTest extends TestCase
             'availableFrom' => $now->format(DateTimeInterface::ATOM),
             'workflowStatus' => 'READY_FOR_VALIDATION',
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->documentRepository->save($itemDocumentReadyDraft);
@@ -1707,6 +1732,7 @@ class OfferLDProjectorTest extends TestCase
             '@type' => 'event',
             'workflowStatus' => 'APPROVED',
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->documentRepository->save($itemDocumentReadyForValidation);
@@ -1738,6 +1764,7 @@ class OfferLDProjectorTest extends TestCase
             '@type' => 'event',
             'workflowStatus' => 'REJECTED',
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->documentRepository->save($itemDocumentReadyForValidation);
@@ -1933,6 +1960,7 @@ class OfferLDProjectorTest extends TestCase
             'languages' => ['nl'],
             'completedLanguages' => ['nl'],
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $body = $this->project($facilitiesUpdated, $id, null, $this->recordedOn->toBroadwayDateTime());

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -67,7 +67,8 @@ abstract class OfferLDProjectorTestBase extends TestCase
         object $event,
         string $entityId,
         Metadata $metadata = null,
-        DateTime $dateTime = null
+        DateTime $dateTime = null,
+        int $playhead = 1
     ): stdClass {
         if (null === $metadata) {
             $metadata = new Metadata();
@@ -80,7 +81,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
         $this->projector->handle(
             new DomainMessage(
                 $entityId,
-                1,
+                $playhead,
                 $metadata,
                 $event,
                 $dateTime
@@ -127,10 +128,10 @@ abstract class OfferLDProjectorTestBase extends TestCase
             ],
             'modified' => $this->recordedOn->toString(),
             'languages' => ['nl'],
-            'playhead' => 1,
+            'playhead' => 3,
         ];
 
-        $body = $this->project($bookingInfoUpdated, $id, null, $this->recordedOn->toBroadwayDateTime());
+        $body = $this->project($bookingInfoUpdated, $id, null, $this->recordedOn->toBroadwayDateTime(), 3);
 
         $this->assertEquals($expectedBody, $body);
     }

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -127,6 +127,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
             ],
             'modified' => $this->recordedOn->toString(),
             'languages' => ['nl'],
+            'playhead' => 1,
         ];
 
         $body = $this->project($bookingInfoUpdated, $id, null, $this->recordedOn->toBroadwayDateTime());
@@ -159,6 +160,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
                 'url' => $urls,
             ],
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->assertEquals(
@@ -200,6 +202,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
             'languages' => ['nl'],
             'completedLanguages' => ['nl'],
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $body = $this->project($descriptionUpdated, $id, null, $this->recordedOn->toBroadwayDateTime());
@@ -242,6 +245,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
                 ],
             ],
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $body = $this->project($imageAdded, $id, null, $this->recordedOn->toBroadwayDateTime());
@@ -292,6 +296,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
                 ],
             ],
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $body = $this->project($imageUpdated, $id, null, $this->recordedOn->toBroadwayDateTime());
@@ -319,6 +324,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
         $expectedBody = (object)[
             'typicalAgeRange' => '0-18',
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $body = $this->project($typicalAgeRangeUpdated, $id, null, $this->recordedOn->toBroadwayDateTime());
@@ -346,6 +352,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
         $expectedBody = (object)[
             'typicalAgeRange' => '-',
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $body = $this->project($typicalAgeRangeDeleted, $id, null, $this->recordedOn->toBroadwayDateTime());

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -173,6 +173,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $jsonLD->bookingAvailability = (object) [
             'type' => 'Available',
         ];
+        $jsonLD->playhead = 1;
 
         $body = $this->project(
             $placeCreated,
@@ -238,6 +239,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $jsonLD->bookingAvailability = (object)[
             'type' => 'Available',
         ];
+        $jsonLD->playhead = 1;
 
         $metadata = new Metadata(
             [
@@ -336,6 +338,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $expectedJsonLD->languages = ['nl'];
         $expectedJsonLD->completedLanguages = ['nl'];
         $expectedJsonLD->modified = $this->recordedOn->toString();
+        $expectedJsonLD->playhead = 1;
 
         $addressUpdated = new AddressUpdated(
             '66f30742-dee9-4794-ac92-fa44634692b8',
@@ -419,6 +422,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $expectedJsonLD->languages = ['nl', 'fr'];
         $expectedJsonLD->completedLanguages = ['nl'];
         $expectedJsonLD->modified = $this->recordedOn->toString();
+        $expectedJsonLD->playhead = 1;
 
         $addressTranslated = new AddressTranslated(
             '66f30742-dee9-4794-ac92-fa44634692b8',
@@ -709,6 +713,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $expectedJsonLD->bookingAvailability = (object)[
             'type' => 'Available',
         ];
+        $expectedJsonLD->playhead = 1;
 
         $body = $this->project(
             $majorInfoUpdated,
@@ -763,6 +768,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
                 'longitude' => -0.34567,
             ],
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $body = $this->project($coordinatesUpdated, $id, null, $this->recordedOn->toBroadwayDateTime());
@@ -785,6 +791,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
             '@context' => '/contexts/place',
             'workflowStatus' => 'DELETED',
             'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
         $this->assertEquals($expectedJson, $body);
@@ -869,6 +876,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $expectedBody->bar = 'stool';
         $expectedBody->labels = ['label B'];
         $expectedBody->modified = $this->recordedOn->toString();
+        $expectedBody->playhead = 1;
 
         $this->assertEquals(
             $expectedBody,


### PR DESCRIPTION
### Changed
- Store playhead inside JSON projection
- Log error when current playhead is not one more than the previous one

### Note
- Before building the retry based on the playhead we will first monitor the logging

---
Ticket: https://jira.uitdatabank.be/browse/III-5528
