### PR TITLE
use old regex cause mysql isn't compatible

### DIFF
--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -149,7 +149,8 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
             );
 
         if ($query->isSuggestion()) {
-            $queryBuilder->andWhere('name REGEXP \'' . str_replace('/', '', LabelName::REGEX_SUGGESTIONS) . '\'');
+            // LabelName::REGEX_SUGGESTIONS is incompatible with MySQL used on acc, test, prod
+            $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\-]{2,50}$\'');
 
             $excludedLabels = $this->excludedLabelsRepository->getAll();
             if (!empty($excludedLabels)) {


### PR DESCRIPTION
### Fixed

- Go back to old Regex in `DBALReadRepository` because older MySQL version is not compatible.

---
Ticket: https://jira.uitdatabank.be/browse/III-5670
