### PR TITLE
Hotfix:revert regex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-uitdatabank/revert-regex",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/revert-regex",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c09dd645f4b24c8e7346ceeacceefd87",
+    "content-hash": "6105232432b318a6e4001a7cbf5a56ee",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5629,19 +5629,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/revert-regex",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "5a2490cea531245c970713a4821d2f78161af251"
+                "reference": "8c845bddd1fe9d66929746b73ceafdb7f7cf1079"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/5a2490cea531245c970713a4821d2f78161af251",
-                "reference": "5a2490cea531245c970713a4821d2f78161af251",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/8c845bddd1fe9d66929746b73ceafdb7f7cf1079",
+                "reference": "8c845bddd1fe9d66929746b73ceafdb7f7cf1079",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5656,9 +5655,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/revert-regex"
             },
-            "time": "2023-07-19T10:08:18+00:00"
+            "time": "2023-07-28T09:40:51+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6105232432b318a6e4001a7cbf5a56ee",
+    "content-hash": "c09dd645f4b24c8e7346ceeacceefd87",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5629,7 +5629,7 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-uitdatabank/revert-regex",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
@@ -5641,6 +5641,7 @@
                 "reference": "8c845bddd1fe9d66929746b73ceafdb7f7cf1079",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5655,7 +5656,7 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/revert-regex"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
             "time": "2023-07-28T09:40:51+00:00"
         },

--- a/features/event/attendance-mode.feature
+++ b/features/event/attendance-mode.feature
@@ -454,7 +454,7 @@ Feature: Test event attendanceMode property
     {
       "schemaErrors": [
         {
-          "error": "The string should match pattern: ^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
+          "error": "The string should match pattern: ^http[s]?:\\/\\/\\w",
           "jsonPointer": "/onlineUrl"
         }
       ],

--- a/features/event/booking-info.feature
+++ b/features/event/booking-info.feature
@@ -248,7 +248,7 @@ Feature: Test the UDB3 events API
       "status":400,
       "schemaErrors": [
         {
-          "error": "The string should match pattern: ^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
+          "error": "The string should match pattern: ^http[s]?:\\/\\/\\w",
           "jsonPointer": "/url"
         }
       ]

--- a/features/organizer/url.feature
+++ b/features/organizer/url.feature
@@ -78,7 +78,7 @@ Feature: Test organizer url property
      "status": 400,
      "schemaErrors": [
         {
-          "error": "The string should match pattern: ^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
+          "error": "The string should match pattern: ^http[s]?:\\/\\/\\w",
           "jsonPointer": "/url"
         }
       ]

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -3028,7 +3028,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/onlineUrl',
-                'The string should match pattern: ^https?:\/\/[\w\-\.]+\.\w{2,}(\/.*)?$'
+                'The string should match pattern: ^http[s]?:\/\/\w'
             ),
         ];
 

--- a/tests/Http/Event/UpdateOnlineUrlRequestHandlerTest.php
+++ b/tests/Http/Event/UpdateOnlineUrlRequestHandlerTest.php
@@ -94,7 +94,7 @@ final class UpdateOnlineUrlRequestHandlerTest extends TestCase
                 [
                     'onlineUrl' => 'rtp://www.publiq.be/livestream',
                 ],
-                new SchemaError('/onlineUrl', 'The string should match pattern: ^https?:\/\/[\w\-\.]+\.\w{2,}(\/.*)?$'),
+                new SchemaError('/onlineUrl', 'The string should match pattern: ^http[s]?:\/\/\w'),
             ],
         ];
     }

--- a/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
@@ -210,7 +210,7 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
             'schemaErrors' => [
                 new SchemaError(
                     '/url',
-                    'The string should match pattern: ^https?:\/\/[\w\-\.]+\.\w{2,}(\/.*)?$'
+                    'The string should match pattern: ^http[s]?:\/\/\w'
                 ),
             ],
         ];

--- a/tests/Http/Organizer/UpdateContactPointRequestHandlerTest.php
+++ b/tests/Http/Organizer/UpdateContactPointRequestHandlerTest.php
@@ -216,7 +216,7 @@ final class UpdateContactPointRequestHandlerTest extends TestCase
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidData(
-                new SchemaError('/url/0', 'The string should match pattern: ^https?:\/\/[\w\-\.]+\.\w{2,}(\/.*)?$')
+                new SchemaError('/url/0', 'The string should match pattern: ^http[s]?:\/\/\w')
             ),
             fn () => $this->updateContactPointRequestHandler->handle($updateUrlRequest)
         );


### PR DESCRIPTION
### Changed

- Updated `apidocs` in `composer` to latest version
- reverted regex for `uri` back to old one in unit tests
- reverted regex for `uri` back to old one in behat tests

### Fixed

- Avoid problems with new regex We will have to look for a better solution for III-5712 in the future

related PR for Ruby acceptance tests: https://github.com/cultuurnet/udb3-acceptance-tests/pull/194

---
