### PR TITLE
III-5613 Refactor `Label\DBALReadRepository`

### DIFF
--- a/app/Console/Command/AbstractRemoveLabel.php
+++ b/app/Console/Command/AbstractRemoveLabel.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Console\Command;
 
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Doctrine\DBALReadRepository;
-use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\InMemoryExcludedLabelsRepository;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\StringLiteral;
@@ -25,8 +24,7 @@ abstract class AbstractRemoveLabel extends Command
             $connection,
             new StringLiteral('labels_json'),
             new StringLiteral('label_roles'),
-            new StringLiteral('user_roles'),
-            new InMemoryExcludedLabelsRepository([])
+            new StringLiteral('user_roles')
         );
         $this->commandBus = $commandBus;
         parent::__construct();

--- a/app/Labels/LabelServiceProvider.php
+++ b/app/Labels/LabelServiceProvider.php
@@ -30,7 +30,6 @@ use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\BroadcastingWriteRepository
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Doctrine\DBALReadRepository as JsonReadRepository;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Doctrine\DBALWriteRepository as JsonWriteRepository;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\GodUserReadRepositoryDecorator;
-use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\InMemoryExcludedLabelsRepository;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\WriteRepositoryInterface;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Projector as RelationsProjector;
@@ -164,8 +163,7 @@ final class LabelServiceProvider extends AbstractServiceProvider
                             $container->get('dbal_connection'),
                             new StringLiteral(self::JSON_TABLE),
                             new StringLiteral(self::LABEL_ROLES_TABLE),
-                            new StringLiteral(UserPermissionsServiceProvider::USER_ROLES_TABLE),
-                            new InMemoryExcludedLabelsRepository($labels ?? [])
+                            new StringLiteral(UserPermissionsServiceProvider::USER_ROLES_TABLE)
                         ),
                         $container->get('config')['user_permissions']['allow_all']
                     ),

--- a/app/Labels/LabelServiceProvider.php
+++ b/app/Labels/LabelServiceProvider.php
@@ -56,8 +56,6 @@ final class LabelServiceProvider extends AbstractServiceProvider
     public const RELATIONS_WRITE_REPOSITORY = 'labels.relations_write_repository';
     public const LABEL_ROLES_WRITE_REPOSITORY = 'labels.label_roles_write_repository';
 
-    public const WRITE_SERVICE = 'labels.write_service';
-
     public const UNIQUE_EVENT_STORE = 'labels.unique_event_store';
     public const REPOSITORY = 'labels.repository';
     public const COMMAND_HANDLER = 'labels.command_handler';

--- a/src/Http/Label/Query/QueryFactory.php
+++ b/src/Http/Label/Query/QueryFactory.php
@@ -42,6 +42,7 @@ class QueryFactory implements QueryFactoryInterface
             $userId,
             $offset,
             $limit,
+            $suggestion,
             $suggestion
         );
     }

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -276,6 +276,8 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
 
         $count = (int) $row[SchemaConfigurator::COUNT_COLUMN];
 
+        $excluded = $row[SchemaConfigurator::EXCLUDED_COLUMN] ?? false;
+
         return new Entity(
             $uuid,
             $name,
@@ -283,7 +285,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
             $privacy,
             $parentUuid,
             $count,
-            $this->isExcluded($uuid)
+            $excluded
         );
     }
 

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -276,7 +276,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
 
         $count = (int) $row[SchemaConfigurator::COUNT_COLUMN];
 
-        $excluded = $row[SchemaConfigurator::EXCLUDED_COLUMN] ?? false;
+        $excluded = (bool) $row[SchemaConfigurator::EXCLUDED_COLUMN];
 
         return new Entity(
             $uuid,

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -142,14 +142,17 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
                 $this->createLikeParameter($query)
             );
 
-        if ($query->isSuggestion()) {
-            $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\-]{2,50}$\'')
-                ->andWhere(
-                    $queryBuilder->expr()->eq(
-                        SchemaConfigurator::EXCLUDED_COLUMN,
-                        0
-                    )
-                );
+        if ($query->isInvalidExcluded()) {
+            $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\-]{2,50}$\'');
+        }
+
+        if ($query->isExcludedExcluded()) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->eq(
+                    SchemaConfigurator::EXCLUDED_COLUMN,
+                    0
+                )
+            );
         }
 
         if ($query->getUserId()) {

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -288,9 +288,4 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
             $excluded
         );
     }
