### PR TITLE
Fix acceptance test: Create a news article with url that should have been encoded

### DIFF
--- a/features/curator/create.feature
+++ b/features/curator/create.feature
@@ -113,7 +113,7 @@ Feature: Test the curator API
 
     When I send a GET request to "/news-articles/%{articleId}"
     Then the response status should be "200"
-    And the JSON response at "url" should be "https://www.publiq.be/blog/caf%%C3%%A9/%{name}"
+    And the JSON response at "url" should be "https://www.publiq.be/blog/caf%C3%A9/%{name}"
 
   Scenario: Create a news article with an existing url and about
     Given I set the JSON request payload to:

--- a/features/curator/create.feature
+++ b/features/curator/create.feature
@@ -89,7 +89,7 @@ Feature: Test the curator API
       "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
       "publisher": "BILL",
       "publisherLogo": "https://www.bill.be/img/favicon.png",
-      "url": "https://www.publiq.be/blog/caf%C3%A9/%{name}"
+      "url": "https://www.publiq.be/blog/café/%{name}"
     }
     """
     When I send a POST request to "/news-articles"


### PR DESCRIPTION
### Changed

- Use `café` instead of `caf%C3%A9` like in original test: https://github.com/cultuurnet/udb3-acceptance-tests/blob/b289e4bb43084603e34958979a6144e24fd89bca/features/curator/create.feature#L94
- Do not escape `%` with `%%` because `sprintf()` of `Ruby` is no longer used.

### Fixed

- `Create a news article with url that should have been encoded` is green

---