### PR TITLE
III-5712 update uri regex for hashtag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-uitdatabank/III-5712-regex-uri",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/III-5712-regex-uri",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "628a4618271beeb37402e319d4d21bd5",
+    "content-hash": "c09dd645f4b24c8e7346ceeacceefd87",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5629,7 +5629,7 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-uitdatabank/III-5712-regex-uri",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
@@ -5641,6 +5641,7 @@
                 "reference": "6500a28d398881f08c37fe4c2bae439feb811e09",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5655,7 +5656,7 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5712-regex-uri"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
             "time": "2023-07-04T11:21:16+00:00"
         },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c09dd645f4b24c8e7346ceeacceefd87",
+    "content-hash": "628a4618271beeb37402e319d4d21bd5",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5629,19 +5629,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/III-5712-regex-uri",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "e633d58408ac68db21411ac1d7b2dfcd5164f1b1"
+                "reference": "58aa9884e7fd4825c10b8fffb54017e5e613650f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/e633d58408ac68db21411ac1d7b2dfcd5164f1b1",
-                "reference": "e633d58408ac68db21411ac1d7b2dfcd5164f1b1",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/58aa9884e7fd4825c10b8fffb54017e5e613650f",
+                "reference": "58aa9884e7fd4825c10b8fffb54017e5e613650f",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5656,9 +5655,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5712-regex-uri"
             },
-            "time": "2023-04-27T12:04:10+00:00"
+            "time": "2023-07-03T11:38:51+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -5633,12 +5633,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "58aa9884e7fd4825c10b8fffb54017e5e613650f"
+                "reference": "6500a28d398881f08c37fe4c2bae439feb811e09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/58aa9884e7fd4825c10b8fffb54017e5e613650f",
-                "reference": "58aa9884e7fd4825c10b8fffb54017e5e613650f",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/6500a28d398881f08c37fe4c2bae439feb811e09",
+                "reference": "6500a28d398881f08c37fe4c2bae439feb811e09",
                 "shasum": ""
             },
             "type": "library",
@@ -5657,7 +5657,7 @@
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
                 "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-5712-regex-uri"
             },
-            "time": "2023-07-03T11:38:51+00:00"
+            "time": "2023-07-04T11:21:16+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/features/event/attendance-mode.feature
+++ b/features/event/attendance-mode.feature
@@ -454,7 +454,7 @@ Feature: Test event attendanceMode property
     {
       "schemaErrors": [
         {
-          "error": "The string should match pattern: ^http[s]?:\\/\\/\\w",
+          "error": "The string should match pattern: ^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
           "jsonPointer": "/onlineUrl"
         }
       ],

--- a/features/event/booking-info.feature
+++ b/features/event/booking-info.feature
@@ -248,7 +248,7 @@ Feature: Test the UDB3 events API
       "status":400,
       "schemaErrors": [
         {
-          "error": "The string should match pattern: ^http[s]?:\\/\\/\\w",
+          "error": "The string should match pattern: ^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
           "jsonPointer": "/url"
         }
       ]

--- a/features/organizer/url.feature
+++ b/features/organizer/url.feature
@@ -78,7 +78,7 @@ Feature: Test organizer url property
      "status": 400,
      "schemaErrors": [
         {
-          "error": "The string should match pattern: ^http[s]?:\\/\\/\\w",
+          "error": "The string should match pattern: ^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
           "jsonPointer": "/url"
         }
       ]

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -3028,7 +3028,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/onlineUrl',
-                'The string should match pattern: ^http[s]?:\/\/\w'
+                'The string should match pattern: ^https?:\/\/[\w\-\.]+\.\w{2,}(\/.*)?$'
             ),
         ];
 

--- a/tests/Http/Event/UpdateOnlineUrlRequestHandlerTest.php
+++ b/tests/Http/Event/UpdateOnlineUrlRequestHandlerTest.php
@@ -94,7 +94,7 @@ final class UpdateOnlineUrlRequestHandlerTest extends TestCase
                 [
                     'onlineUrl' => 'rtp://www.publiq.be/livestream',
                 ],
-                new SchemaError('/onlineUrl', 'The string should match pattern: ^http[s]?:\/\/\w'),
+                new SchemaError('/onlineUrl', 'The string should match pattern: ^https?:\/\/[\w\-\.]+\.\w{2,}(\/.*)?$'),
             ],
         ];
     }

