### PR TITLE
III-5556 productionId property in camelCase

### DIFF
--- a/src/Http/Productions/SearchProductionsRequestHandler.php
+++ b/src/Http/Productions/SearchProductionsRequestHandler.php
@@ -60,7 +60,8 @@ final class SearchProductionsRequestHandler implements RequestHandlerInterface
     {
         return [
             'name' => $production->getName(),
-            'production_id' => $production->getProductionId()->toNative(),
+            'production_id' => $production->getProductionId()->toNative(), // Legacy property, kept to avoid breaking changes
+            'productionId' => $production->getProductionId()->toNative(),
             'events' => $production->getEventIds(),
         ];
     }

--- a/tests/Http/Productions/SearchProductionsRequestHandlerTest.php
+++ b/tests/Http/Productions/SearchProductionsRequestHandlerTest.php
@@ -125,6 +125,7 @@ final class SearchProductionsRequestHandlerTest extends TestCase
                 'member' => [
                     [
                         'production_id' => $productionId->toNative(),
+                        'productionId' => $productionId->toNative(),
                         'name' => $name,
                         'events' => $events,
                     ],


### PR DESCRIPTION
### Added
- Added a property `productionId` in camelCase in `SearchProductionsRequestHandler`

### Changed

- Added a warning comment to the legacy snake_case `production_id` in `SearchProductionsRequestHandler`
- Updated test for `SearchProductionsRequestHandler`

---
Ticket: https://jira.uitdatabank.be/browse/III-5556
