### PR TITLE
III-5546 Handle `ExternalIdLocationUpdated` inside `RdfProjector`

### DIFF
--- a/app/Event/EventRdfServiceProvider.php
+++ b/app/Event/EventRdfServiceProvider.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Event\ReadModel\RDF\RdfProjector;
 use CultuurNet\UDB3\RDF\CacheGraphRepository;
 use CultuurNet\UDB3\RDF\MainLanguageRepository;
 use CultuurNet\UDB3\RDF\RdfServiceProvider;
+use CultuurNet\UDB3\UDB2\UDB2EventServicesProvider;
 
 final class EventRdfServiceProvider extends AbstractServiceProvider
 {
@@ -40,7 +41,8 @@ final class EventRdfServiceProvider extends AbstractServiceProvider
                 RdfServiceProvider::createIriGenerator($this->container->get('config')['rdf']['eventsRdfBaseUri']),
                 RdfServiceProvider::createIriGenerator($this->container->get('config')['rdf']['placesRdfBaseUri']),
                 RdfServiceProvider::createIriGenerator($this->container->get('config')['taxonomy']['terms']),
-                $this->container->get(AddressParser::class)
+                $this->container->get(AddressParser::class),
+                UDB2EventServicesProvider::buildMappingServiceForPlaces(),
             )
         );
     }

--- a/app/UDB2/UDB2EventServicesProvider.php
+++ b/app/UDB2/UDB2EventServicesProvider.php
@@ -24,13 +24,13 @@ final class UDB2EventServicesProvider extends AbstractServiceProvider
         $container->addShared(
             'udb2_event_cdbid_extractor',
             fn () => new EventCdbIdExtractor(
-                $this->buildMappingServiceForLocation(__DIR__ . '../../config.external_id_mapping_place.php'),
-                $this->buildMappingServiceForLocation(__DIR__ . '../../config.external_id_mapping_organizer.php'),
+                $this->buildMappingServiceForPlaces(),
+                $this->buildMappingServiceForOrganizers(),
             ),
         );
     }
 
-    private function buildMappingServiceForLocation(string $mappingFileLocation): ArrayMappingService
+    private static function buildMappingService(string $mappingFileLocation): ArrayMappingService
     {
         $map = [];
 
@@ -43,5 +43,15 @@ final class UDB2EventServicesProvider extends AbstractServiceProvider
         }
 
         return new ArrayMappingService($map);
+    }
+
+    public static function buildMappingServiceForPlaces(): ArrayMappingService
+    {
+        return self::buildMappingService(__DIR__ . '../../config.external_id_mapping_place.php');
+    }
+
+    public static function buildMappingServiceForOrganizers(): ArrayMappingService
+    {
+        return self::buildMappingService(__DIR__ . '../../config.external_id_mapping_organizer.php');
     }
 }