--- a/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
@@ -179,7 +179,7 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
             'schemaErrors' => [
                 new SchemaError(
                     '/url',
-                    'The string should match pattern: ^http[s]?:\/\/\w'
+                    'The string should match pattern: ^https?:\/\/[\w\-\.]+\.\w{2,}(\/.*)?$'
                 ),
             ],
         ];

--- a/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
@@ -54,6 +54,7 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
      */
     public function it_handles_updating_the_booking_info_of_an_offer(
         string $offerType,
+        string $url,
         AbstractUpdateBookingInfo $updateBookingInfo
     ): void {
         $updateBookingInfoRequest = $this->psr7RequestBuilder
@@ -62,7 +63,7 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
             ->withJsonBodyFromArray(
                 [
                     'bookingInfo' => [
-                        'url' => 'https://www.publiq.be/',
+                        'url' => $url,
                         'urlLabel' => ['nl' => 'Publiq vzw'],
                         'phone' => '02/1232323',
                         'email' => 'info@publiq.be',
@@ -90,8 +91,20 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
 
     public function offerTypeDataProvider(): array
     {
-        $bookingInfo = new BookingInfo(
-            'https://www.publiq.be/',
+        $basicUrl = 'https://www.publiq.be/';
+        $specialCharactersUrl = 'https://publiq-vzw.com/Inschrijven.aspx?ReservatieCat=2#/inschrijven/activiteiten';
+
+        $bookingInfoBasicUrl = new BookingInfo(
+            $basicUrl,
+            new MultilingualString(new Language('nl'), new StringLiteral('Publiq vzw')),
+            '02/1232323',
+            'info@publiq.be',
+            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2023-01-01T00:00:00+01:00'),
+            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2028-01-31T23:59:59+01:00')
+        );
+
+        $bookingInfoSpecialCharactersUrl = new BookingInfo(
+            $specialCharactersUrl,
             new MultilingualString(new Language('nl'), new StringLiteral('Publiq vzw')),
             '02/1232323',
             'info@publiq.be',
@@ -102,16 +115,34 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
         return [
             [
                 'offerType' => 'events',
+                'url' => $basicUrl,
                 'updateBookingInfo' => new EventUpdateBookingInfo(
                     self::OFFER_ID,
-                    $bookingInfo
+                    $bookingInfoBasicUrl
                 ),
             ],
             [
                 'offerType' => 'places',
+                'url' => $basicUrl,
                 'updateBookingInfo' => new PlaceUpdateBookingInfo(
                     self::OFFER_ID,
-                    $bookingInfo
+                    $bookingInfoBasicUrl
+                ),
+            ],
+            [
+                'offerType' => 'events',
+                'url' => $specialCharactersUrl,
+                'updateBookingInfo' => new EventUpdateBookingInfo(
+                    self::OFFER_ID,
+                    $bookingInfoSpecialCharactersUrl
+                ),
+            ],
+            [
+                'offerType' => 'places',
+                'url' => $specialCharactersUrl,
+                'updateBookingInfo' => new PlaceUpdateBookingInfo(
+                    self::OFFER_ID,
+                    $bookingInfoSpecialCharactersUrl
                 ),
             ],
         ];

--- a/tests/Http/Organizer/UpdateContactPointRequestHandlerTest.php
+++ b/tests/Http/Organizer/UpdateContactPointRequestHandlerTest.php
@@ -216,7 +216,7 @@ final class UpdateContactPointRequestHandlerTest extends TestCase
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidData(
-                new SchemaError('/url/0', 'The string should match pattern: ^http[s]?:\/\/\w')
+                new SchemaError('/url/0', 'The string should match pattern: ^https?:\/\/[\w\-\.]+\.\w{2,}(\/.*)?$')
             ),
             fn () => $this->updateContactPointRequestHandler->handle($updateUrlRequest)
         );


### PR DESCRIPTION
### Added

- `UpdateBookingInfoRequestHandlerTest`: added test for url's with a `#`

### Changed

- `composer`: updated to latest version of `dev-main`
- `ImportEventRequestHandlerTest`, `UpdateOnlineUrlRequestHandlerTest`, `UpdateBookingInfoRequestHandlerTest` & `UpdateContactPointRequestHandlerTest`: Use new regex for url in tests.
- `features`: `event/attendance-mode`, `event/booking-info` & `organizer/url` Use new regex for url in behat acceptance tests.

### Fixed

- Url's with 1 `#` can now be added

---
Ticket: https://jira.uitdatabank.be/browse/III-5712
