### PR TITLE
III-5749 Add labels data to behat tests and fix failing test

### DIFF
--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -22,9 +22,9 @@ trait LabelSteps
     }
 
     /**
-     * @When I patch the label :id with :command
+     * @When I patch the label with id :id and command :command
      */
-    public function iPatchTheLabelWith(string $id, string $command): void
+    public function iPatchTheLabelWithIdAndCommand(string $id, string $command): void
     {
         $response = $this->getHttpClient()->patchJSON(
             '/labels/' . $id,

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -35,6 +35,22 @@ trait LabelSteps
     }
 
     /**
+     * @Given I patch the label :labelId with command :command
+     */
+    public function patchLabel(string $uuid, string $command): void
+    {
+        $response = $this->getHttpClient()->patchJSON(
+            '/labels/' . $uuid,
+            $this->variableState->replaceVariables(
+                Json::encode([
+                    'command' => $command,
+                ])
+            )
+        );
+        $this->responseState->setResponse($response);
+    }
+
+    /**
      * @Given labels test data is available
      */
     public function labelsTestDataIsAvailable(): void
@@ -130,18 +146,5 @@ trait LabelSteps
         $this->responseState->setResponse($response);
 
         $this->theResponseBodyShouldBeValidJson();
-    }
-
-    private function patchLabel(string $uuid, string $command): void
-    {
-        $response = $this->getHttpClient()->patchJSON(
-            '/labels/' . $uuid,
-            $this->variableState->replaceVariables(
-                Json::encode([
-                    'command' => $command,
-                ])
-            )
-        );
-        $this->responseState->setResponse($response);
     }
 }

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -34,6 +34,58 @@ trait LabelSteps
         );
     }
 
+    /**
+     * @Given labels test data is available
+     */
+    public function labelsTestDataIsAvailable(): void
+    {
+        // Create "public-visible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
+        $this->createLabel('public-visible', true, true);
+        $this->getLabel('public-visible');
+        $uuid = $this->responseState->getJsonContent()['uuid'];
+        $this->patchLabel($uuid, 'MakePublic');
+        $this->patchLabel($uuid, 'MakeVisible');
+
+        // Create "public-invisible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
+        $this->createLabel('public-invisible', false, true);
+        $this->getLabel('public-invisible');
+        $uuid = $this->responseState->getJsonContent()['uuid'];
+        $this->patchLabel($uuid, 'MakePublic');
+        $this->patchLabel($uuid, 'MakeInvisible');
+
+        // Create "private-visible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
+        $this->createLabel('private-visible', true, false);
+        $this->getLabel('private-visible');
+        $uuid = $this->responseState->getJsonContent()['uuid'];
+        $this->patchLabel($uuid, 'MakePrivate');
+        $this->patchLabel($uuid, 'MakeVisible');
+
+        // Create "private-invisible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
+        $this->createLabel('private-invisible', false, false);
+        $this->getLabel('private-invisible');
+        $uuid = $this->responseState->getJsonContent()['uuid'];
+        $this->patchLabel($uuid, 'MakePrivate');
+        $this->patchLabel($uuid, 'MakeInvisible');
+
+        // Create "special_label" if it doesn't exist yet
+        $this->createLabel('special_label', true, true);
+
+        // Create "special-label" if it doesn't exist yet
+        $this->createLabel('special-label', true, true);
+
+        // Create "special_label#" if it doesn't exist yet and exclude it because of invalid #
+        $this->createLabel('special_label#', true, true);
+        $this->getLabel('special_label#');
+        $uuid = $this->responseState->getJsonContent()['uuid'];
+        $this->patchLabel($uuid, 'Exclude');
+
+        // Create "special_label*" if it doesn't exist yet and exclude it because of invalid #
+        $this->createLabel('special_label*', true, true);
+        $this->getLabel('special_label*');
+        $uuid = $this->responseState->getJsonContent()['uuid'];
+        $this->patchLabel($uuid, 'Exclude');
+    }
+
     private function createLabel(string $name, bool $visible, bool $public): void
     {
         $response = $this->getHttpClient()->postJSON(

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -22,6 +22,25 @@ trait LabelSteps
     }
 
     /**
+     * @When I patch the label :uuid with :command
+     */
+    public function iPatchTheLabelWith(string $uuid, string $command): void
+    {
+        $response = $this->getHttpClient()->patchJSON(
+            $this->variableState->replaceVariables(
+                '/labels/' . $uuid
+            ),
+            Json::encode([
+                'command' => $command,
+            ])
+        );
+        $this->responseState->setResponse($response);
+
+        $this->theResponseStatusShouldBe(204);
+    }
+
+
+    /**
      * @Given I create an invisible label with a random name of :nrOfCharacters characters
      */
     public function iCreateAnInvisibleLabelWithARandomNameOfCharacters(int $nrOfCharacters): void
@@ -35,24 +54,6 @@ trait LabelSteps
     }
 
     /**
-     * @Given I patch the label :labelId with :command
-     */
-    public function iPatchTheLabelWith(string $uuid, string $command): void
-    {
-        $response = $this->getHttpClient()->patchJSON(
-            '/labels/' . $uuid,
-            $this->variableState->replaceVariables(
-                Json::encode([
-                    'command' => $command,
-                ])
-            )
-        );
-        $this->responseState->setResponse($response);
-
-        $this->theResponseStatusShouldBe(204);
-    }
-
-    /**
      * @Given labels test data is available
      */
     public function labelsTestDataIsAvailable(): void
