### PR TITLE
III-5648 Port curator features

### DIFF
--- a/features/Bootstrap/FeatureContext.php
+++ b/features/Bootstrap/FeatureContext.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\State\RequestState;
 use CultuurNet\UDB3\State\ResponseState;
 use CultuurNet\UDB3\State\VariableState;
 use CultuurNet\UDB3\Steps\AuthorizationSteps;
+use CultuurNet\UDB3\Steps\CuratorSteps;
 use CultuurNet\UDB3\Steps\EventSteps;
 use CultuurNet\UDB3\Steps\LabelSteps;
 use CultuurNet\UDB3\Steps\OrganizerSteps;
@@ -25,6 +26,7 @@ final class FeatureContext implements Context
     use ResponseSteps;
     use UtilitySteps;
 
+    use CuratorSteps;
     use EventSteps;
     use OrganizerSteps;
     use PlaceSteps;

--- a/features/Steps/AuthorizationSteps.php
+++ b/features/Steps/AuthorizationSteps.php
@@ -47,4 +47,12 @@ trait AuthorizationSteps
     {
         $this->requestState->setJwt('');
     }
+
+    /**
+     * @Given I am not using an UiTID v1 API key
+     */
+    public function iAmNotUsingAnUitidV1ApiKey(): void
+    {
+        $this->requestState->setApiKey('');
+    }
 }

--- a/features/Steps/CuratorSteps.php
+++ b/features/Steps/CuratorSteps.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Steps;
+
+use CultuurNet\UDB3\Json;
+
+trait CuratorSteps
+{
+    /**
+     * @Given I create a news article and save the id as :variableName
+     */
+    public function iCreateANewsArticleAndSaveTheIdAs(string $variableName): void
+    {
+        $this->iCreateARandomNameOfCharacters(12);
+
+        $article = [
+            'headline' => 'Curator API migrated',
+            'inLanguage' => 'nl',
+            'text' => 'Op 6 december 2021 besloot publiq om de curator API te migreren.',
+            'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
+            'publisher' => 'BILL',
+            'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+            'url' => 'https://www.publiq.be/blog/%{name}'
+        ];
+
+        $response = $this->getHttpClient()->postJSON(
+            $this->requestState->getBaseUrl() . '/news-articles/',
+            $this->variableState->replaceVariables(Json::encode($article))
+        );
+        $this->responseState->setResponse($response);
+
+        $this->theResponseStatusShouldBe(201);
+        $this->theResponseBodyShouldBeValidJson();
+        $this->iKeepTheValueOfTheJsonResponseAtAs('id', $variableName);
+    }
+}

--- a/features/Steps/CuratorSteps.php
+++ b/features/Steps/CuratorSteps.php
@@ -22,7 +22,7 @@ trait CuratorSteps
             'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
             'publisher' => 'BILL',
             'publisherLogo' => 'https://www.bill.be/img/favicon.png',
-            'url' => 'https://www.publiq.be/blog/%{name}'
+            'url' => 'https://www.publiq.be/blog/%{name}',
         ];
 
         $response = $this->getHttpClient()->postJSON(

--- a/features/Steps/RequestSteps.php
+++ b/features/Steps/RequestSteps.php
@@ -19,6 +19,14 @@ trait RequestSteps
     }
 
     /**
+     * @Given I accept :type
+     */
+    public function IAccept(string $type): void
+    {
+        $this->requestState->setAcceptHeader($type);
+    }
+
+    /**
      * @Given I set the JSON request payload from :fileName
      */
     public function iSetTheJsonRequestPayloadFrom(string $fileName): void