-
-    private function isExcluded(UUID $uuid): bool
-    {
-        return \in_array($uuid->toString(), $this->excludedLabelsRepository->getAll(), true);
-    }
 }

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -144,11 +144,11 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
 
         if ($query->isSuggestion()) {
             $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\-]{2,50}$\'')
-                ->andWhere(SchemaConfigurator::EXCLUDED_COLUMN . ' = :excluded')
-                ->setParameters(
-                    [
-                        ':excluded' => false,
-                    ]
+                ->andWhere(
+                    $queryBuilder->expr()->eq(
+                        SchemaConfigurator::EXCLUDED_COLUMN,
+                        0
+                    )
                 );
         }
 

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Doctrine;
 
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
-use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ExcludedLabelsRepository;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Query;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ReadModels\Roles\Doctrine\SchemaConfigurator as LabelRolesSchemaConfigurator;
@@ -24,20 +23,16 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
 
     private StringLiteral $userRolesTableName;
 
-    private ExcludedLabelsRepository $excludedLabelsRepository;
-
     public function __construct(
         Connection $connection,
         StringLiteral $tableName,
         StringLiteral $labelRolesTableName,
-        StringLiteral $userRolesTableName,
-        ExcludedLabelsRepository $excludedLabelsRepository
+        StringLiteral $userRolesTableName
     ) {
         parent::__construct($connection, $tableName);
 
         $this->labelRolesTableName = $labelRolesTableName;
         $this->userRolesTableName = $userRolesTableName;
-        $this->excludedLabelsRepository = $excludedLabelsRepository;
     }
 
     public function getByUuid(UUID $uuid): ?Entity

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -148,20 +148,13 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
             );
 
         if ($query->isSuggestion()) {
-            $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\-]{2,50}$\'');
-
-            $excludedLabels = $this->excludedLabelsRepository->getAll();
-            if (!empty($excludedLabels)) {
-                $queryBuilder->andWhere(
-                    $queryBuilder->expr()->notIn(
-                        SchemaConfigurator::UUID_COLUMN,
-                        array_map(
-                            fn (string $label) => '"' . $label . '"',
-                            $excludedLabels
-                        )
-                    )
+            $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\-]{2,50}$\'')
+                ->andWhere(SchemaConfigurator::EXCLUDED_COLUMN . ' = :excluded')
+                ->setParameters(
+                    [
+                        ':excluded' => false,
+                    ]
                 );
-            }
         }
 
         if ($query->getUserId()) {
@@ -219,6 +212,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
             SchemaConfigurator::PRIVATE_COLUMN,
             SchemaConfigurator::PARENT_UUID_COLUMN,
             SchemaConfigurator::COUNT_COLUMN,
+            SchemaConfigurator::EXCLUDED_COLUMN,
         ];
     }
 

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/SchemaConfigurator.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/SchemaConfigurator.php
@@ -11,7 +11,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use CultuurNet\UDB3\StringLiteral;
 
-class SchemaConfigurator implements SchemaConfiguratorInterface
+final class SchemaConfigurator implements SchemaConfiguratorInterface
 {
     public const UUID_COLUMN = 'uuid_col';
     public const NAME_COLUMN = 'name';

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/SchemaConfigurator.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/SchemaConfigurator.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Doctrine;
 use CultuurNet\UDB3\Doctrine\DBAL\SchemaConfiguratorInterface;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use CultuurNet\UDB3\StringLiteral;
 
@@ -21,10 +22,7 @@ class SchemaConfigurator implements SchemaConfiguratorInterface
 
     public const EXCLUDED_COLUMN = 'excluded';
 
-    /**
-     * @var StringLiteral
-     */
-    private $tableName;
+    private StringLiteral $tableName;
 
 
     public function __construct(StringLiteral $tableName)
@@ -32,10 +30,7 @@ class SchemaConfigurator implements SchemaConfiguratorInterface
         $this->tableName = $tableName;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function configure(AbstractSchemaManager $schemaManager)
+    public function configure(AbstractSchemaManager $schemaManager): void
     {
         $schema = $schemaManager->createSchema();
 
@@ -46,10 +41,7 @@ class SchemaConfigurator implements SchemaConfiguratorInterface
         }
     }
 