--- a/src/Cdb/ExternalId/ArrayMappingService.php
+++ b/src/Cdb/ExternalId/ArrayMappingService.php
@@ -6,25 +6,14 @@ namespace CultuurNet\UDB3\Cdb\ExternalId;
 
 class ArrayMappingService implements MappingServiceInterface
 {
-    /**
-     * @var array
-     */
-    private $externalIdMapping;
+    private array $externalIdMapping;
 
-    /**
-     * @param array $externalIdMapping
-     *   Associative array of external ids and their corresponding cdbids.
-     */
     public function __construct(array $externalIdMapping)
     {
         $this->externalIdMapping = $externalIdMapping;
     }
 
-    /**
-     * @param string $externalId
-     * @return string|null
-     */
-    public function getCdbId($externalId)
+    public function getCdbId(string $externalId): ?string
     {
         if (isset($this->externalIdMapping[$externalId])) {
             return (string) $this->externalIdMapping[$externalId];

--- a/src/Cdb/ExternalId/MappingServiceInterface.php
+++ b/src/Cdb/ExternalId/MappingServiceInterface.php
@@ -6,11 +6,5 @@ namespace CultuurNet\UDB3\Cdb\ExternalId;
 
 interface MappingServiceInterface
 {
-    /**
-     * @param string $externalId
-     *
-     * @return string|null
-     *   Cdbid for the given external id, or null if none found.
-     */
-    public function getCdbId($externalId);
+    public function getCdbId(string $externalId): ?string;
 }

--- a/tests/Cdb/ExternalId/ArrayMappingServiceTest.php
+++ b/tests/Cdb/ExternalId/ArrayMappingServiceTest.php
@@ -8,31 +8,23 @@ use PHPUnit\Framework\TestCase;
 
 class ArrayMappingServiceTest extends TestCase
 {
-    /**
-     * @var array
-     */
-    private $array;
-
-    /**
-     * @var ArrayMappingService
-     */
-    private $mappingService;
+    private ArrayMappingService $mappingService;
 
     public function setUp(): void
     {
-        $this->array = [
+        $array = [
             'SKB Import:Organisation_6666' => 'b91a72d0-7d69-4fe2-81f4-5c0f29001089',
             'TA_productie:99999' => '49cedb90-ef38-4612-b958-c49d3d1c8b83',
             'ccbelgica_Organiser_1' => 'b91a72d0-7d69-4fe2-81f4-5c0f29001089',
         ];
 
-        $this->mappingService = new ArrayMappingService($this->array);
+        $this->mappingService = new ArrayMappingService($array);
     }
 
     /**
      * @test
      */
-    public function it_returns_the_cdbid_of_a_known_external_id()
+    public function it_returns_the_cdbid_of_a_known_external_id(): void
     {
         $this->assertEquals(
             'b91a72d0-7d69-4fe2-81f4-5c0f29001089',
@@ -43,7 +35,7 @@ class ArrayMappingServiceTest extends TestCase
     /**
      * @test
      */
-    public function it_can_map_multiple_external_ids_to_the_same_cdbid()
+    public function it_can_map_multiple_external_ids_to_the_same_cdbid(): void
     {
         $cdbid = 'b91a72d0-7d69-4fe2-81f4-5c0f29001089';
 
@@ -54,7 +46,7 @@ class ArrayMappingServiceTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_null_for_unknown_external_ids()
+    public function it_returns_null_for_unknown_external_ids(): void
     {
         $this->assertNull($this->mappingService->getCdbId('unknown-external-id'));
     }

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -19,6 +19,7 @@ use CultuurNet\UDB3\Event\Events\DescriptionUpdated;
 use CultuurNet\UDB3\Event\Events\DummyLocationUpdated;
 use CultuurNet\UDB3\Event\Events\EventCreated;
 use CultuurNet\UDB3\Event\Events\EventDeleted;
+use CultuurNet\UDB3\Event\Events\ExternalIdLocationUpdated;
 use CultuurNet\UDB3\Event\Events\LocationUpdated;
 use CultuurNet\UDB3\Event\Events\Moderation\Approved;
 use CultuurNet\UDB3\Event\Events\Moderation\FlaggedAsDuplicate;
@@ -329,6 +330,26 @@ class RdfProjectorTest extends TestCase
         ]);
 
         $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/location-updated-on-calendar-single.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_external_id_location_updated(): void
+    {
+        $eventId = 'd4b46fba-6433-4f86-bcb5-edeef6689fea';
+
+        $this->mappingService->expects($this->once())
+            ->method('getCdbId')
+            ->with('external_id')
+            ->willReturn('498dab67-236e-4bdb-9a70-7c26ad75301f');
+
+        $this->project($eventId, [
+            $this->getEventCreated($eventId),
+            new ExternalIdLocationUpdated($eventId, 'external_id'),
+        ]);
+
+        $this->assertTurtleData($eventId, file_get_contents(__DIR__ . '/data/external-id-location-updated.ttl'));
     }
 
     /**

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Address\AddressParser;
 use CultuurNet\UDB3\Address\ParsedAddress;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Cdb\ExternalId\MappingServiceInterface;
 use CultuurNet\UDB3\Description;
 use CultuurNet\UDB3\Event\Events\CalendarUpdated;
 use CultuurNet\UDB3\Event\Events\DescriptionTranslated;
@@ -62,11 +63,18 @@ class RdfProjectorTest extends TestCase
      */
     private $addressParser;
 
+    /**
+     * @var MappingServiceInterface|MockObject
+     */
+    private $mappingService;
+
     protected function setUp(): void
     {
         $this->graphRepository = new InMemoryGraphRepository();
 
         $this->addressParser = $this->createMock(AddressParser::class);
+
+        $this->mappingService = $this->createMock(MappingServiceInterface::class);
 
         $this->rdfProjector = new RdfProjector(
             new InMemoryMainLanguageRepository(),
@@ -75,7 +83,8 @@ class RdfProjectorTest extends TestCase
             new CallableIriGenerator(fn (string $item): string => 'https://mock.data.publiq.be/events/' . $item),
             new CallableIriGenerator(fn (string $item): string => 'https://mock.data.publiq.be/places/' . $item),
             new CallableIriGenerator(fn (string $item): string => 'https://mock.taxonomy.uitdatabank.be/terms/' . $item),
-            $this->addressParser
+            $this->addressParser,
+            $this->mappingService
         );
     }
 

--- a/tests/Event/ReadModel/RDF/data/external-id-location-updated.ttl
+++ b/tests/Event/ReadModel/RDF/data/external-id-location-updated.ttl
@@ -1,0 +1,21 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
+  a cidoc:E7_Activity ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea"^^xsd:anyUri ;
+    dcterms:creator <https://fixme.com/example/dataprovider/publiq>
+  ] ;
+  dcterms:title "Faith no more"@nl ;
+  dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
+  dcterms:modified "2023-01-02T12:30:15+01:00"^^xsd:dateTime ;
+  prov:atLocation <https://mock.data.publiq.be/places/498dab67-236e-4bdb-9a70-7c26ad75301f> .


### PR DESCRIPTION
### Changed
- Handled `ExternalIdLocationUpdated` inside `RdfProjector` by converting to a normal `LocationUpdated` when the mapping from an external id to an internal id was successful.

---
Ticket: https://jira.uitdatabank.be/browse/III-5546
