### PR TITLE
III-5546 Convert `ExternalIdLocationUpdated` to concrete event

### DIFF
--- a/src/Event/Events/EventFromUDB2.php
+++ b/src/Event/Events/EventFromUDB2.php
@@ -216,10 +216,10 @@ trait EventFromUDB2
         );
     }
 
-    public function getExternalId(): ?string
+    public function getExternalId(): string
     {
         $eventAsArray = $this->getEventAsArray();
-        return $eventAsArray['location'][0]['label'][0]['@attributes']['externalid'] ?? null;
+        return $eventAsArray['location'][0]['label'][0]['@attributes']['externalid'];
     }
 
     private function getModeration(string $wfstatus, string $lastUpdated): ?AbstractEvent

--- a/src/Event/Events/EventFromUDB2.php
+++ b/src/Event/Events/EventFromUDB2.php
@@ -79,15 +79,15 @@ trait EventFromUDB2
                 $this->eventId,
                 new LocationId($eventAsArray['location'][0]['label'][0]['@attributes']['cdbid'])
             );
-        } elseif (isset($eventAsArray['location'][0]['address'][0]['physical'][0])) {
-            $granularEvents[] = new DummyLocationUpdated(
-                $this->eventId,
-                $this->getDummyLocation()
-            );
         } elseif (isset($eventAsArray['location'][0]['label'][0]['@attributes']['externalid'])) {
             $granularEvents[] = new ExternalIdLocationUpdated(
                 $this->eventId,
                 $this->getExternalId()
+            );
+        } elseif (isset($eventAsArray['location'][0]['address'][0]['physical'][0])) {
+            $granularEvents[] = new DummyLocationUpdated(
+                $this->eventId,
+                $this->getDummyLocation()
             );
         }
 

--- a/src/Event/Events/EventFromUDB2.php
+++ b/src/Event/Events/EventFromUDB2.php
@@ -84,6 +84,11 @@ trait EventFromUDB2
                 $this->eventId,
                 $this->getDummyLocation()
             );
+        } elseif (isset($eventAsArray['location'][0]['label'][0]['@attributes']['externalid'])) {
+            $granularEvents[] = new ExternalIdLocationUpdated(
+                $this->eventId,
+                $this->getExternalId()
+            );
         }
 
         $calendarEvent = $this->getCalendar($eventAsArray['calendar'][0]);

--- a/src/Event/Events/EventImportedFromUDB2.php
+++ b/src/Event/Events/EventImportedFromUDB2.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\HasCdbXmlTrait;
 use CultuurNet\UDB3\Language;
 