@@ -63,8 +64,8 @@ trait LabelSteps
             $this->createLabel('public-visible', true, true);
         } else {
             $uuid = $this->responseState->getJsonContent()['uuid'];
-            $this->patchLabel($uuid, 'MakePublic');
-            $this->patchLabel($uuid, 'MakeVisible');
+            $this->iPatchTheLabelWith($uuid, 'MakePublic');
+            $this->iPatchTheLabelWith($uuid, 'MakeVisible');
         }
 
         // Create "public-invisible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
@@ -73,8 +74,8 @@ trait LabelSteps
             $this->createLabel('public-invisible', false, true);
         }
         $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->patchLabel($uuid, 'MakePublic');
-        $this->patchLabel($uuid, 'MakeInvisible');
+        $this->iPatchTheLabelWith($uuid, 'MakePublic');
+        $this->iPatchTheLabelWith($uuid, 'MakeInvisible');
 
         // Create "private-visible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
         $this->getLabel('private-visible');
@@ -82,8 +83,8 @@ trait LabelSteps
             $this->createLabel('private-visible', true, false);
         }
         $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->patchLabel($uuid, 'MakePrivate');
-        $this->patchLabel($uuid, 'MakeVisible');
+        $this->iPatchTheLabelWith($uuid, 'MakePrivate');
+        $this->iPatchTheLabelWith($uuid, 'MakeVisible');
 
         // Create "private-invisible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
         $this->getLabel('private-invisible');
@@ -91,8 +92,8 @@ trait LabelSteps
             $this->createLabel('private-invisible', false, false);
         }
         $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->patchLabel($uuid, 'MakePrivate');
-        $this->patchLabel($uuid, 'MakeInvisible');
+        $this->iPatchTheLabelWith($uuid, 'MakePrivate');
+        $this->iPatchTheLabelWith($uuid, 'MakeInvisible');
 
         // Create "special_label" if it doesn't exist yet
         $this->getLabel('special_label');
@@ -112,7 +113,7 @@ trait LabelSteps
             $this->createLabel('special_label#', true, true);
         }
         $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->patchLabel($uuid, 'Exclude');
+        $this->iPatchTheLabelWith($uuid, 'Exclude');
 
         // Create "special_label*" if it doesn't exist yet and exclude it because of invalid #
         $this->getLabel('special_label*');
