### PR TITLE
Cleanup AMQP registration code

### DIFF
--- a/app/UiTPAS/UiTPASIncomingEventServicesProvider.php
+++ b/app/UiTPAS/UiTPASIncomingEventServicesProvider.php
@@ -54,13 +54,13 @@ final class UiTPASIncomingEventServicesProvider extends AbstractServiceProvider
                     LoggerFactory::create($container, LoggerName::forAmqpWorker('uitpas')),
                     $uitpasDeserializerLocator,
                     $container->get(EventBus::class),
-                    new StringLiteral($container->get('config')['amqp']['consumer_tag']),
+                    $container->get('config')['amqp']['consumer_tag'],
                     new UuidFactory()
                 );
 
                 $consumerConfig = $container->get('config')['amqp']['consumers']['uitpas'];
-                $exchange = new StringLiteral($consumerConfig['exchange']);
-                $queue = new StringLiteral($consumerConfig['queue']);
+                $exchange = $consumerConfig['exchange'];
+                $queue = $consumerConfig['queue'];
                 return $consumerFactory->create($exchange, $queue);
             }
         );

--- a/src/Broadway/AMQP/CommandBusForwardingConsumer.php
+++ b/src/Broadway/AMQP/CommandBusForwardingConsumer.php
@@ -8,7 +8,7 @@ use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Deserializer\DeserializerLocatorInterface;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 
-class CommandBusForwardingConsumer extends AbstractConsumer
+final class CommandBusForwardingConsumer extends AbstractConsumer
 {
     private CommandBus $commandBus;
 

--- a/src/Broadway/AMQP/CommandBusForwardingConsumer.php
+++ b/src/Broadway/AMQP/CommandBusForwardingConsumer.php
@@ -7,25 +7,18 @@ namespace CultuurNet\UDB3\Broadway\AMQP;
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Deserializer\DeserializerLocatorInterface;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
-use CultuurNet\UDB3\StringLiteral;
 
-/**
- * Forwards messages coming in via AMQP to an event bus.
- */
 class CommandBusForwardingConsumer extends AbstractConsumer
 {
-    /**
-     * @var CommandBus
-     */
-    private $commandBus;
+    private CommandBus $commandBus;
 
     public function __construct(
         AMQPStreamConnection $connection,
         CommandBus $commandBus,
         DeserializerLocatorInterface $deserializerLocator,
-        StringLiteral $consumerTag,
-        StringLiteral $exchangeName,
-        StringLiteral $queueName,
+        string $consumerTag,
+        string $exchangeName,
+        string $queueName,
         int $delay = 0
     ) {
         $this->commandBus = $commandBus;
@@ -40,7 +33,6 @@ class CommandBusForwardingConsumer extends AbstractConsumer
             'command bus'
         );
     }
-
 
     protected function handle($deserializedMessage, array $context)
     {

--- a/src/Broadway/AMQP/EventBusForwardingConsumer.php
+++ b/src/Broadway/AMQP/EventBusForwardingConsumer.php
@@ -12,17 +12,10 @@ use Broadway\EventHandling\EventBus;
 use CultuurNet\UDB3\Deserializer\DeserializerLocatorInterface;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use Ramsey\Uuid\UuidFactoryInterface;
-use CultuurNet\UDB3\StringLiteral;
 
-/**
- * Forwards messages coming in via AMQP to an event bus.
- */
 class EventBusForwardingConsumer extends AbstractConsumer
 {
-    /**
-     * @var EventBus
-     */
-    private $eventBus;
+    private EventBus $eventBus;
 
     private UuidFactoryInterface $uuidFactory;
 
@@ -30,9 +23,9 @@ class EventBusForwardingConsumer extends AbstractConsumer
         AMQPStreamConnection $connection,
         EventBus $eventBus,
         DeserializerLocatorInterface $deserializerLocator,
-        StringLiteral $consumerTag,
-        StringLiteral $exchangeName,
-        StringLiteral $queueName,
+        string $consumerTag,
+        string $exchangeName,
+        String $queueName,
         UuidFactoryInterface $uuidFactory,
         int $delay = 0
     ) {

--- a/src/Broadway/AMQP/EventBusForwardingConsumer.php
+++ b/src/Broadway/AMQP/EventBusForwardingConsumer.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Deserializer\DeserializerLocatorInterface;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use Ramsey\Uuid\UuidFactoryInterface;
 
-class EventBusForwardingConsumer extends AbstractConsumer
+final class EventBusForwardingConsumer extends AbstractConsumer
 {
     private EventBus $eventBus;
 

--- a/src/Broadway/AMQP/EventBusForwardingConsumerFactory.php
+++ b/src/Broadway/AMQP/EventBusForwardingConsumerFactory.php
@@ -10,7 +10,6 @@ use InvalidArgumentException;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidFactoryInterface;
-use CultuurNet\UDB3\StringLiteral;
 
 final class EventBusForwardingConsumerFactory
 {
@@ -30,7 +29,7 @@ final class EventBusForwardingConsumerFactory
 
     private EventBus $eventBus;
 
-    private StringLiteral $consumerTag;
+    private string $consumerTag;
 
     private UuidFactoryInterface $uuidFactory;
 
@@ -40,7 +39,7 @@ final class EventBusForwardingConsumerFactory
         LoggerInterface $logger,
         DeserializerLocatorInterface $deserializerLocator,
         EventBus $eventBus,
-        StringLiteral $consumerTag,
+        string $consumerTag,
         UuidFactoryInterface $uuidFactory
     ) {
         if ($executionDelay < 0) {
@@ -57,8 +56,8 @@ final class EventBusForwardingConsumerFactory
     }
 
     public function create(
-        StringLiteral $exchange,
-        StringLiteral $queue
+        string $exchange,
+        string $queue
     ): EventBusForwardingConsumer {
         $eventBusForwardingConsumer = new EventBusForwardingConsumer(
             $this->connection,

--- a/tests/Broadway/AMQP/CommandBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/CommandBusForwardingConsumerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use CultuurNet\UDB3\StringLiteral;
 
-class CommandBusForwardingConsumerTest extends TestCase
+final class CommandBusForwardingConsumerTest extends TestCase
 {
     /**
      * @var CommandBus|MockObject

--- a/tests/Broadway/AMQP/CommandBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/CommandBusForwardingConsumerTest.php
@@ -18,26 +18,6 @@ use CultuurNet\UDB3\StringLiteral;
 class CommandBusForwardingConsumerTest extends TestCase
 {
     /**
-     * @var AMQPStreamConnection|MockObject
-     */
-    private $connection;
-
-    /**
-     * @var StringLiteral
-     */
-    private $queueName;
-
-    /**
-     * @var StringLiteral
-     */
-    private $exchangeName;
-
-    /**
-     * @var StringLiteral
-     */
-    private $consumerTag;
-
-    /**
      * @var CommandBus|MockObject
      */
     private $commandBus;
@@ -54,20 +34,11 @@ class CommandBusForwardingConsumerTest extends TestCase
 
     /**
      * Seconds to delay the actual consumption of the message after it arrived.
-     *
-     * @var int
      */
-    private $delay;
+    private int $delay;
 
-    /**
-     * @var CommandBusForwardingConsumer
-     */
-    private $commandBusForwardingConsumer;
 
-    /**
-     * @var LoggerInterface|MockObject
-     */
-    private $logger;
+    private CommandBusForwardingConsumer $commandBusForwardingConsumer;
 
     /**
      * @var DeserializerInterface|MockObject
@@ -77,13 +48,13 @@ class CommandBusForwardingConsumerTest extends TestCase
 
     public function setUp(): void
     {
-        $this->connection = $this->createMock(AMQPStreamConnection::class);
+        $connection = $this->createMock(AMQPStreamConnection::class);
 
         $this->delay = 1;
 
-        $this->queueName = new StringLiteral('my-queue');
-        $this->exchangeName = new StringLiteral('my-exchange');
-        $this->consumerTag = new StringLiteral('my-tag');
+        $queueName = 'my-queue';
+        $exchangeName = 'my-exchange';
+        $consumerTag = 'my-tag';
         $this->commandBus = $this->createMock(CommandBus::class);
         $this->deserializerLocator = $this->createMock(DeserializerLocatorInterface::class);
         $this->channel = $this->getMockBuilder(AMQPChannel::class)
@@ -91,22 +62,22 @@ class CommandBusForwardingConsumerTest extends TestCase
             ->disableProxyingToOriginalMethods()
             ->getMock();
 
-        $this->connection->expects($this->any())
+        $connection->expects($this->any())
             ->method('channel')
             ->willReturn($this->channel);
 
         $this->commandBusForwardingConsumer = new CommandBusForwardingConsumer(
-            $this->connection,
+            $connection,
             $this->commandBus,
             $this->deserializerLocator,
-            $this->consumerTag,
-            $this->exchangeName,
-            $this->queueName,
+            $consumerTag,
+            $exchangeName,
+            $queueName,
             $this->delay
         );
 
-        $this->logger = $this->createMock(LoggerInterface::class);
-        $this->commandBusForwardingConsumer->setLogger($this->logger);
+        $logger = $this->createMock(LoggerInterface::class);
+        $this->commandBusForwardingConsumer->setLogger($logger);
 
         $this->deserializer = $this->createMock(DeserializerInterface::class);
     }
@@ -116,9 +87,6 @@ class CommandBusForwardingConsumerTest extends TestCase
      */
     public function it_can_dispatch_the_message_on_the_command_bus()
     {
-        $context = [];
-        $context['correlation_id'] = 'my-correlation-id-123';
-
         $expectedCommand = new \stdClass();
         $expectedCommand->foo = 'bar';
 

--- a/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
@@ -26,11 +26,11 @@ final class EventBusForwardingConsumerTest extends TestCase
      */
     private $connection;
 
-    private StringLiteral $queueName;
+    private string $queueName;
 
-    private StringLiteral $exchangeName;
+    private string $exchangeName;
 
-    private StringLiteral $consumerTag;
+    private string $consumerTag;
 
     /**
      * @var EventBus|MockObject
@@ -46,11 +46,6 @@ final class EventBusForwardingConsumerTest extends TestCase
      * @var AMQPChannel|MockObject
      */
     private $channel;
-
-    /**
-     * Seconds to delay the actual consumption of the message after it arrived.
-     */
-    private int $delay;
 
     private EventBusForwardingConsumer $eventBusForwardingConsumer;
 
@@ -69,11 +64,11 @@ final class EventBusForwardingConsumerTest extends TestCase
     {
         $this->connection = $this->createMock(AMQPStreamConnection::class);
 
-        $this->delay = 1;
+        $delay = 1;
 
-        $this->queueName = new StringLiteral('my-queue');
-        $this->exchangeName = new StringLiteral('my-exchange');
-        $this->consumerTag = new StringLiteral('my-tag');
+        $this->queueName = 'my-queue';
+        $this->exchangeName = 'my-exchange';
+        $this->consumerTag = 'my-tag';
         $this->eventBus = $this->createMock(EventBus::class);
         $this->deserializerLocator = $this->createMock(DeserializerLocatorInterface::class);
         $this->channel = $this->getMockBuilder(AMQPChannel::class)
@@ -93,7 +88,7 @@ final class EventBusForwardingConsumerTest extends TestCase
             $this->exchangeName,
             $this->queueName,
             new UuidFactory(),
-            $this->delay
+            $delay
         );
 
         $this->logger = $this->createMock(LoggerInterface::class);
@@ -231,9 +226,6 @@ final class EventBusForwardingConsumerTest extends TestCase
      */
     public function it_rejects_the_massage_when_an_error_occurs(): void
     {
-        $context = [];
-        $context['correlation_id'] = new StringLiteral('my-correlation-id-123');
-
         $this->deserializerLocator->expects($this->once())
             ->method('getDeserializerForContentType')
             ->with(new StringLiteral('application/vnd.cultuurnet.udb3-events.dummy-event+json'))


### PR DESCRIPTION
### Changed
- Replaced usages of `StringLiteral` with `string`
- Used local variables where possible
- Removed unused local variables

### Note
- There is only one big commit but the review should be straightforward file by file

---
Ticket: https://jira.uitdatabank.be/browse/III-5630
