### PR TITLE
III-5685 Refactored `AbstractDBALRepository` to use `string`

### DIFF
--- a/app/Labels/LabelServiceProvider.php
+++ b/app/Labels/LabelServiceProvider.php
@@ -40,7 +40,6 @@ use CultuurNet\UDB3\Label\ReadModels\Roles\Doctrine\LabelRolesWriteRepository;
 use CultuurNet\UDB3\Label\ReadModels\Roles\LabelRolesProjector;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
 use CultuurNet\UDB3\Role\UserPermissionsServiceProvider;
-use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\User\CurrentUser;
 use League\Container\Container;
 use Monolog\Handler\StreamHandler;
@@ -190,7 +189,7 @@ final class LabelServiceProvider extends AbstractServiceProvider
             function () use ($container): RelationsWriteRepository {
                 return new RelationsWriteRepository(
                     $container->get('dbal_connection'),
-                    new StringLiteral(self::RELATIONS_TABLE)
+                    self::RELATIONS_TABLE
                 );
             }
         );
@@ -200,7 +199,7 @@ final class LabelServiceProvider extends AbstractServiceProvider
             function () use ($container): RelationsReadRepository {
                 return new RelationsReadRepository(
                     $container->get('dbal_connection'),
-                    new StringLiteral(self::RELATIONS_TABLE)
+                    self::RELATIONS_TABLE
                 );
             }
         );