@@ -120,7 +121,7 @@ trait LabelSteps
             $this->createLabel('special_label*', true, true);
         }
         $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->patchLabel($uuid, 'Exclude');
+        $this->iPatchTheLabelWith($uuid, 'Exclude');
     }
 
     private function createLabel(string $name, bool $visible, bool $public): void

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -62,8 +62,8 @@ trait LabelSteps
             $this->createLabel('public-visible', true, true);
         } else {
             $uuid = $this->responseState->getJsonContent()['uuid'];
-            $this->iPatchTheLabelWith($uuid, 'MakePublic');
-            $this->iPatchTheLabelWith($uuid, 'MakeVisible');
+            $this->iPatchTheLabelWithIdAndCommand($uuid, 'MakePublic');
+            $this->iPatchTheLabelWithIdAndCommand($uuid, 'MakeVisible');
         }
 
         // Create "public-invisible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
@@ -72,8 +72,8 @@ trait LabelSteps
             $this->createLabel('public-invisible', false, true);
         }
         $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->iPatchTheLabelWith($uuid, 'MakePublic');
-        $this->iPatchTheLabelWith($uuid, 'MakeInvisible');
+        $this->iPatchTheLabelWithIdAndCommand($uuid, 'MakePublic');
+        $this->iPatchTheLabelWithIdAndCommand($uuid, 'MakeInvisible');
 
         // Create "private-visible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
         $this->getLabel('private-visible');
@@ -81,8 +81,8 @@ trait LabelSteps
             $this->createLabel('private-visible', true, false);
         }
         $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->iPatchTheLabelWith($uuid, 'MakePrivate');
-        $this->iPatchTheLabelWith($uuid, 'MakeVisible');
+        $this->iPatchTheLabelWithIdAndCommand($uuid, 'MakePrivate');
+        $this->iPatchTheLabelWithIdAndCommand($uuid, 'MakeVisible');
 
         // Create "private-invisible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
         $this->getLabel('private-invisible');
@@ -90,8 +90,8 @@ trait LabelSteps
             $this->createLabel('private-invisible', false, false);
         }
         $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->iPatchTheLabelWith($uuid, 'MakePrivate');
-        $this->iPatchTheLabelWith($uuid, 'MakeInvisible');
+        $this->iPatchTheLabelWithIdAndCommand($uuid, 'MakePrivate');
+        $this->iPatchTheLabelWithIdAndCommand($uuid, 'MakeInvisible');
 
         // Create "special_label" if it doesn't exist yet
         $this->getLabel('special_label');
@@ -111,7 +111,7 @@ trait LabelSteps
             $this->createLabel('special_label#', true, true);
         }
         $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->iPatchTheLabelWith($uuid, 'Exclude');
+        $this->iPatchTheLabelWithIdAndCommand($uuid, 'Exclude');
 
         // Create "special_label*" if it doesn't exist yet and exclude it because of invalid #
         $this->getLabel('special_label*');
@@ -119,7 +119,7 @@ trait LabelSteps
             $this->createLabel('special_label*', true, true);
         }
         $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->iPatchTheLabelWith($uuid, 'Exclude');
+        $this->iPatchTheLabelWithIdAndCommand($uuid, 'Exclude');
     }
 
     private function createLabel(string $name, bool $visible, bool $public): void

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -22,14 +22,13 @@ trait LabelSteps
     }
 
     /**
-     * @When I patch the label :uuid with :command
+     * @When I patch the label :id with :command
      */
