### PR TITLE
III-5670 add excluded to db query

### DIFF
--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -150,6 +150,9 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
             // LabelName::REGEX_SUGGESTIONS is incompatible with MySQL used on acc, test, prod
             $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\-]{2,50}$\'');
 
+            $queryBuilder->andWhere(SchemaConfigurator::EXCLUDED_COLUMN . ' = :excluded')
+                ->setParameter(':excluded', 0);
+
             $excludedLabels = $this->excludedLabelsRepository->getAll();
             if (!empty($excludedLabels)) {
                 $queryBuilder->andWhere(

--- a/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepositoryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepositoryTest.php
@@ -316,6 +316,22 @@ final class DBALReadRepositoryTest extends BaseDBALRepositoryTest
     /**
      * @test
      */
+    public function it_does_not_filter_excluded_labels_if_suggestions_is_false(): void
+    {
+        $search = new Query(
+            'excluded',
+            null,
+            null,
+            null,
+            false
+        );
+        $entities = $this->dbalReadRepository->search($search);
+        $this->assertEquals('excluded', $entities[0]->getName());
+    }
+
+    /**
+     * @test
+     */
     public function it_can_get_total_items_of_search(): void
     {
         $search = new Query('lab');


### PR DESCRIPTION
### Added

- `Label\DBALReadRepository`: filter `Labels` if `excluded` is true in `database`
- `DBALReadRepositoryTest`: Added test to check if `excluded` `Labels` are shown if `suggestions` is set to false (note: an opposite test is not possible until `regexp` is removed, because the UnitTests use `sqlite`).

---
Ticket: https://jira.uitdatabank.be/browse/III-5670
