### PR TITLE
III-5670 regex with whitespace

### DIFF
--- a/app/Console/Command/ExcludeInvalidLabels.php
+++ b/app/Console/Command/ExcludeInvalidLabels.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Console\Command;
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Label\Commands\ExcludeLabel as ExcludeLabelCommand;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use Doctrine\DBAL\Connection;
 use PDO;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -16,8 +17,6 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 final class ExcludeInvalidLabels extends AbstractCommand
 {
-    private const LABEL_REGEX = '/^[a-zA-Z\d_\- ]{2,50}$/';
-
     private const MAX_RESULTS = 500;
     private Connection $connection;
 
@@ -53,7 +52,7 @@ final class ExcludeInvalidLabels extends AbstractCommand
                 $labelId = new Uuid($label['uuid_col']);
                 $labelName = $label['name'];
 
-                if (!preg_match(self::LABEL_REGEX, $labelName)) {
+                if (!preg_match(LabelName::REGEX, $labelName)) {
                     $this->commandBus->dispatch(
                         new ExcludeLabelCommand($labelId)
                     );

--- a/app/Console/Command/ExcludeInvalidLabels.php
+++ b/app/Console/Command/ExcludeInvalidLabels.php
@@ -52,7 +52,7 @@ final class ExcludeInvalidLabels extends AbstractCommand
                 $labelId = new Uuid($label['uuid_col']);
                 $labelName = $label['name'];
 
-                if (!preg_match(LabelName::REGEX, $labelName)) {
+                if (!preg_match(LabelName::REGEX_SUGGESTIONS, $labelName)) {
                     $this->commandBus->dispatch(
                         new ExcludeLabelCommand($labelId)
                     );

--- a/app/Console/Command/ExcludeInvalidLabels.php
+++ b/app/Console/Command/ExcludeInvalidLabels.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 final class ExcludeInvalidLabels extends AbstractCommand
 {
-    private const LABEL_REGEX = '/^[a-zA-Z\d_\-]{2,50}$/';
+    private const LABEL_REGEX = '/^[a-zA-Z\d_\- ]{2,50}$/';
 
     private const MAX_RESULTS = 500;
     private Connection $connection;

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Label\ReadModels\Roles\Doctrine\SchemaConfigurator as LabelR
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine\SchemaConfigurator as PermissionsSchemaConfigurator;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
@@ -148,7 +149,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
             );
 
         if ($query->isSuggestion()) {
-            $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\- ]{2,50}$\'');
+            $queryBuilder->andWhere('name REGEXP \'' . str_replace('/', '', LabelName::REGEX)  . '\'');
 
             $excludedLabels = $this->excludedLabelsRepository->getAll();
             if (!empty($excludedLabels)) {

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -149,7 +149,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
             );
 
         if ($query->isSuggestion()) {
-            $queryBuilder->andWhere('name REGEXP \'' . str_replace('/', '', LabelName::REGEX)  . '\'');
+            $queryBuilder->andWhere('name REGEXP \'' . str_replace('/', '', LabelName::REGEX) . '\'');
 
             $excludedLabels = $this->excludedLabelsRepository->getAll();
             if (!empty($excludedLabels)) {

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -148,7 +148,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
             );
 
         if ($query->isSuggestion()) {
-            $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\-]{2,50}$\'');
+            $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\- ]{2,50}$\'');
 
             $excludedLabels = $this->excludedLabelsRepository->getAll();
             if (!empty($excludedLabels)) {

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -149,7 +149,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
             );
 
         if ($query->isSuggestion()) {
-            $queryBuilder->andWhere('name REGEXP \'' . str_replace('/', '', LabelName::REGEX) . '\'');
+            $queryBuilder->andWhere('name REGEXP \'' . str_replace('/', '', LabelName::REGEX_SUGGESTIONS) . '\'');
 
             $excludedLabels = $this->excludedLabelsRepository->getAll();
             if (!empty($excludedLabels)) {

--- a/src/Model/ValueObject/Taxonomy/Label/LabelName.php
+++ b/src/Model/ValueObject/Taxonomy/Label/LabelName.php
@@ -16,7 +16,7 @@ final class LabelName
 
     public const LEGACY_REGEX = '/^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$/';
 
-    public const REGEX = '/^(?![-_ ])(?=.{2,50}$)(?=.*\S.*\S.*)[^;,\#\'!&]*$/';
+    public const REGEX = '/^(?![_ \-])(?!.*[_ \-]$)[a-zA-ZÀ-ÿ\d_ \-]{2,50}$/';
 
     public function __construct(string $value)
     {

--- a/src/Model/ValueObject/Taxonomy/Label/LabelName.php
+++ b/src/Model/ValueObject/Taxonomy/Label/LabelName.php
@@ -16,7 +16,7 @@ class LabelName
 
     public const LEGACY_REGEX = '/^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$/';
 
-    public const REGEX = '/^(?=[^\s\-_;&.,#\'"]{2,50}$)(?=.*\S.*\S.*)[^;.&,\'#"\'\s]*$/';
+    public const REGEX = '/^(?![-_ ])(?=.{2,50}$)(?=.*\S.*\S.*)[^;,\#\'!&]*$/';
 
     /**
      * @param string $value

--- a/src/Model/ValueObject/Taxonomy/Label/LabelName.php
+++ b/src/Model/ValueObject/Taxonomy/Label/LabelName.php
@@ -16,7 +16,7 @@ final class LabelName
 
     public const LEGACY_REGEX = '/^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$/';
 
-    public const REGEX = '/^(?![_ \-])(?!.*[_ \-]$)[a-zA-ZÀ-ÿ\d_ \-]{2,50}$/';
+    public const REGEX_SUGGESTIONS = '/^(?![_ \-])(?!.*[_ \-]$)[a-zA-ZÀ-ÿ\d_ \-]{2,50}$/';
 
     public function __construct(string $value)
     {

--- a/src/Model/ValueObject/Taxonomy/Label/LabelName.php
+++ b/src/Model/ValueObject/Taxonomy/Label/LabelName.php
@@ -16,7 +16,7 @@ class LabelName
 
     public const LEGACY_REGEX = '/^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$/';
 
-
+    public const REGEX = '/^(?=[^\s\-_;&.,#\'"]{2,50}$)(?=.*\S.*\S.*)[^;.&,\'#"\'\s]*$/';
 
     /**
      * @param string $value

--- a/src/Model/ValueObject/Taxonomy/Label/LabelName.php
+++ b/src/Model/ValueObject/Taxonomy/Label/LabelName.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\IsString;
 use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\MatchesRegexPattern;
 use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\Trims;
 
-class LabelName
+final class LabelName
 {
     use IsString;
     use Trims;
@@ -18,10 +18,7 @@ class LabelName
 
     public const REGEX = '/^(?![-_ ])(?=.{2,50}$)(?=.*\S.*\S.*)[^;,\#\'!&]*$/';
 
-    /**
-     * @param string $value
-     */
-    public function __construct($value)
+    public function __construct(string $value)
     {
         $value = $this->trim($value);
 

--- a/src/Model/ValueObject/Taxonomy/Label/LabelName.php
+++ b/src/Model/ValueObject/Taxonomy/Label/LabelName.php
@@ -14,7 +14,9 @@ class LabelName
     use Trims;
     use MatchesRegexPattern;
 
-    public const REGEX = '/^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$/';
+    public const LEGACY_REGEX = '/^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$/';
+
+
 
     /**
      * @param string $value
@@ -23,7 +25,7 @@ class LabelName
     {
         $value = $this->trim($value);
 
-        $this->guardRegexPattern(self::REGEX, $value);
+        $this->guardRegexPattern(self::LEGACY_REGEX, $value);
 
         $this->setValue($value);
     }

--- a/src/Model/ValueObject/Taxonomy/Label/LabelName.php
+++ b/src/Model/ValueObject/Taxonomy/Label/LabelName.php
@@ -14,7 +14,7 @@ final class LabelName
     use Trims;
     use MatchesRegexPattern;
 
-    public const LEGACY_REGEX = '/^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$/';
+    public const REGEX = '/^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$/';
 
     public const REGEX_SUGGESTIONS = '/^(?![_ \-])(?!.*[_ \-]$)[a-zA-ZÀ-ÿ\d_ \-]{2,50}$/';
 
@@ -22,7 +22,7 @@ final class LabelName
     {
         $value = $this->trim($value);
 
-        $this->guardRegexPattern(self::LEGACY_REGEX, $value);
+        $this->guardRegexPattern(self::REGEX, $value);
 
         $this->setValue($value);
     }

--- a/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
+++ b/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
@@ -16,7 +16,7 @@ class LabelNameTest extends TestCase
     {
         $this->assertEquals(
             $matchesLegacyRegex,
-            preg_match(LabelName::LEGACY_REGEX, $labelName)
+            preg_match(LabelName::REGEX, $labelName)
         );
     }
 
@@ -182,7 +182,7 @@ class LabelNameTest extends TestCase
     public function it_does_not_support_semi_colons(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('String \'foo;bar\' does not match regex pattern ' . LabelName::LEGACY_REGEX . '.');
+        $this->expectExceptionMessage('String \'foo;bar\' does not match regex pattern ' . LabelName::REGEX . '.');
         new LabelName('foo;bar');
     }
 
@@ -192,7 +192,7 @@ class LabelNameTest extends TestCase
     public function it_requires_labels_of_at_least_2_characters(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('String \'f\' does not match regex pattern ' . LabelName::LEGACY_REGEX . '.');
+        $this->expectExceptionMessage('String \'f\' does not match regex pattern ' . LabelName::REGEX . '.');
         new LabelName('f');
     }
 
@@ -213,7 +213,7 @@ class LabelNameTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'String \'' . $longLabel . '\' does not match regex pattern ' . LabelName::LEGACY_REGEX . '.'
+            'String \'' . $longLabel . '\' does not match regex pattern ' . LabelName::REGEX . '.'
         );
         new LabelName($longLabel);
     }
@@ -226,7 +226,7 @@ class LabelNameTest extends TestCase
         $newLineLabel = "New\nWave";
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'String \'' . $newLineLabel . '\' does not match regex pattern ' . LabelName::LEGACY_REGEX . '.'
+            'String \'' . $newLineLabel . '\' does not match regex pattern ' . LabelName::REGEX . '.'
         );
         new LabelName($newLineLabel);
     }

--- a/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
+++ b/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
@@ -12,10 +12,10 @@ class LabelNameTest extends TestCase
      * @test
      * @dataProvider labelNameDataProvider
      */
-    public function validateLegacyRegex(string $labelName, bool $matchesLegacyRegex): void
+    public function validateRegex(string $labelName, bool $matchesRegex): void
     {
         $this->assertEquals(
-            $matchesLegacyRegex,
+            $matchesRegex,
             preg_match(LabelName::REGEX, $labelName)
         );
     }
@@ -24,10 +24,10 @@ class LabelNameTest extends TestCase
      * @test
      * @dataProvider labelNameDataProvider
      */
-    public function validateRegex(string $labelName, bool $matchesLegacyRegex, bool $matchesRegex): void
+    public function validateSuggestionsRegex(string $labelName, bool $matchesRegex, bool $matchesSuggestionsRegex): void
     {
         $this->assertEquals(
-            $matchesRegex,
+            $matchesSuggestionsRegex,
             preg_match(LabelName::REGEX_SUGGESTIONS, $labelName)
         );
     }
@@ -37,123 +37,123 @@ class LabelNameTest extends TestCase
         return [
             [
                 'labelName' => ';',
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => 'a',
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => '',
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => '   ',
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => ' a',
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => 'a ',
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => 'a;a',
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => str_repeat('abcde', 51) . 'f',
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => 'aa',
-                'matchesLegacyRegex' => true,
                 'matchesRegex' => true,
+                'matchesSuggestionsRegex' => true,
             ],
             [
                 'labelName' => ' aa ',
-                'matchesLegacyRegex' => true,
-                'matchesRegex' => false,
+                'matchesRegex' => true,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => '--',
-                'matchesLegacyRegex' => true,
-                'matchesRegex' => false,
+                'matchesRegex' => true,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => "\r\n",
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => "A\n",
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => "Hard\r\nRock",
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => "\r\nTechno",
-                'matchesLegacyRegex' => false,
                 'matchesRegex' => false,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => '#Hashtag',
-                'matchesLegacyRegex' => true,
-                'matchesRegex' => false,
+                'matchesRegex' => true,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => 'Europese Thema\'s',
-                'matchesLegacyRegex' => true,
-                'matchesRegex' => false,
+                'matchesRegex' => true,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => 'Yin & Yang',
-                'matchesLegacyRegex' => true,
-                'matchesRegex' => false,
+                'matchesRegex' => true,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => '-MyLabel',
-                'matchesLegacyRegex' => true,
-                'matchesRegex' => false,
+                'matchesRegex' => true,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => '_MyLabel',
-                'matchesLegacyRegex' => true,
-                'matchesRegex' => false,
+                'matchesRegex' => true,
+                'matchesSuggestionsRegex' => false,
             ],
             [
                 'labelName' => 'My-Label',
-                'matchesLegacyRegex' => true,
                 'matchesRegex' => true,
+                'matchesSuggestionsRegex' => true,
             ],
             [
                 'labelName' => 'My_Label',
-                'matchesLegacyRegex' => true,
                 'matchesRegex' => true,
+                'matchesSuggestionsRegex' => true,
             ],
             [
                 'labelName' => 'één taalicoon',
-                'matchesLegacyRegex' => true,
                 'matchesRegex' => true,
+                'matchesSuggestionsRegex' => true,
             ],
             [
                 'labelName' => 'Feest!',
-                'matchesLegacyRegex' => true,
-                'matchesRegex' => false,
+                'matchesRegex' => true,
+                'matchesSuggestionsRegex' => false,
             ],
         ];
     }

--- a/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
+++ b/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
@@ -155,11 +155,6 @@ class LabelNameTest extends TestCase
                 'matchesLegacyRegex' => true,
                 'matchesRegex' => false,
             ],
-            [
-                'labelName' => 'Waar is iedereen-fuif!',
-                'matchesLegacyRegex' => true,
-                'matchesRegex' => false,
-            ],
         ];
     }
 

--- a/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
+++ b/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
@@ -28,7 +28,7 @@ class LabelNameTest extends TestCase
     {
         $this->assertEquals(
             $matchesRegex,
-            preg_match(LabelName::REGEX, $labelName)
+            preg_match(LabelName::REGEX_SUGGESTIONS, $labelName)
         );
     }
 

--- a/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
+++ b/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
@@ -10,78 +10,155 @@ class LabelNameTest extends TestCase
 {
     /**
      * @test
-     * @dataProvider legacyLabelNameDataProvider
+     * @dataProvider labelNameDataProvider
      */
-    public function validateLegacyRegex(string $labelName, bool $valid): void
+    public function validateLegacyRegex(string $labelName, bool $matchesLegacyRegex): void
     {
         $this->assertEquals(
-            $valid,
+            $matchesLegacyRegex,
             preg_match(LabelName::LEGACY_REGEX, $labelName)
         );
     }
 
-    public function legacyLabelNameDataProvider(): array
+    /**
+     * @test
+     * @dataProvider labelNameDataProvider
+     */
+    public function validateRegex(string $labelName, bool $matchesLegacyRegex, bool $matchesRegex): void
+    {
+        $this->assertEquals(
+            $matchesRegex,
+            preg_match(LabelName::REGEX, $labelName)
+        );
+    }
+
+    public function labelNameDataProvider(): array
     {
         return [
             [
-                ';',
-                false,
+                'labelName' => ';',
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                'a',
-                false,
+                'labelName' => 'a',
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                '',
-                false,
+                'labelName' => '',
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                '   ',
-                false,
+                'labelName' => '   ',
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                ' a',
-                false,
+                'labelName' => ' a',
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                'a ',
-                false,
+                'labelName' => 'a ',
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                'a;a',
-                false,
+                'labelName' => 'a;a',
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                str_repeat('abcde', 51) . 'f',
-                false,
+                'labelName' => str_repeat('abcde', 51) . 'f',
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                'aa',
-                true,
+                'labelName' => 'aa',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => true,
             ],
             [
-                ' aa ',
-                true,
+                'labelName' => ' aa ',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => false,
             ],
             [
-                '--',
-                true,
+                'labelName' => '--',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => false,
             ],
             [
-                "\r\n",
-                false,
+                'labelName' => "\r\n",
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                "A\n",
-                false,
+                'labelName' => "A\n",
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                "Hard\r\nRock",
-                false,
+                'labelName' => "Hard\r\nRock",
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
             ],
             [
-                "\r\nTechno",
-                false,
+                'labelName' => "\r\nTechno",
+                'matchesLegacyRegex' => false,
+                'matchesRegex' => false,
+            ],
+            [
+                'labelName' => '#Hashtag',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => false,
+            ],
+            [
+                'labelName' => 'Europese Thema\'s',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => false,
+            ],
+            [
+                'labelName' => 'Yin & Yang',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => false,
+            ],
+            [
+                'labelName' => '-MyLabel',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => false,
+            ],
+            [
+                'labelName' => '_MyLabel',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => false,
+            ],
+            [
+                'labelName' => 'My-Label',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => true,
+            ],
+            [
+                'labelName' => 'My_Label',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => true,
+            ],
+            [
+                'labelName' => 'één taalicoon',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => true,
+            ],
+            [
+                'labelName' => 'Feest!',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => false,
+            ],
+            [
+                'labelName' => 'Waar is iedereen-fuif!',
+                'matchesLegacyRegex' => true,
+                'matchesRegex' => false,
             ],
         ];
     }
@@ -110,7 +187,7 @@ class LabelNameTest extends TestCase
     public function it_does_not_support_semi_colons(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('String \'foo;bar\' does not match regex pattern ' . LabelName::REGEX . '.');
+        $this->expectExceptionMessage('String \'foo;bar\' does not match regex pattern ' . LabelName::LEGACY_REGEX . '.');
         new LabelName('foo;bar');
     }
 
@@ -120,7 +197,7 @@ class LabelNameTest extends TestCase
     public function it_requires_labels_of_at_least_2_characters(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('String \'f\' does not match regex pattern ' . LabelName::REGEX . '.');
+        $this->expectExceptionMessage('String \'f\' does not match regex pattern ' . LabelName::LEGACY_REGEX . '.');
         new LabelName('f');
     }
 
@@ -141,7 +218,7 @@ class LabelNameTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'String \'' . $longLabel . '\' does not match regex pattern ' . LabelName::REGEX . '.'
+            'String \'' . $longLabel . '\' does not match regex pattern ' . LabelName::LEGACY_REGEX . '.'
         );
         new LabelName($longLabel);
     }
@@ -154,7 +231,7 @@ class LabelNameTest extends TestCase
         $newLineLabel = "New\nWave";
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'String \'' . $newLineLabel . '\' does not match regex pattern ' . LabelName::REGEX . '.'
+            'String \'' . $newLineLabel . '\' does not match regex pattern ' . LabelName::LEGACY_REGEX . '.'
         );
         new LabelName($newLineLabel);
     }

