### PR TITLE
III-5613 endpoint label exclusion

### DIFF
--- a/src/Http/Label/CommandType.php
+++ b/src/Http/Label/CommandType.php
@@ -15,6 +15,8 @@ class CommandType extends Enum
             'MakeInvisible',
             'MakePublic',
             'MakePrivate',
+            'Include',
+            'Exclude',
         ];
     }
 
@@ -36,5 +38,15 @@ class CommandType extends Enum
     public static function makePrivate(): self
     {
         return new CommandType('MakePrivate');
+    }
+
+    public static function include(): self
+    {
+        return new CommandType('Include');
+    }
+
+    public static function exclude(): self
+    {
+        return new CommandType('Exclude');
     }
 }

--- a/src/Http/Label/PatchLabelRequestHandler.php
+++ b/src/Http/Label/PatchLabelRequestHandler.php
@@ -8,6 +8,8 @@ use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\Label\Commands\ExcludeLabel;
+use CultuurNet\UDB3\Label\Commands\IncludeLabel;
 use CultuurNet\UDB3\Label\Commands\MakeInvisible;
 use CultuurNet\UDB3\Label\Commands\MakePrivate;
 use CultuurNet\UDB3\Label\Commands\MakePublic;
@@ -45,6 +47,12 @@ final class PatchLabelRequestHandler implements RequestHandlerInterface
                 break;
             case CommandType::makePrivate():
                 $this->commandBus->dispatch(new MakePrivate($labelId));
+                break;
+            case CommandType::include():
+                $this->commandBus->dispatch(new IncludeLabel($labelId));
+                break;
+            case CommandType::exclude():
+                $this->commandBus->dispatch(new ExcludeLabel($labelId));
                 break;
         }
 

--- a/tests/Http/Label/CommandTypeTest.php
+++ b/tests/Http/Label/CommandTypeTest.php
@@ -61,7 +61,7 @@ class CommandTypeTest extends TestCase
     /**
      * @test
      */
-    public function it_has_a_make_exclude_option()
+    public function it_has_a_exclude_option()
     {
         $commandType = CommandType::exclude();
 

--- a/tests/Http/Label/CommandTypeTest.php
+++ b/tests/Http/Label/CommandTypeTest.php
@@ -51,7 +51,27 @@ class CommandTypeTest extends TestCase
     /**
      * @test
      */
-    public function it_has_only_four_specified_options()
+    public function it_has_a_make_include_option()
+    {
+        $commandType = CommandType::include();
+
+        $this->assertEquals($commandType->toString(), 'Include');
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_make_exclude_option()
+    {
+        $commandType = CommandType::exclude();
+
+        $this->assertEquals($commandType->toString(), 'Exclude');
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_only_six_specified_options()
     {
         $options = CommandType::getAllowedValues();
 
@@ -61,6 +81,8 @@ class CommandTypeTest extends TestCase
                 CommandType::makeInvisible()->toString(),
                 CommandType::makePublic()->toString(),
                 CommandType::makePrivate()->toString(),
+                CommandType::include()->toString(),
+                CommandType::exclude()->toString(),
             ],
             $options
         );

--- a/tests/Http/Label/CommandTypeTest.php
+++ b/tests/Http/Label/CommandTypeTest.php
@@ -51,7 +51,7 @@ class CommandTypeTest extends TestCase
     /**
      * @test
      */
-    public function it_has_a_make_include_option()
+    public function it_has_an_include_option()
     {
         $commandType = CommandType::include();
 

--- a/tests/Http/Label/PatchLabelRequestHandlerTest.php
+++ b/tests/Http/Label/PatchLabelRequestHandlerTest.php
@@ -9,6 +9,8 @@ use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Label\Commands\AbstractCommand;
+use CultuurNet\UDB3\Label\Commands\ExcludeLabel;
+use CultuurNet\UDB3\Label\Commands\IncludeLabel;
 use CultuurNet\UDB3\Label\Commands\MakeInvisible;
 use CultuurNet\UDB3\Label\Commands\MakePrivate;
 use CultuurNet\UDB3\Label\Commands\MakePublic;
@@ -69,6 +71,14 @@ final class PatchLabelRequestHandlerTest extends TestCase
             'makePrivate' => [
                 'command' => CommandType::makePrivate(),
                 'expectedCommand' => new MakePrivate(new UUID('9714108c-dddc-4105-a736-2e32632999f4')),
+            ],
+            'include' => [
+                'command' => CommandType::include(),
+                'expectedCommand' => new IncludeLabel(new UUID('9714108c-dddc-4105-a736-2e32632999f4')),
+            ],
+            'exclude' => [
+                'command' => CommandType::exclude(),
+                'expectedCommand' => new ExcludeLabel(new UUID('9714108c-dddc-4105-a736-2e32632999f4')),
             ],
         ];
     }


### PR DESCRIPTION
### Changed

- `CommandType`: Added `Include` & `Exclude` to Enum
- `PatchLabelRequestHandler`: Added support to `Include` & `Exclude` Labels.
- Updated tests

---
Ticket: https://jira.uitdatabank.be/browse/III-5613
