### PR TITLE
III-5613 rename bulkexcludelabel

### DIFF
--- a/app/Console/Command/ExcludeLabelsFromConfig.php
+++ b/app/Console/Command/ExcludeLabelsFromConfig.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-final class BulkExcludeLabel extends AbstractCommand
+final class ExcludeLabelsFromConfig extends AbstractCommand
 {
     public function configure(): void
     {

--- a/app/Console/Command/ExcludeLabelsFromConfig.php
+++ b/app/Console/Command/ExcludeLabelsFromConfig.php
@@ -14,7 +14,7 @@ final class ExcludeLabelsFromConfig extends AbstractCommand
 {
     public function configure(): void
     {
-        $this->setName('label:bulk-exclude');
+        $this->setName('label:exclude-from-config');
         $this->setDescription('Excludes all labels in the config.excluded_labels file');
     }
 

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Console;
 
 use Broadway\EventHandling\EventBus;
-use CultuurNet\UDB3\Console\Command\BulkExcludeLabel;
+use CultuurNet\UDB3\Console\Command\ExcludeLabelsFromConfig;
 use CultuurNet\UDB3\Console\Command\ChangeOfferOwner;
 use CultuurNet\UDB3\Console\Command\ChangeOfferOwnerInBulk;
 use CultuurNet\UDB3\Console\Command\ChangeOrganizerOwner;
@@ -321,7 +321,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
 
         $container->addShared(
             'console.label:bulk-exclude',
-            fn () => new BulkExcludeLabel($container->get('event_command_bus'))
+            fn () => new ExcludeLabelsFromConfig($container->get('event_command_bus'))
         );
 
         $container->addShared(

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -74,8 +74,8 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         'console.offer:change-owner-bulk',
         'console.organizer:change-owner',
         'console.organizer:change-owner-bulk',
-        'console.label:bulk-exclude',
         'console.label:exclude',
+        'console.label:exclude-from-config',
         'console.label:include',
         'console.label:update-unique',
         'console.organizer:update-unique',
@@ -320,7 +320,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         );
 
         $container->addShared(
-            'console.label:bulk-exclude',
+            'console.label:exclude-from-config',
             fn () => new ExcludeLabelsFromConfig($container->get('event_command_bus'))
         );
 


### PR DESCRIPTION
### Changed

- Renamed  `BulkExcludeLabel ` to `ExcludeLabelsFromConfig`
- Changed commandName from `label:bulk-exclude` to `label:exclude-from-config`

---
Ticket: https://jira.uitdatabank.be/browse/III-5613