-    /**
-     * @return \Doctrine\DBAL\Schema\Table
-     */
-    private function createTable(Schema $schema, StringLiteral $tableName)
+    private function createTable(Schema $schema, StringLiteral $tableName): Table
     {
         $table = $schema->createTable($tableName->toNative());
 

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/SchemaConfigurator.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/SchemaConfigurator.php
@@ -19,6 +19,8 @@ class SchemaConfigurator implements SchemaConfiguratorInterface
     public const PARENT_UUID_COLUMN = 'parentUuid';
     public const COUNT_COLUMN = 'count_col';
 
+    public const EXCLUDED_COLUMN = 'excluded';
+
     /**
      * @var StringLiteral
      */
@@ -74,6 +76,10 @@ class SchemaConfigurator implements SchemaConfiguratorInterface
         $table->addColumn(self::COUNT_COLUMN, Type::BIGINT)
             ->setNotnull(true)
             ->setDefault(0);
+
+        $table->addColumn(self::EXCLUDED_COLUMN, Type::BOOLEAN)
+            ->setNotnull(true)
+            ->setDefault(false);
 
         $table->setPrimaryKey([self::UUID_COLUMN]);
         $table->addUniqueIndex([self::UUID_COLUMN]);

--- a/src/Label/ReadModels/JSON/Repository/Query.php
+++ b/src/Label/ReadModels/JSON/Repository/Query.php
@@ -62,11 +62,6 @@ final class Query
         return $this->limit;
     }
 
-    public function isSuggestion(): bool
-    {
-        return $this->excludeExcludedLabels && $this->excludeInvalidLabels;
-    }
-
     public function isExcludedExcluded(): bool
     {
         return $this->excludeExcludedLabels;

--- a/src/Label/ReadModels/JSON/Repository/Query.php
+++ b/src/Label/ReadModels/JSON/Repository/Query.php
@@ -14,14 +14,17 @@ final class Query
 
     private ?int $limit;
 
-    private bool $suggestion;
+    private bool $excludeExcludedLabels;
+
+    private bool $excludeInvalidLabels;
 
     public function __construct(
         string $value,
         ?string $userId = null,
         ?int $offset = null,
         ?int $limit = null,
-        bool $suggestion = false
+        bool $excludeExcludedLabels = false,
+        bool $excludeInvalidLabels = false
     ) {
         if ($offset < 0) {
             throw new \InvalidArgumentException('Offset should be zero or higher');
@@ -35,7 +38,8 @@ final class Query
         $this->userId = $userId;
         $this->offset = $offset;
         $this->limit = $limit;
-        $this->suggestion = $suggestion;
+        $this->excludeExcludedLabels = $excludeExcludedLabels;
+        $this->excludeInvalidLabels = $excludeInvalidLabels;
     }
 
     public function getValue(): string
@@ -60,6 +64,16 @@ final class Query
 
     public function isSuggestion(): bool
     {
-        return $this->suggestion;
+        return $this->excludeExcludedLabels && $this->excludeInvalidLabels;
+    }
+
+    public function isExcludedExcluded(): bool
+    {
+        return $this->excludeExcludedLabels;
+    }
+
+    public function isInvalidExcluded(): bool
+    {
+        return $this->excludeInvalidLabels;
     }
 }

--- a/tests/Http/Label/Query/QueryFactoryTest.php
+++ b/tests/Http/Label/Query/QueryFactoryTest.php
@@ -233,6 +233,7 @@ final class QueryFactoryTest extends TestCase
             null,
             self::START_VALUE,
             self::LIMIT_VALUE,
+            $suggestion,
             $suggestion
         );
 

--- a/tests/Label/ReadModels/JSON/Repository/Doctrine/BaseDBALRepositoryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/Doctrine/BaseDBALRepositoryTest.php
@@ -45,7 +45,7 @@ abstract class BaseDBALRepositoryTest extends TestCase
     {
         $values = $this->entityToValues($entity);
 
-        $sql = 'INSERT INTO ' . $this->tableName . ' VALUES (?, ?, ?, ?, ?, ?)';
+        $sql = 'INSERT INTO ' . $this->tableName . ' VALUES (?, ?, ?, ?, ?, ?, ?)';
 
         $this->connection->executeQuery($sql, $values);
     }
@@ -62,6 +62,7 @@ abstract class BaseDBALRepositoryTest extends TestCase
             $entity->getPrivacy()->sameAs(Privacy::PRIVACY_PRIVATE()),
             $entity->getParentUuid() ? $entity->getParentUuid()->toString() : null,
             $entity->getCount(),
+            $entity->isExcluded(),
         ];
     }
 

