### PR TITLE
added xdebug to docker

### DIFF
--- a/bin/start-xdebug.sh
+++ b/bin/start-xdebug.sh
@@ -1,0 +1,1 @@
+export XDEBUG_MODE=debug XDEBUG_SESSION=1 PHP_IDE_CONFIG="serverName=host.docker.internal"

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -27,3 +27,6 @@ RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+
+RUN pecl install xdebug-3.1.5 && docker-php-ext-enable xdebug
+COPY xdebug.ini $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini

--- a/docker/php/xdebug.ini
+++ b/docker/php/xdebug.ini
@@ -1,0 +1,5 @@
+zend_extension=xdebug
+xdebug.mode=debug
+xdebug.output_dir=/profile
+xdebug.client_host=host.docker.internal
+xdebug.start_with_request=trigger


### PR DESCRIPTION
### Added
Added xdebug to the docker setup

I configured xdebug to only run when enable with a trigger, meaning:
- Running the script in ./bin/start-xdebug.sh for CLI scripts
- Adding XDEBUG_TRIGGER as a GET or POST variable when using Postman

There is a slight performance degradation because of using xdebug, so I am not 100% sure we should include it, but I want to open it for the team. I myself use xdebug a lot, but I can just keep it on my own machine.

Performance tests without xdebug, running "time make ci" on my machine:

make ci  0.10s user 0.23s system 2% cpu 11.059 total
make ci  0.10s user 0.22s system 2% cpu 11.102 total
make ci  0.10s user 0.23s system 2% cpu 11.561 total
make ci  0.10s user 0.22s system 2% cpu 11.572 total

With xdebug:
make ci  0.10s user 0.24s system 2% cpu 13.702 total
make ci  0.11s user 0.26s system 2% cpu 13.497 total
make ci  0.10s user 0.25s system 2% cpu 13.430 total
make ci  0.11s user 0.25s system 2% cpu 13.733 total

You see it adds around 2 seconds of time, even with xdebug trigger off.

Please let me know your opinion, happy to discuss!
