### PR TITLE
III-5614 Sleep 500 milliseconds before new fetch

### DIFF
--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -167,6 +167,12 @@ final class EventJSONLDServiceProvider extends AbstractServiceProvider
                 );
 
                 $eventLDProjector->setLogger(LoggerFactory::create($container, LoggerName::forWeb()));
+                $eventLDProjector->setNrOfRetries(
+                    $container->get('config')['event_ld_projector']['nr_of_retries'] ?? 3
+                );
+                $eventLDProjector->setTimeBetweenRetries(
+                    $container->get('config')['event_ld_projector']['time_between_retries'] ?? 500
+                );
 
                 return $eventLDProjector;
             }

--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -61,7 +61,7 @@ final class PlaceJSONLDServiceProvider extends AbstractServiceProvider
         $container->addShared(
             self::PROJECTOR,
             function () use ($container) {
-                return new PlaceLDProjector(
+                $placeLDProjector = new PlaceLDProjector(
                     $container->get('place_jsonld_repository'),
                     $container->get('place_iri_generator'),
                     $container->get('organizer_service'),
@@ -73,6 +73,15 @@ final class PlaceJSONLDServiceProvider extends AbstractServiceProvider
                     $container->get('config')['base_price_translations'],
                     new VideoNormalizer($container->get('config')['media']['video_default_copyright'])
                 );
+
+                $placeLDProjector->setNrOfRetries(
+                    $container->get('config')['place_ld_projector']['nr_of_retries'] ?? 3
+                );
+                $placeLDProjector->setTimeBetweenRetries(
+                    $container->get('config')['place_ld_projector']['time_between_retries'] ?? 500
+                );
+
+                return $placeLDProjector;
             }
         );
 

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -837,6 +837,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
             $nrOfRetries = 3;
 
             while ($this->playheadMismatch($document->getBody()) && $nrOfRetries > 0) {
+                usleep(500);
                 $nrOfRetries--;
                 $this->logger->warning(
                     'Playhead mismatch for document ' . $itemId . ' retries left ' . $nrOfRetries . '. Expected ' . ($this->playhead - 1) . ' but found ' . $document->getBody()->playhead

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -110,9 +110,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         MediaObjectSerializer $mediaObjectSerializer,
         JsonDocumentMetaDataEnricherInterface $jsonDocumentMetaDataEnricher,
         array $basePriceTranslations,
-        VideoNormalizer $videoNormalizer,
-        int $nrOfRetries = 3,
-        int $timeBetweenRetries = 500
+        VideoNormalizer $videoNormalizer
     ) {
         $this->repository = $repository;
         $this->iriGenerator = $iriGenerator;
@@ -121,12 +119,23 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         $this->mediaObjectSerializer = $mediaObjectSerializer;
         $this->basePriceTranslations = $basePriceTranslations;
         $this->videoNormalizer = $videoNormalizer;
-        $this->nrOfRetries = $nrOfRetries;
-        $this->timeBetweenRetries = $timeBetweenRetries;
 
         $this->slugger = new CulturefeedSlugger();
 
         $this->logger = new NullLogger();
+
+        $this->nrOfRetries = 3;
+        $this->timeBetweenRetries = 500;
+    }
+
+    public function setNrOfRetries(int $nrOfRetries): void
+    {
+        $this->nrOfRetries = $nrOfRetries;
+    }
+
+    public function setTimeBetweenRetries(int $timeBetweenRetries): void
+    {
+        $this->timeBetweenRetries = $timeBetweenRetries;
     }
 
     public function handle(DomainMessage $domainMessage): void

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -859,7 +859,23 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
 
     private function playheadMismatch(\stdClass $body): bool
     {
-        return isset($this->playhead) && $this->playhead > 0 && isset($body->playhead) && $body->playhead !== $this->playhead - 1;
+        if (!isset($this->playhead)) {
+            return false;
+        }
+
+        if ($this->playhead <= 0) {
+            return false;
+        }
+
+        if (!isset($body->playhead)) {
+            return false;
+        }
+
+        if ($body->playhead === $this->playhead - 1) {
+            return false;
+        }
+
+        return true;
     }
 
     public function organizerJSONLD(string $organizerId): array


### PR DESCRIPTION
### Added
- Added configurable for retry count and time between retries
  - https://github.com/cultuurnet/appconfig/pull/349
  - https://github.com/cultuurnet/udb3-vagrant/pull/163

### Note
- A replay will still work without warnings/errors because a `PlaceCreated` and `EventCreated` will trigger the creation of a new JSON document.

---
Ticket: https://jira.uitdatabank.be/browse/III-5614
