### PR TITLE
Bugfix - Fix broken config.sh script

### DIFF
--- a/docker/config.sh
+++ b/docker/config.sh
@@ -3,7 +3,7 @@
 # setup config & key files
 DIR="../appconfig/files/udb3/docker/udb3-backend/"
 if [ -d "$DIR" ]; then
-  cp "$DIR"/* .
+  cp -R "$DIR"/* .
   # needed because it is hidden
   cp "$DIR"/.env .
 else


### PR DESCRIPTION
### Fixed
Because there is a dir called features/ in the config/ dir the old config.sh script was broken, it needed the -R flag.
