### PR TITLE
III-5683 case insensitive label check

### DIFF
--- a/src/Label/ReadModels/JSON/Repository/AppConfigReadRepositoryDecorator.php
+++ b/src/Label/ReadModels/JSON/Repository/AppConfigReadRepositoryDecorator.php
@@ -48,7 +48,7 @@ final class AppConfigReadRepositoryDecorator implements ReadRepositoryInterface
         }
 
         $labels = $config['labels'] ?? [];
-        return in_array($name, $labels);
+        return in_array(strtolower($name), array_map('strtolower', $labels));
     }
 
     public function search(Query $query): array

--- a/tests/Label/ReadModels/JSON/Repository/AppConfigReadRepositoryDecoratorTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/AppConfigReadRepositoryDecoratorTest.php
@@ -134,7 +134,7 @@ final class AppConfigReadRepositoryDecoratorTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_true_if_the_decorator_returns_false_but_the_client_has_the_label_in_a_different_case_in_the_config(): void
+    public function it_returns_true_if_the__client_has_the_label_in_a_different_case_in_the_config(): void
     {
         $userId = 'clientWithLabels@clients';
         $label = 'PRIVATElABEL';

--- a/tests/Label/ReadModels/JSON/Repository/AppConfigReadRepositoryDecoratorTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/AppConfigReadRepositoryDecoratorTest.php
@@ -130,4 +130,21 @@ final class AppConfigReadRepositoryDecoratorTest extends TestCase
         $canUseLabel = $this->appConfigReadRepositoryDecorator->canUseLabel($userId, $label);
         $this->assertTrue($canUseLabel);
     }
+
+    /**
+     * @test
+     */
+    public function it_returns_true_if_the_decorator_returns_false_but_the_client_has_the_label_in_a_different_case_in_the_config(): void
+    {
+        $userId = 'clientWithLabels@clients';
+        $label = 'PRIVATElABEL';
+
+        $this->decoratee->expects($this->once())
+            ->method('canUseLabel')
+            ->with($userId, $label)
+            ->willReturn(false);
+
+        $canUseLabel = $this->appConfigReadRepositoryDecorator->canUseLabel($userId, $label);
+        $this->assertTrue($canUseLabel);
+    }
 }


### PR DESCRIPTION
### Changed

- `AppConfigReadRepositoryDecorator`: make `canUseLabel()` case-insensitive

---
Ticket: https://jira.uitdatabank.be/browse/IIII-5683