-    public function iPatchTheLabelWith(string $uuid, string $command): void
+    public function iPatchTheLabelWith(string $id, string $command): void
     {
         $response = $this->getHttpClient()->patchJSON(
-            $this->variableState->replaceVariables(
-                '/labels/' . $uuid
-            ),
+            '/labels/' . $id
+            ,
             Json::encode([
                 'command' => $command,
             ])

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -40,48 +40,66 @@ trait LabelSteps
     public function labelsTestDataIsAvailable(): void
     {
         // Create "public-visible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
-        $this->createLabel('public-visible', true, true);
         $this->getLabel('public-visible');
+        if ($this->responseState->getStatusCode() === 404) {
+            $this->createLabel('public-visible', true, true);
+        }
         $uuid = $this->responseState->getJsonContent()['uuid'];
         $this->patchLabel($uuid, 'MakePublic');
         $this->patchLabel($uuid, 'MakeVisible');
 
         // Create "public-invisible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
-        $this->createLabel('public-invisible', false, true);
         $this->getLabel('public-invisible');
+        if ($this->responseState->getStatusCode() === 404) {
+            $this->createLabel('public-invisible', false, true);
+        }
         $uuid = $this->responseState->getJsonContent()['uuid'];
         $this->patchLabel($uuid, 'MakePublic');
         $this->patchLabel($uuid, 'MakeInvisible');
 
         // Create "private-visible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
-        $this->createLabel('private-visible', true, false);
         $this->getLabel('private-visible');
+        if ($this->responseState->getStatusCode() === 404) {
+            $this->createLabel('private-visible', true, false);
+        }
         $uuid = $this->responseState->getJsonContent()['uuid'];
         $this->patchLabel($uuid, 'MakePrivate');
         $this->patchLabel($uuid, 'MakeVisible');
 
         // Create "private-invisible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
-        $this->createLabel('private-invisible', false, false);
         $this->getLabel('private-invisible');
+        if ($this->responseState->getStatusCode() === 404) {
+            $this->createLabel('private-invisible', false, false);
+        }
         $uuid = $this->responseState->getJsonContent()['uuid'];
         $this->patchLabel($uuid, 'MakePrivate');
         $this->patchLabel($uuid, 'MakeInvisible');
 
         // Create "special_label" if it doesn't exist yet
-        $this->createLabel('special_label', true, true);
+        $this->getLabel('special_label');
+        if ($this->responseState->getStatusCode() === 404) {
+            $this->createLabel('special_label', true, true);
+        }
 
         // Create "special-label" if it doesn't exist yet
-        $this->createLabel('special-label', true, true);
+        $this->getLabel('special-label');
+        if ($this->responseState->getStatusCode() === 404) {
+            $this->createLabel('special-label', true, true);
+        }
 
         // Create "special_label#" if it doesn't exist yet and exclude it because of invalid #
-        $this->createLabel('special_label#', true, true);
         $this->getLabel('special_label#');
+        if ($this->responseState->getStatusCode() === 404) {
+            $this->createLabel('special_label#', true, true);
+        }
         $uuid = $this->responseState->getJsonContent()['uuid'];
         $this->patchLabel($uuid, 'Exclude');
 
         // Create "special_label*" if it doesn't exist yet and exclude it because of invalid #
-        $this->createLabel('special_label*', true, true);
         $this->getLabel('special_label*');
+        if ($this->responseState->getStatusCode() === 404) {
+            $this->createLabel('special_label*', true, true);
+        }
         $uuid = $this->responseState->getJsonContent()['uuid'];
         $this->patchLabel($uuid, 'Exclude');
     }

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -35,9 +35,9 @@ trait LabelSteps
     }
 
     /**
-     * @Given I patch the label :labelId with command :command
+     * @Given I patch the label :labelId with :command
      */
-    public function patchLabel(string $uuid, string $command): void
+    public function iPatchTheLabelWith(string $uuid, string $command): void
     {
         $response = $this->getHttpClient()->patchJSON(
             '/labels/' . $uuid,

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -48,6 +48,8 @@ trait LabelSteps
             )
         );
         $this->responseState->setResponse($response);
+
+        $this->theResponseStatusShouldBe(204);
     }
 
     /**

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -50,4 +50,27 @@ trait LabelSteps
 
         $this->theResponseBodyShouldBeValidJson();
     }
+
+    private function getLabel(string $name): void
+    {
+        $response = $this->getHttpClient()->get(
+            '/labels/' . urlencode($name)
+        );
+        $this->responseState->setResponse($response);
+
+        $this->theResponseBodyShouldBeValidJson();
+    }
+
+    private function patchLabel(string $uuid, string $command): void
+    {
+        $response = $this->getHttpClient()->patchJSON(
+            '/labels/' . $uuid,
+            $this->variableState->replaceVariables(
+                Json::encode([
+                    'command' => $command,
+                ])
+            )
+        );
+        $this->responseState->setResponse($response);
+    }
 }

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -27,8 +27,7 @@ trait LabelSteps
     public function iPatchTheLabelWith(string $id, string $command): void
     {
         $response = $this->getHttpClient()->patchJSON(
-            '/labels/' . $id
-            ,
+            '/labels/' . $id,
             Json::encode([
                 'command' => $command,
             ])

--- a/features/Steps/LabelSteps.php
+++ b/features/Steps/LabelSteps.php
@@ -43,10 +43,11 @@ trait LabelSteps
         $this->getLabel('public-visible');
         if ($this->responseState->getStatusCode() === 404) {
             $this->createLabel('public-visible', true, true);
+        } else {
+            $uuid = $this->responseState->getJsonContent()['uuid'];
+            $this->patchLabel($uuid, 'MakePublic');
+            $this->patchLabel($uuid, 'MakeVisible');
         }
-        $uuid = $this->responseState->getJsonContent()['uuid'];
-        $this->patchLabel($uuid, 'MakePublic');
-        $this->patchLabel($uuid, 'MakeVisible');
 
         // Create "public-invisible" if it doesn't exist yet and (re)set the right privacy and visibility in case its needed
         $this->getLabel('public-invisible');

--- a/features/label/get.feature
+++ b/features/label/get.feature
@@ -4,6 +4,7 @@ Feature: Test the UDB3 labels API
     Given I am using the UDB3 base URL
     And I am using an UiTID v1 API key of consumer "uitdatabank"
     And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And labels test data is available
 
   Scenario: Get single label by name
     When I create a label with a random name of 10 characters

--- a/features/label/get.feature
+++ b/features/label/get.feature
@@ -51,11 +51,7 @@ Feature: Test the UDB3 labels API
     And I keep the value of the JSON response at "uuid" as "uuid"
     And I send a GET request to "/labels/%{uuid}"
     And I keep the value of the JSON response at "name" as "name"
-    And I set the JSON request payload to:
-    """
-    { "command": "Exclude" }
-    """
-    And I send a PATCH request to "/labels/%{uuid}"
+    And I patch the label "%{uuid}" with "Exclude"
     And I send a GET request to "/labels/" with parameters:
       | limit      | 10      |
       | query      | %{name} |

--- a/features/label/get.feature
+++ b/features/label/get.feature
@@ -34,7 +34,7 @@ Feature: Test the UDB3 labels API
     And I keep the value of the JSON response at "uuid" as "uuid"
     And I send a GET request to "/labels/%{uuid}"
     And I keep the value of the JSON response at "name" as "name"
-    And I patch the label with id "%{uuid}" and "Exclude"
+    And I patch the label with id "%{uuid}" and command "Exclude"
     And I send a GET request to "/labels/" with parameters:
       | limit      | 10      |
       | query      | %{name} |

--- a/features/label/get.feature
+++ b/features/label/get.feature
@@ -34,7 +34,7 @@ Feature: Test the UDB3 labels API
     And I keep the value of the JSON response at "uuid" as "uuid"
     And I send a GET request to "/labels/%{uuid}"
     And I keep the value of the JSON response at "name" as "name"
-    And I patch the label "%{uuid}" with "Exclude"
+    And I patch the label with id "%{uuid}" and "Exclude"
     And I send a GET request to "/labels/" with parameters:
       | limit      | 10      |
       | query      | %{name} |
@@ -47,7 +47,7 @@ Feature: Test the UDB3 labels API
     And I keep the value of the JSON response at "uuid" as "uuid"
     And I send a GET request to "/labels/%{uuid}"
     And I keep the value of the JSON response at "name" as "name"
-    And I patch the label "%{uuid}" with "Exclude"
+    And I patch the label with id "%{uuid}" and command "Exclude"
     And I send a GET request to "/labels/" with parameters:
       | limit      | 10      |
       | query      | %{name} |

--- a/features/label/get.feature
+++ b/features/label/get.feature
@@ -34,11 +34,7 @@ Feature: Test the UDB3 labels API
     And I keep the value of the JSON response at "uuid" as "uuid"
     And I send a GET request to "/labels/%{uuid}"
     And I keep the value of the JSON response at "name" as "name"
-    And I set the JSON request payload to:
-    """
-    { "command": "Exclude" }
-    """
-    And I send a PATCH request to "/labels/%{uuid}"
+    And I patch the label "%{uuid}" with "Exclude"
     And I send a GET request to "/labels/" with parameters:
       | limit      | 10      |
       | query      | %{name} |

--- a/features/label/update.feature
+++ b/features/label/update.feature
@@ -9,7 +9,7 @@ Feature: Test the UDB3 labels API
   Scenario: Make label invisible
     Given I create a label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-    When I patch the label "%{uuid}" with "MakeInvisible"
+    When I patch the label with id "%{uuid}" and command "MakeInvisible"
     And I send a GET request to "/labels/%{uuid}"
     Then the response status should be "200"
     And the JSON response at "visibility" should be "invisible"
@@ -17,7 +17,7 @@ Feature: Test the UDB3 labels API
   Scenario: Make label visible
     Given I create an invisible label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-    When I patch the label "%{uuid}" with "MakeVisible"
+    When I patch the label with id "%{uuid}" and command "MakeVisible"
     And I send a GET request to "/labels/%{uuid}"
     Then the response status should be "200"
     And the JSON response at "visibility" should be "visible"
@@ -25,7 +25,7 @@ Feature: Test the UDB3 labels API
   Scenario: Make label private
     Given I create a label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-    When I patch the label "%{uuid}" with "MakePrivate"
+    When I patch the label with id "%{uuid}" and command "MakePrivate"
     And I send a GET request to "/labels/%{uuid}"
     Then the response status should be "200"
     And the JSON response at "privacy" should be "private"
@@ -33,8 +33,8 @@ Feature: Test the UDB3 labels API
   Scenario: Make label public
     Given I create a label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-    And I patch the label "%{uuid}" with "MakePrivate"
-    When I patch the label "%{uuid}" with "MakePublic"
+    And I patch the label with id "%{uuid}" and command "MakePrivate"
+    When I patch the label with id "%{uuid}" and command "MakePublic"
     And I send a GET request to "/labels/%{uuid}"
     Then the response status should be "200"
     And the JSON response at "privacy" should be "public"
@@ -42,7 +42,7 @@ Feature: Test the UDB3 labels API
   Scenario: Exclude a label
     Given I create a label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-    When I patch the label "%{uuid}" with "Exclude"
+    When I patch the label with id "%{uuid}" and command "Exclude"
     And I send a GET request to "/labels/%{uuid}"
     Then the response status should be "200"
     And the JSON response at "excluded" should be true
@@ -50,8 +50,8 @@ Feature: Test the UDB3 labels API
   Scenario: Include an excluded label
     Given I create a label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-    And I patch the label "%{uuid}" with "Exclude"
-    When I patch the label "%{uuid}" with "Include"
+    And I patch the label with id "%{uuid}" and command "Exclude"
+    When I patch the label with id "%{uuid}" and command "Include"
     And I send a GET request to "/labels/%{uuid}"
     Then the response status should be "200"
     And the JSON response at "excluded" should be false

--- a/features/label/update.feature
+++ b/features/label/update.feature
@@ -9,31 +9,17 @@ Feature: Test the UDB3 labels API
   Scenario: Make label invisible
     Given I create a label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-
-    When I set the JSON request payload to:
-    """
-    { "command": "MakeInvisible" }
-    """
-    And I send a PATCH request to "/labels/%{uuid}"
-
-    Then the response status should be "204"
+    When I patch the label "%{uuid}" with "MakeInvisible"
     And I send a GET request to "/labels/%{uuid}"
-    And the response status should be "200"
+    Then the response status should be "200"
     And the JSON response at "visibility" should be "invisible"
 
   Scenario: Make label visible
     Given I create an invisible label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-
-    When I set the JSON request payload to:
-    """
-    { "command": "MakeVisible" }
-    """
-    And I send a PATCH request to "/labels/%{uuid}"
-
-    Then the response status should be "204"
+    When I patch the label "%{uuid}" with "MakeVisible"
     And I send a GET request to "/labels/%{uuid}"
-    And the response status should be "200"
+    Then the response status should be "200"
     And the JSON response at "visibility" should be "visible"
 
   Scenario: Make label private

--- a/features/label/update.feature
+++ b/features/label/update.feature
@@ -25,65 +25,33 @@ Feature: Test the UDB3 labels API
   Scenario: Make label private
     Given I create a label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-
-    When I set the JSON request payload to:
-    """
-    { "command": "MakePrivate" }
-    """
-    And I send a PATCH request to "/labels/%{uuid}"
-
-    Then the response status should be "204"
+    When I patch the label "%{uuid}" with "MakePrivate"
     And I send a GET request to "/labels/%{uuid}"
-    And the response status should be "200"
+    Then the response status should be "200"
     And the JSON response at "privacy" should be "private"
 
   Scenario: Make label public
     Given I create a label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-    And I set the JSON request payload to:
-    """
-    { "command": "MakePrivate" }
-    """
-    And I send a PATCH request to "/labels/%{uuid}"
-
-    When I set the JSON request payload to:
-    """
-    { "command": "MakePublic" }
-    """
-    And I send a PATCH request to "/labels/%{uuid}"
-
-    Then the response status should be "204"
+    And I patch the label "%{uuid}" with "MakePrivate"
+    When I patch the label "%{uuid}" with "MakePublic"
     And I send a GET request to "/labels/%{uuid}"
-    And the response status should be "200"
+    Then the response status should be "200"
     And the JSON response at "privacy" should be "public"
 
   Scenario: Exclude a label
     Given I create a label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-    When I set the JSON request payload to:
-    """
-    { "command": "Exclude" }
-    """
-    And I send a PATCH request to "/labels/%{uuid}"
-    Then the response status should be "204"
+    When I patch the label "%{uuid}" with "Exclude"
     And I send a GET request to "/labels/%{uuid}"
-    And the response status should be "200"
+    Then the response status should be "200"
     And the JSON response at "excluded" should be true
 
   Scenario: Include an excluded label
     Given I create a label with a random name of 10 characters
     And I keep the value of the JSON response at "uuid" as "uuid"
-    And I set the JSON request payload to:
-    """
-    { "command": "Exclude" }
-    """
-    And I send a PATCH request to "/labels/%{uuid}"
-    When I set the JSON request payload to:
-    """
-    { "command": "Include" }
-    """
-    And I send a PATCH request to "/labels/%{uuid}"
-    Then the response status should be "204"
+    And I patch the label "%{uuid}" with "Exclude"
+    When I patch the label "%{uuid}" with "Include"
     And I send a GET request to "/labels/%{uuid}"
-    And the response status should be "200"
+    Then the response status should be "200"
     And the JSON response at "excluded" should be false


### PR DESCRIPTION
### Added

- Added Labels Data setup on `LabelSteps`
- Added `getLabel()` on `LabelSteps`
- Add step  `When I patch the label with :id and :command` on `LabelSteps`

### Changed

- Make sure LabelData is created when running tests for `labels/get`


Related PR: https://github.com/cultuurnet/udb3-acceptance-tests/pull/193

---
Ticket: https://jira.uitdatabank.be/browse/III-5749