--- a/features/curator/create.feature
+++ b/features/curator/create.feature
@@ -1,0 +1,329 @@
+Feature: Test the curator API
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I send and accept "application/json"
+    And I create a random name of 12 characters
+
+  Scenario: Create a news article
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}"
+    }
+    """
+    When I send a POST request to "/news-articles"
+    Then the response status should be "201"
+    And the response body should be valid JSON
+    And I keep the value of the JSON response at "id" as "articleId"
+    When I send a GET request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the JSON response should be:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}",
+      "id": "%{articleId}"
+    }
+    """
+
+  Scenario: Create a news article with an image
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}",
+      "image": {
+        "url": "https://www.uitinvlaanderen.be/img.png",
+        "copyrightHolder": "publiq vzw"
+      }
+    }
+    """
+    When I send a POST request to "/news-articles"
+    Then the response status should be "201"
+    And the response body should be valid JSON
+    And I keep the value of the JSON response at "id" as "articleId"
+    When I send a GET request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the JSON response should be:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}",
+      "image": {
+        "url": "https://www.uitinvlaanderen.be/img.png",
+        "copyrightHolder": "publiq vzw"
+      },
+      "id": "%{articleId}"
+    }
+    """
+
+  Scenario: Create a news article with url that should have been encoded
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/caf%C3%A9/%{name}"
+    }
+    """
+    When I send a POST request to "/news-articles"
+    Then the response status should be "201"
+    And the response body should be valid JSON
+    And I keep the value of the JSON response at "id" as "articleId"
+    And the JSON response should be:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/caf%C3%A9/%{name}",
+      "id": "%{articleId}"
+    }
+    """
+    And I keep the value of the JSON response at "id" as "articleId"
+
+    When I send a GET request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the JSON response at "url" should be "https://www.publiq.be/blog/caf%%C3%%A9/%{name}"
+
+  Scenario: Create a news article with an existing url and about
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}"
+    }
+    """
+    When I send a POST request to "/news-articles"
+    Then the response status should be "201"
+    And the response body should be valid JSON
+    And I keep the value of the JSON response at "id" as "articleId"
+    When I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award (again!)",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}"
+    }
+    """
+    And I send a POST request to "/news-articles"
+    Then the response status should be "400"
+    And the JSON response should be:
+    """
+    {
+      "type": "https://api.publiq.be/probs/body/invalid-data",
+      "title": "Invalid body data",
+      "status": 400,
+      "detail": "A news article with the given url and about already exists. (%{articleId}) Do a GET /news-articles request with `url` and `about` parameters to find it programmatically."
+    }
+    """
+
+  Scenario: Try to create a news article with missing properties
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}"
+    }
+    """
+    When I send a POST request to "/news-articles"
+    Then the response status should be "400"
+    And the JSON response should be:
+    """
+    {
+      "schemaErrors": [
+        {
+          "error": "The required properties (inLanguage, publisher) are missing",
+          "jsonPointer": "/"
+        }
+      ],
+      "status": 400,
+      "title": "Invalid body data",
+      "type": "https://api.publiq.be/probs/body/invalid-data"
+    }
+    """
+
+  Scenario: Try to create a news article with an image without copyrightHolder
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}",
+      "image": {
+        "url": "https://www.uitinvlaanderen.be/img.png"
+      }
+    }
+    """
+    When I send a POST request to "/news-articles"
+    Then the response status should be "400"
+    And the JSON response should be:
+    """
+    {
+      "schemaErrors": [
+        {
+          "error": "The required properties (copyrightHolder) are missing",
+          "jsonPointer": "/image"
+        }
+      ],
+      "status": 400,
+      "title": "Invalid body data",
+      "type": "https://api.publiq.be/probs/body/invalid-data"
+    }
+    """
+
+  Scenario: Try to create a news article with an image with an invalid image url
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}",
+      "image": {
+        "url": "https://www.uitinvlaanderen.be/img.pdf",
+        "copyrightHolder": "Publiq vzw"
+      }
+    }
+    """
+    When I send a POST request to "/news-articles"
+    Then the response status should be "400"
+    And the JSON response should be:
+    """
+    {
+      "schemaErrors": [
+        {
+          "error": "The string should match pattern: ^http(s?):([/|.|\\w|\\s|-])*\\.(?:jpeg|jpeg|gif|png)$",
+          "jsonPointer": "/image/url"
+        }
+      ],
+      "status": 400,
+      "title": "Invalid body data",
+      "type": "https://api.publiq.be/probs/body/invalid-data"
+    }
+    """
+
+  Scenario: Applies label on about event
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I send and accept "application/json"
+
+    Given I set the JSON request payload from "places/place.json"
+    When I send a POST request to "/places/"
+    Then the response status should be "201"
+    And I keep the value of the JSON response at "placeId" as "uuid_place"
+    And I set the JSON request payload from "events/legacy/event-with-referenced-location.json"
+    When I send a POST request to "/events/"
+    Then the response status should be "201"
+    And the response body should be valid JSON
+    And I keep the value of the JSON response at "eventId" as "uuid_testevent"
+
+    Given I am not using an UiTID v1 API key
+    And I am not authorized
+    When I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "%{uuid_testevent}",
+      "publisher": "BRUZZ",
+      "publisherLogo": "https://www.bruzz.be/img/favicon.png",
+      "url": "https://www.bruzz.be/blog/%{name}"
+    }
+    """
+    And I send a POST request to "/news-articles"
+    Then the response status should be "201"
+
+    Given I am using the UDB3 base URL
+    When I send a GET request to "/events/%{uuid_testevent}"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response at "hiddenLabels" should be:
+    """
+    [
+      "BRUZZ-redactioneel"
+    ]
+    """
+
+  Scenario: Create a news article via the old underscored path
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award (UNDERSCORED)",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}"
+    }
+    """
+    When I send a POST request to "/news_articles"
+    Then the response status should be "201"
+    And the response body should be valid JSON
+    And I keep the value of the JSON response at "id" as "articleIdUnderscored"
+    When I send a GET request to "/news_articles/%{articleIdUnderscored}"
+    Then the response status should be "200"
+    And the JSON response should be:
+    """
+    {
+      "headline": "publiq wint API award (UNDERSCORED)",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}",
+      "id": "%{articleIdUnderscored}"
+    }
+    """

--- a/features/curator/delete.feature
+++ b/features/curator/delete.feature
@@ -1,0 +1,13 @@
+Feature: Test the curator API
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I send and accept "application/json"
+    And I create a news article and save the id as "articleId"
+
+  Scenario: Delete an article
+    Given I send and accept "application/json"
+    When I send a DELETE request to "/news-articles/%{articleId}"
+    Then the response status should be "204"
+    When I send a GET request to "/news-articles/%{articleId}"
+    Then the response status should be "404"

--- a/features/curator/get.feature
+++ b/features/curator/get.feature
@@ -1,0 +1,107 @@
+Feature: Test the curator API
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I send and accept "application/json"
+    And I create a news article and save the id as "articleId"
+
+  Scenario: Get an article
+    When I send a GET request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response at "headline" should be "Curator API migrated"
+
+  Scenario: Get an article via the old underscored path
+    When I send a GET request to "/news_articles/%{articleId}"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response at "headline" should be "Curator API migrated"
+
+  Scenario: Get an non-existing article article
+    When I send a GET request to "/news-articles/18827e56-3666-4961-a5c8-7acd5dcfed9a"
+    Then the response status should be "404"
+    And the response body should be valid JSON
+    And the JSON response should be:
+    """
+    {
+     "type": "https://api.publiq.be/probs/url/not-found",
+     "title": "Not Found",
+     "status": 404,
+     "detail": "The News Article with id \"18827e56-3666-4961-a5c8-7acd5dcfed9a\" was not found."
+    }
+    """
+
+  Scenario: Get an non-existing article article via the old underscored path
+    When I send a GET request to "/news_articles/18827e56-3666-4961-a5c8-7acd5dcfed9a"
+    Then the response status should be "404"
+    And the response body should be valid JSON
+    And the JSON response should be:
+    """
+    {
+     "type": "https://api.publiq.be/probs/url/not-found",
+     "title": "Not Found",
+     "status": 404,
+     "detail": "The News Article with id \"18827e56-3666-4961-a5c8-7acd5dcfed9a\" was not found."
+    }
+    """
+
+  Scenario: Get all articles in linked data
+    Given I accept "application/ld+json"
+    When I send a GET request to "/news-articles"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response should have "hydra:member"
+
+  Scenario: Get all articles
+    Given I accept "application/json"
+    When I send a GET request to "/news-articles"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response should not have "hydra:member"
+
+  Scenario: Get all articles via the old underscored path in linked data
+    Given I accept "application/ld+json"
+    When I send a GET request to "/news_articles"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response should have "hydra:member"
+
+  Scenario: Get all articles via the old underscored path
+    Given I accept "application/json"
+    When I send a GET request to "/news_articles"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response should not have "hydra:member"
+
+  Scenario: Get articles past last result in linked data
+    Given I accept "application/ld+json"
+    When I send a GET request to "/news-articles?page=1000000"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response should be:
+    """
+    {
+      "hydra:member": [
+      ]
+    }
+    """
+
+  Scenario: Get articles past last result
+    Given I accept "application/json"
+    When I send a GET request to "/news-articles?page=1000000"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response should be:
+    """
+    []
+    """
+
+  Scenario: Search an article
+    When I send a GET request to "/news-articles?publisher=BILL&about=17284745-7bcf-461a-aad0-d3ad54880e75&url=https://www.publiq.be/blog/curator-migratie"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+
+  Scenario: Search an article via the old underscored path
+    When I send a GET request to "/news_articles?publisher=BILL&about=17284745-7bcf-461a-aad0-d3ad54880e75&url=https://www.publiq.be/blog/curator-migratie"
+    Then the response status should be "200"
+    And the response body should be valid JSON

--- a/features/curator/update.feature
+++ b/features/curator/update.feature
@@ -1,0 +1,244 @@
+Feature: Test the curator API
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I send and accept "application/json"
+    And I create a news article and save the id as "articleId"
+    And I create a random name of 12 characters
+
+  Scenario: Update a news article
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint opnieuw API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/%{name}"
+    }
+    """
+    When I send a PUT request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response should be:
+    """
+    {
+      "headline": "publiq wint opnieuw API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/%{name}",
+      "id": "%{articleId}"
+    }
+    """
+    And I keep the value of the JSON response at "id" as "articleId"
+    When I send a GET request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the JSON response at "headline" should be "publiq wint opnieuw API award"
+
+  Scenario: Update a news article with an image
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint opnieuw API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/%{name}",
+      "image": {
+        "url": "https://www.buzz.be/img.png",
+        "copyrightHolder": "Buzz"
+      }
+    }
+    """
+    When I send a PUT request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response should be:
+    """
+    {
+      "headline": "publiq wint opnieuw API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/%{name}",
+      "image": {
+        "url": "https://www.buzz.be/img.png",
+        "copyrightHolder": "Buzz"
+      },
+      "id": "%{articleId}"
+    }
+    """
+    And I keep the value of the JSON response at "id" as "articleId"
+    When I send a GET request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the JSON response at "image" should be:
+    """
+    {
+      "copyrightHolder": "Buzz",
+      "url": "https://www.buzz.be/img.png"
+    }
+    """
+
+  Scenario: Update a news article with an url that should have been encoded
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint opnieuw API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/caf%C3%A9/%{name}"
+    }
+    """
+    When I send a PUT request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response should be:
+    """
+    {
+      "headline": "publiq wint opnieuw API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/café/%{name}",
+      "id": "%{articleId}"
+    }
+    """
+    And I keep the value of the JSON response at "id" as "articleId"
+
+    When I send a GET request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the JSON response at "headline" should be "publiq wint opnieuw API award"
+    And the JSON response at "url" should be "https://www.buzz.be/blog/caf%%C3%%A9/%{name}"
+
+  Scenario: Update a non-existing news article
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint opnieuw API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/%{name}"
+    }
+    """
+    When I send a PUT request to "/news-articles/18827e56-3666-4961-a5c8-7acd5dcfed9a"
+    Then the response status should be "404"
+
+  Scenario: Update a news article via the old underscored path
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint opnieuw API award (UPDATED)",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/%{name}"
+    }
+    """
+    When I send a PUT request to "/news_articles/%{articleId}"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response should be:
+    """
+    {
+      "headline": "publiq wint opnieuw API award (UPDATED)",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/%{name}",
+      "id": "%{articleId}"
+    }
+    """
+    And I keep the value of the JSON response at "id" as "articleId"
+    When I send a GET request to "/news_articles/%{articleId}"
+    Then the response status should be "200"
+    And the JSON response at "headline" should be "publiq wint opnieuw API award (UPDATED)"
+
+  Scenario: Try to update a news article with an image without copyright
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint opnieuw API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/%{name}",
+      "image": {
+        "url": "https://www.buzz.be/pic.jpeg"
+      }
+    }
+    """
+    When I send a PUT request to "/news-articles/%{articleId}"
+    Then the response status should be "400"
+    And the response body should be valid JSON
+    And the JSON response should be:
+    """
+    {
+      "schemaErrors": [
+        {
+          "error": "The required properties (copyrightHolder) are missing",
+          "jsonPointer": "/image"
+        }
+      ],
+      "status": 400,
+      "title": "Invalid body data",
+      "type": "https://api.publiq.be/probs/body/invalid-data"
+    }
+    """
+
+  Scenario: Try to update a news article with an invalid image url
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint opnieuw API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BUZZ",
+      "publisherLogo": "https://www.buzz.be/img/favicon.png",
+      "url": "https://www.buzz.be/blog/%{name}",
+      "image": {
+        "url": "https://www.buzz.be/pic.mp4",
+        "copyrightHolder": "Buzz"
+      }
+    }
+    """
+    When I send a PUT request to "/news-articles/%{articleId}"
+    Then the response status should be "400"
+    And the response body should be valid JSON
+    And the JSON response should be:
+    """
+    {
+      "schemaErrors": [
+        {
+          "error": "The string should match pattern: ^http(s?):([/|.|\\w|\\s|-])*\\.(?:jpeg|jpeg|gif|png)$",
+          "jsonPointer": "/image/url"
+        }
+      ],
+      "status": 400,
+      "title": "Invalid body data",
+      "type": "https://api.publiq.be/probs/body/invalid-data"
+    }
+    """

--- a/features/data/events/legacy/event-with-referenced-location.json
+++ b/features/data/events/legacy/event-with-referenced-location.json
@@ -1,0 +1,30 @@
+{
+  "mainLanguage": "nl",
+  "name": "name example",
+  "type": {
+    "id": "0.50.4.0.0",
+    "label": "Concert",
+    "domain": "eventtype"
+  },
+  "theme": {
+    "id": "1.8.2.0.0",
+    "label": "Jazz en blues",
+    "domain": "theme"
+  },
+  "location": {
+    "id": "%{uuid_place}"
+  },
+  "calendar": {
+    "calendarType": "multiple",
+    "timeSpans": [
+      {
+        "start": "2020-05-05T18:00:00.000Z",
+        "end": "2020-05-05T21:00:00.000Z"
+      },
+      {
+        "start": "2020-05-12T18:00:00.000Z",
+        "end": "2020-05-12T21:00:00.000Z"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Added
- Added acceptance tests for Curator

### Note
- Two tests are failing that check the encoding of a URL. I was not able to fix them in a short timeframe but I also did not exclude them with `@wip`

---
Ticket: https://jira.uitdatabank.be/browse/III-5648
