### PR TITLE
III-5636 Require Redis for resque from config

### DIFF
--- a/app/CommandHandling/CommandBusServiceProvider.php
+++ b/app/CommandHandling/CommandBusServiceProvider.php
@@ -293,7 +293,9 @@ final class CommandBusServiceProvider extends AbstractServiceProvider
         $commandBus = new ResqueCommandBus(
             $container->get('authorized_command_bus'),
             $queueName,
-            $container->get('command_bus_event_dispatcher')
+            $container->get('command_bus_event_dispatcher'),
+            $container->get('config')['resque']['host'] ?? '127.0.0.1',
+            $container->get('config')['resque']['port'] ?? 6379
         );
         $commandBus->setLogger($container->get('logger_factory.resque_worker')($queueName));
         return $commandBus;

--- a/app/CommandHandling/CommandBusServiceProvider.php
+++ b/app/CommandHandling/CommandBusServiceProvider.php
@@ -262,8 +262,8 @@ final class CommandBusServiceProvider extends AbstractServiceProvider
             new \League\Container\Argument\Literal\CallableArgument(
                 function ($queueName) use ($container) {
                     $redisConfig = [
-                        'host' => '127.0.0.1',
-                        'port' => 6379,
+                        'host' => $container->get('config')['resque']['host'] ?? '127.0.0.1',
+                        'port' => $container->get('config')['resque']['port'] ?? 6379,
                     ];
                     if (extension_loaded('redis')) {
                         $redis = new Redis();

--- a/app/Jobs/JobsServiceProvider.php
+++ b/app/Jobs/JobsServiceProvider.php
@@ -21,7 +21,12 @@ final class JobsServiceProvider extends AbstractServiceProvider
 
         $container->addShared(
             GetJobStatusRequestHandler::class,
-            fn () => new GetJobStatusRequestHandler(new ResqueJobStatusFactory())
+            fn () => new GetJobStatusRequestHandler(
+                new ResqueJobStatusFactory(
+                    $container->get('config')['resque']['host'] ?? '127.0.0.1',
+                    $container->get('config')['resque']['port'] ?? 6379
+                )
+            )
         );
     }
 }

--- a/src/CommandHandling/ResqueCommandBus.php
+++ b/src/CommandHandling/ResqueCommandBus.php
@@ -46,8 +46,12 @@ class ResqueCommandBus extends CommandBusDecoratorBase implements ContextAwareIn
     public function __construct(
         CommandBus $decoratee,
         string $queueName,
-        EventDispatcher $dispatcher
+        EventDispatcher $dispatcher,
+        string $host,
+        int $port
     ) {
+        \Resque::setBackend($host . ':' . $port);
+
         parent::__construct($decoratee);
         $this->queueName = $queueName;
         $this->eventDispatcher = $dispatcher;

--- a/src/Http/Jobs/ResqueJobStatusFactory.php
+++ b/src/Http/Jobs/ResqueJobStatusFactory.php
@@ -8,6 +8,11 @@ use Resque_Job_Status;
 
 class ResqueJobStatusFactory implements JobsStatusFactory
 {
+    public function __construct(string $host, int $port)
+    {
+        \Resque::setBackend($host . ':' . $port);
+    }
+
     public function createFromJobId(string $jobId): ?JobStatus
     {
         $resqueJobStatus = new Resque_Job_Status($jobId);

--- a/tests/CommandHandling/ResqueCommandBusTest.php
+++ b/tests/CommandHandling/ResqueCommandBusTest.php
@@ -37,7 +37,9 @@ class ResqueCommandBusTest extends TestCase
         $this->commandBus = new ResqueCommandBus(
             $this->decoratedCommandBus,
             $queueName,
-            $this->dispatcher
+            $this->dispatcher,
+            '127.0.0.1',
+            6379
         );
     }
 
@@ -75,7 +77,9 @@ class ResqueCommandBusTest extends TestCase
         $commandBus = new ResqueCommandBus(
             $decoratee,
             $queueName,
-            $this->dispatcher
+            $this->dispatcher,
+            '127.0.0.1',
+            6379
         );
 
         $command = $this->createMock(AuthorizableCommand::class);


### PR DESCRIPTION
### Changed
- Required Redis host and port for the `ResqueJobStatusFactory`
- Required Redis host and port for the `ResqueCommandBus`

---
Ticket: https://jira.uitdatabank.be/browse/III-5636