--- a/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
+++ b/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
@@ -10,17 +10,17 @@ class LabelNameTest extends TestCase
 {
     /**
      * @test
-     * @dataProvider labelNameDataProvider
+     * @dataProvider legacyLabelNameDataProvider
      */
-    public function validateRegex(string $labelName, bool $valid): void
+    public function validateLegacyRegex(string $labelName, bool $valid): void
     {
         $this->assertEquals(
             $valid,
-            preg_match(LabelName::REGEX, $labelName)
+            preg_match(LabelName::LEGACY_REGEX, $labelName)
         );
     }
 
-    public function labelNameDataProvider(): array
+    public function legacyLabelNameDataProvider(): array
     {
         return [
             [


### PR DESCRIPTION
### Added

- `LabelName`: Added new `REGEX` to improve uniformity.


### Changed

- `LabelName`: introduced new  `SUGGESTIONS_REGEX`
- `ExcludeInvalidLabels`: Use new `SUGGESTIONS_REGEX` from `LabelName` instead of a seperate one
- `DBALReadRepository`: Use new `SUGGESTIONS_REGEX`  from `LabelName` when querying database
- `LabelNameTest`: Added new scenario's for validating with existing `REGEX` & new `SUGGESTIONS_REGEX`

### Fixed

- Do not exclude `Labels` with whitespaces from the database search.
- Code Cleanup in `LabelName`

---
Ticket: https://jira.uitdatabank.be/browse/III-5670