--- a/tests/Label/ReadModels/JSON/Repository/Doctrine/BaseDBALRepositoryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/Doctrine/BaseDBALRepositoryTest.php
@@ -16,10 +16,7 @@ abstract class BaseDBALRepositoryTest extends TestCase
 {
     use DBALTestConnectionTrait;
 
-    /**
-     * @var StringLiteral
-     */
-    private $tableName;
+    private StringLiteral $tableName;
 
     protected function setUp(): void
     {
@@ -32,16 +29,13 @@ abstract class BaseDBALRepositoryTest extends TestCase
         $schemaConfigurator->configure($schemaManager);
     }
 
-    /**
-     * @return StringLiteral
-     */
-    protected function getTableName()
+    protected function getTableName(): StringLiteral
     {
         return $this->tableName;
     }
 
 
-    protected function saveEntity(Entity $entity)
+    protected function saveEntity(Entity $entity): void
     {
         $values = $this->entityToValues($entity);
 
@@ -50,10 +44,7 @@ abstract class BaseDBALRepositoryTest extends TestCase
         $this->connection->executeQuery($sql, $values);
     }
 
-    /**
-     * @return array
-     */
-    protected function entityToValues(Entity $entity)
+    protected function entityToValues(Entity $entity): array
     {
         return [
             $entity->getUuid()->toString(),
@@ -66,10 +57,7 @@ abstract class BaseDBALRepositoryTest extends TestCase
         ];
     }
 
-    /**
-     * @return Entity
-     */
-    protected function getEntity()
+    protected function getEntity(): Entity
     {
         $sql = 'SELECT * FROM ' . $this->tableName;
 
@@ -79,10 +67,7 @@ abstract class BaseDBALRepositoryTest extends TestCase
         return $this->rowToEntity($row);
     }
 
-    /**
-     * @return Entity
-     */
-    protected function rowToEntity(array $row)
+    protected function rowToEntity(array $row): Entity
     {
         return new Entity(
             new UUID($row[SchemaConfigurator::UUID_COLUMN]),

--- a/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepositoryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepositoryTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Doctrine;
 
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Query;
-use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\InMemoryExcludedLabelsRepository;
 use CultuurNet\UDB3\Label\ReadModels\Roles\Doctrine\SchemaConfigurator as LabelRolesSchemaConfigurator;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
@@ -57,13 +56,7 @@ final class DBALReadRepositoryTest extends BaseDBALRepositoryTest
             $this->getConnection(),
             $this->getTableName(),
             $this->labelRolesTableName,
-            $this->userRolesTableName,
-            new InMemoryExcludedLabelsRepository(
-                [
-                    '67dcd2a0-5301-4747-a956-3741420efd52',
-                    '5d6efb46-835c-413f-a62b-fa764c68a33f',
-                ]
-            )
+            $this->userRolesTableName
         );
 
         $this->entityByUuid = new Entity(

--- a/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepositoryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepositoryTest.php
@@ -340,6 +340,25 @@ final class DBALReadRepositoryTest extends BaseDBALRepositoryTest
     /**
      * @test
      */
+    public function it_can_omit_excluded_labels(): void
+    {
+        $search = new Query(
+            'excluded',
+            null,
+            null,
+            null,
+            true,
+            false,
+        );
+
+        $totalLabels = $this->dbalReadRepository->searchTotalLabels($search);
+
+        $this->assertEquals(0, $totalLabels);
+    }
+
+    /**
+     * @test
+     */
     public function a_new_label_can_be_used(): void
     {
         $this->assertTrue($this->dbalReadRepository->canUseLabel(

--- a/tests/Label/ReadModels/JSON/Repository/QueryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/QueryTest.php
@@ -138,6 +138,7 @@ final class QueryTest extends TestCase
     {
         $query = new Query(self::NAME);
 
-        $this->assertFalse($query->isSuggestion());
+        $this->assertFalse($query->isInvalidExcluded());
+        $this->assertFalse($query->isExcludedExcluded());
     }
 }


### PR DESCRIPTION
### Added

- DBALReadRepository: `Test` if it can omit excluded `Labels`

### Changed

- `Query`: split up `$suggestion` between `$excludeExcludedLabels` & `$excludeInvalidLabels`
- `Query`: split up `isSuggestion` member between `isExcludedExcluded ` & `isInvalidExcluded`
- `QueryFactory`: `suggestion` is translated to both `excludeExcludedLabels` & `excludeInvalidLabels`
- `Label\DBALReadRepository`: `ExcludedLabelsRepository` removed from `__construct`
-  `Label\DBALReadRepository`: excluded labels work via database Column instead of from `config`
- `Label\SchemaConfigurator`: Add `EXCLUDED_COLUMN `

### Fixed

- Code cleanup

---
Ticket: https://jira.uitdatabank.be/browse/III-5613
