### PR TITLE
III-5613: Hotfix save bool as 0

### DIFF
--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALWriteRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALWriteRepository.php
@@ -36,7 +36,7 @@ final class DBALWriteRepository extends AbstractDBALRepository implements WriteR
                 $visibility->sameAs(Visibility::VISIBLE()) ? 1 : 0,
                 $privacy->sameAs(Privacy::PRIVACY_PRIVATE()) ? 1 : 0,
                 $parentUuid ? $parentUuid->toString() : null,
-                false,
+                0,
             ]);
 
         $queryBuilder->execute();


### PR DESCRIPTION
### Fixed

-  Save 'excluded' as `0` instead of `false` when creating new labels.

---
Ticket: https://jira.uitdatabank.be/browse/III-5613
