### PR TITLE
III-5545 Handle missing street and/or number on dummy location

### DIFF
--- a/src/Event/Events/EventFromUDB2.php
+++ b/src/Event/Events/EventFromUDB2.php
@@ -200,12 +200,15 @@ trait EventFromUDB2
     {
         $eventAsArray = $this->getEventAsArray();
         $addressAsArray = $eventAsArray['location'][0]['address'][0]['physical'][0];
-        $streetAsAddress = trim($addressAsArray['street'][0]['_text'] . ' ' . $addressAsArray['housenr'][0]['_text']);
+
+        $street = $addressAsArray['street'][0]['_text'] ?? '';
+        $number = $addressAsArray['housenr'][0]['_text'] ?? '';
+        $streetAndNumber = trim($street . ' ' . $number);
 
         return new DummyLocation(
             new Title($eventAsArray['location'][0]['label'][0]['_text']),
             new Address(
-                empty($streetAsAddress) ? new Street('-') : new Street($streetAsAddress),
+                empty($streetAndNumber) ? new Street('-') : new Street($streetAndNumber),
                 new PostalCode($addressAsArray['zipcode'][0]['_text']),
                 new Locality($addressAsArray['city'][0]['_text']),
                 new CountryCode($addressAsArray['country'][0]['_text'])

--- a/src/Event/Events/EventFromUDB2.php
+++ b/src/Event/Events/EventFromUDB2.php
@@ -200,11 +200,12 @@ trait EventFromUDB2
     {
         $eventAsArray = $this->getEventAsArray();
         $addressAsArray = $eventAsArray['location'][0]['address'][0]['physical'][0];
+        $streetAsAddress = trim($addressAsArray['street'][0]['_text'] . ' ' . $addressAsArray['housenr'][0]['_text']);
 
         return new DummyLocation(
             new Title($eventAsArray['location'][0]['label'][0]['_text']),
             new Address(
-                new Street(trim($addressAsArray['street'][0]['_text'] . ' ' . $addressAsArray['housenr'][0]['_text'])),
+                empty($streetAsAddress) ? new Street('-') : new Street($streetAsAddress),
                 new PostalCode($addressAsArray['zipcode'][0]['_text']),
                 new Locality($addressAsArray['city'][0]['_text']),
                 new CountryCode($addressAsArray['country'][0]['_text'])

--- a/src/Event/Events/EventFromUDB2.php
+++ b/src/Event/Events/EventFromUDB2.php
@@ -204,7 +204,7 @@ trait EventFromUDB2
         return new DummyLocation(
             new Title($eventAsArray['location'][0]['label'][0]['_text']),
             new Address(
-                new Street($addressAsArray['street'][0]['_text'] . ' ' . $addressAsArray['housenr'][0]['_text']),
+                new Street(trim($addressAsArray['street'][0]['_text'] . ' ' . $addressAsArray['housenr'][0]['_text'])),
                 new PostalCode($addressAsArray['zipcode'][0]['_text']),
                 new Locality($addressAsArray['city'][0]['_text']),
                 new CountryCode($addressAsArray['country'][0]['_text'])

--- a/tests/Event/Events/EventUpdatedFromUDB2Test.php
+++ b/tests/Event/Events/EventUpdatedFromUDB2Test.php
@@ -120,12 +120,12 @@ final class EventUpdatedFromUDB2Test extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_dummy_location_(): void
+    public function it_returns_a_dummy_location(): void
     {
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventWithDummyLocation = new EventUpdatedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_photo.cdbxml.xml'),
+            file_get_contents(__DIR__ . '/../samples/event_with_dummy_location.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -134,6 +134,84 @@ final class EventUpdatedFromUDB2Test extends TestCase
                 new Title('Liberaal Archief'),
                 new Address(
                     new Street('Kramersplein 23'),
+                    new PostalCode('9000'),
+                    new Locality('Gent'),
+                    new CountryCode('BE')
+                )
+            ),
+            $eventWithDummyLocation->getDummyLocation()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_dummy_location_without_street(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventWithDummyLocation = new EventUpdatedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_dummy_location_without_street.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            new DummyLocation(
+                new Title('Liberaal Archief'),
+                new Address(
+                    new Street('23'),
+                    new PostalCode('9000'),
+                    new Locality('Gent'),
+                    new CountryCode('BE')
+                )
+            ),
+            $eventWithDummyLocation->getDummyLocation()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_dummy_location_without_number(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventWithDummyLocation = new EventUpdatedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_dummy_location_without_number.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            new DummyLocation(
+                new Title('Liberaal Archief'),
+                new Address(
+                    new Street('Kramersplein'),
+                    new PostalCode('9000'),
+                    new Locality('Gent'),
+                    new CountryCode('BE')
+                )
+            ),
+            $eventWithDummyLocation->getDummyLocation()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_dummy_location_without_street_and_number(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventWithDummyLocation = new EventUpdatedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_dummy_location_without_street_and_number.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            new DummyLocation(
+                new Title('Liberaal Archief'),
+                new Address(
+                    new Street(''),
                     new PostalCode('9000'),
                     new Locality('Gent'),
                     new CountryCode('BE')

--- a/tests/Event/Events/EventUpdatedFromUDB2Test.php
+++ b/tests/Event/Events/EventUpdatedFromUDB2Test.php
@@ -211,7 +211,7 @@ final class EventUpdatedFromUDB2Test extends TestCase
             new DummyLocation(
                 new Title('Liberaal Archief'),
                 new Address(
-                    new Street(''),
+                    new Street('-'),
                     new PostalCode('9000'),
                     new Locality('Gent'),
                     new CountryCode('BE')

--- a/tests/Event/samples/event_with_calendar_timestamps.cdbxml.xml
+++ b/tests/Event/samples/event_with_calendar_timestamps.cdbxml.xml
@@ -70,7 +70,7 @@
             <cdb:title>'Bekend met Gent' - quiz</cdb:title>
         </cdb:eventdetail>
     </cdb:eventdetails>
-    <cdb:keywords>gent;Quiz;;Gent on Files</cdb:keywords>
+    <cdb:keywords>gent;Quiz;Gent on Files</cdb:keywords>
     <cdb:location>
         <cdb:address>
             <cdb:physical>

--- a/tests/Event/samples/event_with_dummy_location.cdbxml.xml
+++ b/tests/Event/samples/event_with_dummy_location.cdbxml.xml
@@ -29,7 +29,6 @@
             <cdb:title>'Bekend met Gent' - quiz</cdb:title>
         </cdb:eventdetail>
     </cdb:eventdetails>
-    <cdb:keywords>gent;Quiz;;Gent on Files</cdb:keywords>
     <cdb:location>
         <cdb:address>
             <cdb:physical>

--- a/tests/Event/samples/event_with_dummy_location.cdbxml.xml
+++ b/tests/Event/samples/event_with_dummy_location.cdbxml.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<cdb:event xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL" availablefrom="2014-11-05T00:00:00" availableto="2014-11-22T00:00:00" cdbid="dcd1ef37-0608-4824-afe3-99124feda64b" createdby="gentonfiles@gmail.com" creationdate="2014-11-05T13:23:36" externalid="CDB:a0a2120e-34f9-4653-a504-09550475bc84" isparent="false" lastupdated="2014-11-08T15:36:06" lastupdatedby="sdebuck1" pctcomplete="85" published="true" owner="Invoerders Algemeen " private="false" validator="Gent Validatoren" wfstatus="approved">
+    <cdb:activities>
+        <cdb:activity count="0" type="like"/>
+        <cdb:activity count="0" type="attend"/>
+        <cdb:activity count="0" type="comment"/>
+        <cdb:activity count="0" type="recommend"/>
+        <cdb:activity count="0" type="facebook_share"/>
+        <cdb:activity count="0" type="review"/>
+    </cdb:activities>
+    <cdb:calendar>
+        <cdb:timestamps>
+            <cdb:timestamp>
+                <cdb:date>2014-11-21</cdb:date>
+                <cdb:timestart>20:00:00</cdb:timestart>
+            </cdb:timestamp>
+        </cdb:timestamps>
+    </cdb:calendar>
+    <cdb:categories>
+        <cdb:category catid="reg.359" type="flanderstouristregion">Kunststad Gent</cdb:category>
+        <cdb:category catid="0.50.21.0.0" type="eventtype">Spel of quiz</cdb:category>
+        <cdb:category catid="reg.1258" type="flandersregion">9000 Gent</cdb:category>
+    </cdb:categories>
+    <cdb:comments/>
+    <cdb:eventdetails>
+        <cdb:eventdetail lang="nl">
+            <cdb:calendarsummary>vrij 21/11/14 om 20:00 </cdb:calendarsummary>
+            <cdb:shortdescription>Korte beschrijving</cdb:shortdescription>
+            <cdb:title>'Bekend met Gent' - quiz</cdb:title>
+        </cdb:eventdetail>
+    </cdb:eventdetails>
+    <cdb:keywords>gent;Quiz;;Gent on Files</cdb:keywords>
+    <cdb:location>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Gent</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>3.725970</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.040984</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>23</cdb:housenr>
+                <cdb:street>Kramersplein</cdb:street>
+                <cdb:zipcode>9000</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:label>Liberaal Archief</cdb:label>
+    </cdb:location>
+    <cdb:organiser>
+        <cdb:label>Gent on Files</cdb:label>
+    </cdb:organiser>
+</cdb:event>

--- a/tests/Event/samples/event_with_dummy_location_without_number.cdbxml.xml
+++ b/tests/Event/samples/event_with_dummy_location_without_number.cdbxml.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<cdb:event xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL" availablefrom="2014-11-05T00:00:00" availableto="2014-11-22T00:00:00" cdbid="dcd1ef37-0608-4824-afe3-99124feda64b" createdby="gentonfiles@gmail.com" creationdate="2014-11-05T13:23:36" externalid="CDB:a0a2120e-34f9-4653-a504-09550475bc84" isparent="false" lastupdated="2014-11-08T15:36:06" lastupdatedby="sdebuck1" pctcomplete="85" published="true" owner="Invoerders Algemeen " private="false" validator="Gent Validatoren" wfstatus="approved">
+    <cdb:activities>
+        <cdb:activity count="0" type="like"/>
+        <cdb:activity count="0" type="attend"/>
+        <cdb:activity count="0" type="comment"/>
+        <cdb:activity count="0" type="recommend"/>
+        <cdb:activity count="0" type="facebook_share"/>
+        <cdb:activity count="0" type="review"/>
+    </cdb:activities>
+    <cdb:calendar>
+        <cdb:timestamps>
+            <cdb:timestamp>
+                <cdb:date>2014-11-21</cdb:date>
+                <cdb:timestart>20:00:00</cdb:timestart>
+            </cdb:timestamp>
+        </cdb:timestamps>
+    </cdb:calendar>
+    <cdb:categories>
+        <cdb:category catid="reg.359" type="flanderstouristregion">Kunststad Gent</cdb:category>
+        <cdb:category catid="0.50.21.0.0" type="eventtype">Spel of quiz</cdb:category>
+        <cdb:category catid="reg.1258" type="flandersregion">9000 Gent</cdb:category>
+    </cdb:categories>
+    <cdb:comments/>
+    <cdb:eventdetails>
+        <cdb:eventdetail lang="nl">
+            <cdb:calendarsummary>vrij 21/11/14 om 20:00 </cdb:calendarsummary>
+            <cdb:shortdescription>Korte beschrijving</cdb:shortdescription>
+            <cdb:title>'Bekend met Gent' - quiz</cdb:title>
+        </cdb:eventdetail>
+    </cdb:eventdetails>
+    <cdb:keywords>gent;Quiz;;Gent on Files</cdb:keywords>
+    <cdb:location>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Gent</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>3.725970</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.040984</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:street>Kramersplein</cdb:street>
+                <cdb:zipcode>9000</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:label>Liberaal Archief</cdb:label>
+    </cdb:location>
+    <cdb:organiser>
+        <cdb:label>Gent on Files</cdb:label>
+    </cdb:organiser>
+</cdb:event>

--- a/tests/Event/samples/event_with_dummy_location_without_number.cdbxml.xml
+++ b/tests/Event/samples/event_with_dummy_location_without_number.cdbxml.xml
@@ -29,7 +29,6 @@
             <cdb:title>'Bekend met Gent' - quiz</cdb:title>
         </cdb:eventdetail>
     </cdb:eventdetails>
-    <cdb:keywords>gent;Quiz;;Gent on Files</cdb:keywords>
     <cdb:location>
         <cdb:address>
             <cdb:physical>

--- a/tests/Event/samples/event_with_dummy_location_without_street.cdbxml.xml
+++ b/tests/Event/samples/event_with_dummy_location_without_street.cdbxml.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<cdb:event xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL" availablefrom="2014-11-05T00:00:00" availableto="2014-11-22T00:00:00" cdbid="dcd1ef37-0608-4824-afe3-99124feda64b" createdby="gentonfiles@gmail.com" creationdate="2014-11-05T13:23:36" externalid="CDB:a0a2120e-34f9-4653-a504-09550475bc84" isparent="false" lastupdated="2014-11-08T15:36:06" lastupdatedby="sdebuck1" pctcomplete="85" published="true" owner="Invoerders Algemeen " private="false" validator="Gent Validatoren" wfstatus="approved">
+    <cdb:activities>
+        <cdb:activity count="0" type="like"/>
+        <cdb:activity count="0" type="attend"/>
+        <cdb:activity count="0" type="comment"/>
+        <cdb:activity count="0" type="recommend"/>
+        <cdb:activity count="0" type="facebook_share"/>
+        <cdb:activity count="0" type="review"/>
+    </cdb:activities>
+    <cdb:calendar>
+        <cdb:timestamps>
+            <cdb:timestamp>
+                <cdb:date>2014-11-21</cdb:date>
+                <cdb:timestart>20:00:00</cdb:timestart>
+            </cdb:timestamp>
+        </cdb:timestamps>
+    </cdb:calendar>
+    <cdb:categories>
+        <cdb:category catid="reg.359" type="flanderstouristregion">Kunststad Gent</cdb:category>
+        <cdb:category catid="0.50.21.0.0" type="eventtype">Spel of quiz</cdb:category>
+        <cdb:category catid="reg.1258" type="flandersregion">9000 Gent</cdb:category>
+    </cdb:categories>
+    <cdb:comments/>
+    <cdb:eventdetails>
+        <cdb:eventdetail lang="nl">
+            <cdb:calendarsummary>vrij 21/11/14 om 20:00 </cdb:calendarsummary>
+            <cdb:shortdescription>Korte beschrijving</cdb:shortdescription>
+            <cdb:title>'Bekend met Gent' - quiz</cdb:title>
+        </cdb:eventdetail>
+    </cdb:eventdetails>
+    <cdb:keywords>gent;Quiz;;Gent on Files</cdb:keywords>
+    <cdb:location>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Gent</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>3.725970</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.040984</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>23</cdb:housenr>
+                <cdb:zipcode>9000</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:label>Liberaal Archief</cdb:label>
+    </cdb:location>
+    <cdb:organiser>
+        <cdb:label>Gent on Files</cdb:label>
+    </cdb:organiser>
+</cdb:event>

--- a/tests/Event/samples/event_with_dummy_location_without_street.cdbxml.xml
+++ b/tests/Event/samples/event_with_dummy_location_without_street.cdbxml.xml
@@ -29,7 +29,6 @@
             <cdb:title>'Bekend met Gent' - quiz</cdb:title>
         </cdb:eventdetail>
     </cdb:eventdetails>
-    <cdb:keywords>gent;Quiz;;Gent on Files</cdb:keywords>
     <cdb:location>
         <cdb:address>
             <cdb:physical>

--- a/tests/Event/samples/event_with_dummy_location_without_street_and_number.cdbxml.xml
+++ b/tests/Event/samples/event_with_dummy_location_without_street_and_number.cdbxml.xml
@@ -29,7 +29,6 @@
             <cdb:title>'Bekend met Gent' - quiz</cdb:title>
         </cdb:eventdetail>
     </cdb:eventdetails>
-    <cdb:keywords>gent;Quiz;;Gent on Files</cdb:keywords>
     <cdb:location>
         <cdb:address>
             <cdb:physical>

--- a/tests/Event/samples/event_with_dummy_location_without_street_and_number.cdbxml.xml
+++ b/tests/Event/samples/event_with_dummy_location_without_street_and_number.cdbxml.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<cdb:event xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL" availablefrom="2014-11-05T00:00:00" availableto="2014-11-22T00:00:00" cdbid="dcd1ef37-0608-4824-afe3-99124feda64b" createdby="gentonfiles@gmail.com" creationdate="2014-11-05T13:23:36" externalid="CDB:a0a2120e-34f9-4653-a504-09550475bc84" isparent="false" lastupdated="2014-11-08T15:36:06" lastupdatedby="sdebuck1" pctcomplete="85" published="true" owner="Invoerders Algemeen " private="false" validator="Gent Validatoren" wfstatus="approved">
+    <cdb:activities>
+        <cdb:activity count="0" type="like"/>
+        <cdb:activity count="0" type="attend"/>
+        <cdb:activity count="0" type="comment"/>
+        <cdb:activity count="0" type="recommend"/>
+        <cdb:activity count="0" type="facebook_share"/>
+        <cdb:activity count="0" type="review"/>
+    </cdb:activities>
+    <cdb:calendar>
+        <cdb:timestamps>
+            <cdb:timestamp>
+                <cdb:date>2014-11-21</cdb:date>
+                <cdb:timestart>20:00:00</cdb:timestart>
+            </cdb:timestamp>
+        </cdb:timestamps>
+    </cdb:calendar>
+    <cdb:categories>
+        <cdb:category catid="reg.359" type="flanderstouristregion">Kunststad Gent</cdb:category>
+        <cdb:category catid="0.50.21.0.0" type="eventtype">Spel of quiz</cdb:category>
+        <cdb:category catid="reg.1258" type="flandersregion">9000 Gent</cdb:category>
+    </cdb:categories>
+    <cdb:comments/>
+    <cdb:eventdetails>
+        <cdb:eventdetail lang="nl">
+            <cdb:calendarsummary>vrij 21/11/14 om 20:00 </cdb:calendarsummary>
+            <cdb:shortdescription>Korte beschrijving</cdb:shortdescription>
+            <cdb:title>'Bekend met Gent' - quiz</cdb:title>
+        </cdb:eventdetail>
+    </cdb:eventdetails>
+    <cdb:keywords>gent;Quiz;;Gent on Files</cdb:keywords>
+    <cdb:location>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Gent</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>3.725970</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.040984</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:zipcode>9000</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:label>Liberaal Archief</cdb:label>
+    </cdb:location>
+    <cdb:organiser>
+        <cdb:label>Gent on Files</cdb:label>
+    </cdb:organiser>
+</cdb:event>

--- a/tests/Event/samples/event_with_photo.cdbxml.xml
+++ b/tests/Event/samples/event_with_photo.cdbxml.xml
@@ -70,7 +70,7 @@
             <cdb:title>'Bekend met Gent' - quiz</cdb:title>
         </cdb:eventdetail>
     </cdb:eventdetails>
-    <cdb:keywords>gent;Quiz;;Gent on Files</cdb:keywords>
+    <cdb:keywords>gent;Quiz;Gent on Files</cdb:keywords>
     <cdb:location>
         <cdb:address>
             <cdb:physical>


### PR DESCRIPTION
### Changed
- Handled missing street and/or number on dummy location by converting it to `-`. This simple workaround avoids if statements when `Street` on `Address` would have been made `nullable` for this exceptional case on dummy locations.

---
Ticket: https://jira.uitdatabank.be/browse/III-5545 