-final class EventImportedFromUDB2 extends EventEvent implements EventCdbXMLInterface, MainLanguageDefined, ConvertsToGranularEvents, ExternalIdLocationUpdated
+final class EventImportedFromUDB2 extends EventEvent implements EventCdbXMLInterface, MainLanguageDefined, ConvertsToGranularEvents
 {
     use HasCdbXmlTrait;
     use EventFromUDB2;

--- a/src/Event/Events/EventUpdatedFromUDB2.php
+++ b/src/Event/Events/EventUpdatedFromUDB2.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Event\EventEvent;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\HasCdbXmlTrait;
 
-final class EventUpdatedFromUDB2 extends EventEvent implements EventCdbXMLInterface, ConvertsToGranularEvents, ExternalIdLocationUpdated
+final class EventUpdatedFromUDB2 extends EventEvent implements EventCdbXMLInterface, ConvertsToGranularEvents
 {
     use HasCdbXmlTrait;
     use EventFromUDB2;

--- a/src/Event/Events/ExternalIdLocationUpdated.php
+++ b/src/Event/Events/ExternalIdLocationUpdated.php
@@ -4,7 +4,24 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\Events;
 
-interface ExternalIdLocationUpdated
+final class ExternalIdLocationUpdated
 {
-    public function getExternalId(): ?string;
+    private string $eventId;
+    private string $externalId;
+
+    public function __construct(string $eventId, string $externalId)
+    {
+        $this->eventId = $eventId;
+        $this->externalId = $externalId;
+    }
+
+    public function getEventId(): string
+    {
+        return $this->eventId;
+    }
+
+    public function getExternalId(): string
+    {
+        return $this->externalId;
+    }
 }

--- a/tests/Event/Events/EventImportedFromUDB2Test.php
+++ b/tests/Event/Events/EventImportedFromUDB2Test.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\Events\CalendarUpdated;
 use CultuurNet\UDB3\Event\Events\DummyLocationUpdated;
+use CultuurNet\UDB3\Event\Events\ExternalIdLocationUpdated;
 use CultuurNet\UDB3\Event\ValueObjects\DummyLocation;
 use CultuurNet\UDB3\Event\Events\EventDeleted;
 use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;
@@ -203,6 +204,44 @@ final class EventImportedFromUDB2Test extends TestCase
                 new TitleTranslated($eventId, new Language('de'), new LegacyTitle('Das Ereignis!')),
                 new TypeUpdated($eventId, new EventType('0.3.1.0.0', 'Cursus of workshop')),
                 new LocationUpdated($eventId, new LocationId('28d2900d-f784-4d04-8d66-5b93900c6f9c')),
+                new CalendarUpdated(
+                    $eventId,
+                    new Calendar(
+                        CalendarType::SINGLE(),
+                        null,
+                        null,
+                        [
+                            new Timestamp(
+                                new \DateTimeImmutable('2016-04-13T00:00:00.000000+0200'),
+                                new \DateTimeImmutable('2016-04-13T00:00:00.000000+0200')
+                            ),
+                        ]
+                    )
+                ),
+            ],
+            $eventImportedFromUDB2->toGranularEvents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_convert_events_with_external_id_to_granular_events(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventImportedFromUDB2 = new EventImportedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            [
+                new TitleUpdated($eventId, new LegacyTitle('Het evenement!')),
+                new TitleTranslated($eventId, new Language('fr'), new LegacyTitle('L\'événement!')),
+                new TitleTranslated($eventId, new Language('de'), new LegacyTitle('Das Ereignis!')),
+                new TypeUpdated($eventId, new EventType('0.3.1.0.0', 'Cursus of workshop')),
+                new ExternalIdLocationUpdated($eventId, 'SKB:9ccbf9c1-a5c5-4689-9687-9a7dd3c51aee'),
                 new CalendarUpdated(
                     $eventId,
                     new Calendar(

--- a/tests/Event/Events/EventImportedFromUDB2Test.php
+++ b/tests/Event/Events/EventImportedFromUDB2Test.php
@@ -243,21 +243,6 @@ final class EventImportedFromUDB2Test extends TestCase
     /**
      * @test
      */
-    public function it_returns_null_if_no_external_id_is_present(): void
-    {
-        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
-        $eventWithExternalIdLocation = new EventImportedFromUDB2(
-            $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_existing_location.cdbxml.xml'),
-            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
-        );
-
-        $this->assertNull($eventWithExternalIdLocation->getExternalId());
-    }
-
-    /**
-     * @test
-     */
     public function it_can_convert_a_periodic_event_to_granular_events(): void
     {
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';

--- a/tests/Event/Events/EventUpdatedFromUDB2Test.php
+++ b/tests/Event/Events/EventUpdatedFromUDB2Test.php
@@ -7,6 +7,7 @@ namespace test\Event\Events;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\Events\CalendarUpdated;
+use CultuurNet\UDB3\Event\Events\ExternalIdLocationUpdated;
 use CultuurNet\UDB3\Event\ValueObjects\DummyLocation;
 use CultuurNet\UDB3\Event\Events\EventUpdatedFromUDB2;
 use CultuurNet\UDB3\Event\Events\LocationUpdated;
@@ -98,6 +99,44 @@ final class EventUpdatedFromUDB2Test extends TestCase
                 new TitleTranslated($eventId, new Language('de'), new LegacyTitle('Das Ereignis!')),
                 new TypeUpdated($eventId, new EventType('0.3.1.0.0', 'Cursus of workshop')),
                 new LocationUpdated($eventId, new LocationId('28d2900d-f784-4d04-8d66-5b93900c6f9c')),
+                new CalendarUpdated(
+                    $eventId,
+                    new Calendar(
+                        CalendarType::SINGLE(),
+                        null,
+                        null,
+                        [
+                            new Timestamp(
+                                new \DateTimeImmutable('2016-04-13T00:00:00.000000+0200'),
+                                new \DateTimeImmutable('2016-04-13T00:00:00.000000+0200')
+                            ),
+                        ]
+                    )
+                ),
+            ],
+            $eventUpdatedFromUdb2->toGranularEvents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_convert_events_with_external_id_to_granular_events(): void
+    {
+        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
+        $eventUpdatedFromUdb2 = new EventUpdatedFromUDB2(
+            $eventId,
+            file_get_contents(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
+            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+        );
+
+        $this->assertEquals(
+            [
+                new TitleUpdated($eventId, new LegacyTitle('Het evenement!')),
+                new TitleTranslated($eventId, new Language('fr'), new LegacyTitle('L\'événement!')),
+                new TitleTranslated($eventId, new Language('de'), new LegacyTitle('Das Ereignis!')),
+                new TypeUpdated($eventId, new EventType('0.3.1.0.0', 'Cursus of workshop')),
+                new ExternalIdLocationUpdated($eventId, 'SKB:9ccbf9c1-a5c5-4689-9687-9a7dd3c51aee'),
                 new CalendarUpdated(
                     $eventId,
                     new Calendar(

--- a/tests/Event/Events/EventUpdatedFromUDB2Test.php
+++ b/tests/Event/Events/EventUpdatedFromUDB2Test.php
@@ -239,21 +239,6 @@ final class EventUpdatedFromUDB2Test extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_null_if_no_external_id_is_present(): void
-    {
-        $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
-        $eventWithExternalIdLocation = new EventUpdatedFromUDB2(
-            $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_existing_location.cdbxml.xml'),
-            'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
-        );
-
-        $this->assertNull($eventWithExternalIdLocation->getExternalId());
-    }
-
     public function serializationDataProvider(): array
     {
         $xml = file_get_contents(__DIR__ . '/../samples/event_entryapi_valid_with_keywords.xml');


### PR DESCRIPTION
### Changed
- Converted `ExternalIdLocationUpdated` to a concrete event so it can be used inside a handle method of the `RdfProjector`

---
Ticket: https://jira.uitdatabank.be/browse/III-5546