--- a/src/Event/Productions/DBALProductionRepository.php
+++ b/src/Event/Productions/DBALProductionRepository.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use CultuurNet\UDB3\StringLiteral;
 
 class DBALProductionRepository extends AbstractDBALRepository implements ProductionRepository
 {
@@ -17,7 +16,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
 
     public function __construct(Connection $connection)
     {
-        parent::__construct($connection, new StringLiteral(self::TABLE_NAME));
+        parent::__construct($connection, self::TABLE_NAME);
     }
 
     public function add(Production $production): void
@@ -57,7 +56,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
     {
         $addedAt = Chronos::now();
         $this->getConnection()->insert(
-            $this->getTableName()->toNative(),
+            $this->getTableName(),
             [
                 'event_id' => $eventId,
                 'production_id' => $production->getProductionId()->toNative(),
@@ -70,7 +69,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
     public function removeEvent(string $eventId, ProductionId $productionId): void
     {
         $this->getConnection()->delete(
-            $this->getTableName()->toNative(),
+            $this->getTableName(),
             [
                 'event_id' => $eventId,
                 'production_id' => $productionId->toNative(),
@@ -82,7 +81,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
     {
         $addedAt = Chronos::now();
         $this->getConnection()->update(
-            $this->getTableName()->toNative(),
+            $this->getTableName(),
             [
                 'production_id' => $to->getProductionId()->toNative(),
                 'name' => $to->getName(),
@@ -97,7 +96,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
     public function renameProduction(ProductionId $productionId, string $name): void
     {
         $this->getConnection()->update(
-            $this->getTableName()->toNative(),
+            $this->getTableName(),
             [
                 'name' => $name,
             ],
@@ -119,7 +118,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
 
         $query = $this->getConnection()->createQueryBuilder()
             ->select('p1.production_id, p1.name, p1.event_id')
-            ->from($this->getTableName()->toNative(), 'p1')
+            ->from($this->getTableName(), 'p1')
             ->innerJoin('p1', sprintf('(%s)', $subQuery->getSQL()), 'p2', 'p1.production_id = p2.production_id');
 
         if (!empty($keyword)) {
@@ -162,7 +161,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
     {
         $query = $this->getConnection()->createQueryBuilder()
             ->select('DISTINCT production_id')
-            ->from($this->getTableName()->toNative());
+            ->from($this->getTableName());
 
         if (!empty($keyword)) {
             $query = $query->where('MATCH(name) AGAINST(:keyword IN BOOLEAN MODE)')

--- a/src/Event/Productions/SimilarEventsRepository.php
+++ b/src/Event/Productions/SimilarEventsRepository.php
@@ -6,19 +6,18 @@ namespace CultuurNet\UDB3\Event\Productions;
 
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
-use CultuurNet\UDB3\StringLiteral;
 
 final class SimilarEventsRepository extends AbstractDBALRepository
 {
     public function __construct(Connection $connection)
     {
-        parent::__construct($connection, new StringLiteral('similar_events'));
+        parent::__construct($connection, 'similar_events');
     }
 
     public function add(Suggestion $suggestion): void
     {
         $this->getConnection()->insert(
-            $this->getTableName()->toNative(),
+            $this->getTableName(),
             [
                 'similarity' => $suggestion->getSimilarity(),
                 'event1' => $suggestion->getEventOne(),
@@ -47,7 +46,7 @@ final class SimilarEventsRepository extends AbstractDBALRepository
 
         $query = $this->getConnection()->createQueryBuilder()
             ->select('se.similarity, se.event1, se.event2, p1.production_id as production1, p2.production_id as production2')
-            ->from($this->getTableName()->toNative(), 'se')
+            ->from($this->getTableName(), 'se')
             ->leftJoin('se', DBALProductionRepository::TABLE_NAME, 'p1', 'p1.event_id = se.event1')
             ->leftJoin('se', DBALProductionRepository::TABLE_NAME, 'p2', 'p2.event_id = se.event2')
             ->where('(p1.production_id IS NULL OR p2.production_id IS NULL OR p1.production_id != p2.production_id)')

--- a/src/Event/Productions/SkippedSimilarEventsRepository.php
+++ b/src/Event/Productions/SkippedSimilarEventsRepository.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Event\Productions;
 
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
-use CultuurNet\UDB3\StringLiteral;
 
 class SkippedSimilarEventsRepository extends AbstractDBALRepository
 {
@@ -14,13 +13,13 @@ class SkippedSimilarEventsRepository extends AbstractDBALRepository
 
     public function __construct(Connection $connection)
     {
-        parent::__construct($connection, new StringLiteral('similar_events_skipped'));
+        parent::__construct($connection, 'similar_events_skipped');
     }
 
     public function add(SimilarEventPair $eventPair): void
     {
         $this->getConnection()->insert(
-            $this->getTableName()->toNative(),
+            $this->getTableName(),
             [
                 'event1' => $eventPair->getEventOne(),
                 'event2' => $eventPair->getEventTwo(),

--- a/src/Label/ReadModels/Doctrine/AbstractDBALRepository.php
+++ b/src/Label/ReadModels/Doctrine/AbstractDBALRepository.php
@@ -6,17 +6,16 @@ namespace CultuurNet\UDB3\Label\ReadModels\Doctrine;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractDBALRepository
 {
     private Connection $connection;
 
-    private StringLiteral $tableName;
+    private string $tableName;
 
     public function __construct(
         Connection $connection,
-        StringLiteral $tableName
+        string $tableName
     ) {
         $this->connection = $connection;
         $this->tableName = $tableName;
@@ -27,7 +26,7 @@ abstract class AbstractDBALRepository
         return $this->connection;
     }
 
-    public function getTableName(): StringLiteral
+    public function getTableName(): string
     {
         return $this->tableName;
     }

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -16,7 +16,6 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine\SchemaConfigurator as PermissionsSchemaConfigurator;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use CultuurNet\UDB3\StringLiteral;
 
 final class DBALReadRepository extends AbstractDBALRepository implements ReadRepositoryInterface
 {
@@ -33,7 +32,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
         string $userRolesTableName,
         ExcludedLabelsRepository $excludedLabelsRepository
     ) {
-        parent::__construct($connection, new StringLiteral($tableName));
+        parent::__construct($connection, $tableName);
 
         $this->labelRolesTableName = $labelRolesTableName;
         $this->userRolesTableName = $userRolesTableName;
@@ -46,7 +45,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
         $whereId = SchemaConfigurator::UUID_COLUMN . ' = ?';
 
         $queryBuilder = $this->createQueryBuilder()->select($aliases)
-            ->from($this->getTableName()->toNative())
+            ->from($this->getTableName())
             ->where($whereId)
             ->setParameters([$uuid->toString()]);
 
@@ -63,7 +62,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
         );
 
         $queryBuilder = $queryBuilder->select($aliases)
-            ->from($this->getTableName()->toNative())
+            ->from($this->getTableName())
             ->where($likeCondition)
             ->setParameter(
                 SchemaConfigurator::NAME_COLUMN,
@@ -140,7 +139,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
         $queryBuilder = $this->createQueryBuilder();
         $like = $this->createLike($queryBuilder);
 
-        $queryBuilder->from($this->getTableName()->toNative())
+        $queryBuilder->from($this->getTableName())
             ->where($like)
             ->setParameter(
                 SchemaConfigurator::NAME_COLUMN,

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALWriteRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALWriteRepository.php
@@ -9,16 +9,9 @@ use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\WriteRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use CultuurNet\UDB3\StringLiteral;
-use Doctrine\DBAL\Connection;
 
 final class DBALWriteRepository extends AbstractDBALRepository implements WriteRepositoryInterface
 {
-    public function __construct(Connection $connection, string $tableName)
-    {
-        parent::__construct($connection, new StringLiteral($tableName));
-    }
-
     public function save(
         UUID $uuid,
         string $name,
@@ -26,7 +19,7 @@ final class DBALWriteRepository extends AbstractDBALRepository implements WriteR
         Privacy $privacy
     ): void {
         $queryBuilder = $this->createQueryBuilder()
-            ->insert($this->getTableName()->toNative())
+            ->insert($this->getTableName())
             ->values([
                 SchemaConfigurator::UUID_COLUMN => '?',
                 SchemaConfigurator::NAME_COLUMN => '?',
@@ -107,7 +100,7 @@ final class DBALWriteRepository extends AbstractDBALRepository implements WriteR
         UUID $uuid
     ): void {
         $queryBuilder = $this->createQueryBuilder()
-            ->update($this->getTableName()->toNative())
+            ->update($this->getTableName())
             ->set($column, '?')
             ->where(SchemaConfigurator::UUID_COLUMN . ' = ?')
             ->setParameters([

--- a/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
@@ -17,7 +17,7 @@ class DBALReadRepository extends AbstractDBALRepository implements ReadRepositor
         $whereLabelName = SchemaConfigurator::LABEL_NAME . ' = ?';
 
         $queryBuilder = $this->createQueryBuilder()->select($aliases)
-            ->from($this->getTableName()->toNative())
+            ->from($this->getTableName())
             ->where($whereLabelName)
             ->setParameters([$labelName]);
 
@@ -34,7 +34,7 @@ class DBALReadRepository extends AbstractDBALRepository implements ReadRepositor
         $whereLabelName = SchemaConfigurator::LABEL_NAME . ' = ?';
 
         return $this->createQueryBuilder()->select(SchemaConfigurator::RELATION_ID)
-            ->from($this->getTableName()->toNative())
+            ->from($this->getTableName())
             ->where($whereLabelName)
             ->andWhere(SchemaConfigurator::RELATION_TYPE . ' = ?')
             ->setParameters([$labelName, $relationType->toString()])
@@ -47,7 +47,7 @@ class DBALReadRepository extends AbstractDBALRepository implements ReadRepositor
         $whereRelationId = SchemaConfigurator::RELATION_ID . ' = ?';
 
         $queryBuilder = $this->createQueryBuilder()->select($aliases)
-            ->from($this->getTableName()->toNative())
+            ->from($this->getTableName())
             ->where($whereRelationId)
             ->setParameters(
                 [

--- a/src/Offer/ReadModel/Metadata/OfferMetadataRepository.php
+++ b/src/Offer/ReadModel/Metadata/OfferMetadataRepository.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Offer\ReadModel\Metadata;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
-use CultuurNet\UDB3\StringLiteral;
 
 class OfferMetadataRepository extends AbstractDBALRepository
 {
@@ -15,7 +14,7 @@ class OfferMetadataRepository extends AbstractDBALRepository
 
     public function __construct(Connection $connection)
     {
-        parent::__construct($connection, new StringLiteral(self::TABLE));
+        parent::__construct($connection, self::TABLE);
     }
 
     public function get(string $offerId)

--- a/tests/Event/Productions/SkippedSimilarEventsRepositoryTest.php
+++ b/tests/Event/Productions/SkippedSimilarEventsRepositoryTest.php
@@ -14,10 +14,7 @@ class SkippedSimilarEventsRepositoryTest extends TestCase
 {
     use DBALTestConnectionTrait;
 
-    /**
-     * @var SkippedSimilarEventsRepository
-     */
-    private $repository;
+    private SkippedSimilarEventsRepository $repository;
 
     protected function setUp(): void
     {
@@ -43,7 +40,7 @@ class SkippedSimilarEventsRepositoryTest extends TestCase
 
     private function assertSkippedSimilarEventExists(string $event1, string $event2): void
     {
-        $table = $this->repository->getTableName()->toNative();
+        $table = $this->repository->getTableName();
         $sql = "SELECT * FROM $table WHERE event1 = :event1 AND event2 = :event2";
         $result = $this->getConnection()->executeQuery(
             $sql,

--- a/tests/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepositoryTest.php
+++ b/tests/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepositoryTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Label\ReadModels\Relations\Repository\Doctrine;
 
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\LabelRelation;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
-use CultuurNet\UDB3\StringLiteral;
 
 class DBALReadRepositoryTest extends BaseDBALRepositoryTest
 {
@@ -24,7 +23,7 @@ class DBALReadRepositoryTest extends BaseDBALRepositoryTest
 
         $this->readRepository = new DBALReadRepository(
             $this->getConnection(),
-            new StringLiteral($this->getTableName())
+            $this->getTableName()
         );
 
         $this->saveOfferLabelRelations();

--- a/tests/Label/ReadModels/Relations/Repository/Doctrine/DBALWriteRepositoryTest.php
+++ b/tests/Label/ReadModels/Relations/Repository/Doctrine/DBALWriteRepositoryTest.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Label\ReadModels\Relations\Repository\Doctrine;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\LabelRelation;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use CultuurNet\UDB3\StringLiteral;
 
 class DBALWriteRepositoryTest extends BaseDBALRepositoryTest
 {
@@ -19,7 +18,7 @@ class DBALWriteRepositoryTest extends BaseDBALRepositoryTest
 
         $this->dbalWriteRepository = new DBALWriteRepository(
             $this->getConnection(),
-            new StringLiteral($this->getTableName())
+            $this->getTableName()
         );
     }
 

--- a/tests/Place/Canonical/CanonicalServiceTest.php
+++ b/tests/Place/Canonical/CanonicalServiceTest.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\Doctrine\DBALReadRepos
 use CultuurNet\UDB3\Place\Canonical\Exception\MuseumPassNotUniqueInCluster;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
-use CultuurNet\UDB3\StringLiteral;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
@@ -209,7 +208,7 @@ class CanonicalServiceTest extends TestCase
             ),
             new DBALReadRepository(
                 $this->getConnection(),
-                new StringLiteral('labels_relations')
+                'labels_relations'
             ),
             $documentRepository
         );


### PR DESCRIPTION
### Changed
- Refactored `AbstractDBALRepository` to use `string` 

### Note
- The abstract class `AbstractDBALRepository` is also used in other namespaces so the PR crosses the boundaries of the `Label` namespace

---
Ticket: https://jira.uitdatabank.be/browse/III-5685
