### PR TITLE
III-5763 remove bookinginfo when given empty values

### DIFF
--- a/features/data/events/event-with-bookinginfo.json
+++ b/features/data/events/event-with-bookinginfo.json
@@ -1,0 +1,28 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Permanent event with bookinginfo"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{placeUrl}"
+  },
+  "calendarType": "permanent",
+  "bookingInfo": {
+    "phone": "string",
+    "email": "info@example.com",
+    "url": "https://www.example.com",
+    "urlLabel": {
+      "nl": "Nederlandse beschrijving",
+      "en": "English description"
+    },
+    "availabilityStarts": "2021-05-17T22:00:00+00:00",
+    "availabilityEnds": "2021-05-17T22:00:00+00:00"
+  }
+}

--- a/features/event/booking-info.feature
+++ b/features/event/booking-info.feature
@@ -254,3 +254,16 @@ Feature: Test the UDB3 events API
       ]
     }
     """
+
+  Scenario: Delete event booking info (with put)
+    Given I create an event from "events/event-with-bookinginfo.json" and save the "url" as "eventUrl"
+    When I set the JSON request payload to:
+    """
+    {
+      "bookingInfo": {}
+    }
+    """
+    And I send a PUT request to "%{eventUrl}/booking-info"
+    Then the response status should be "204"
+    When I get the event at "%{eventUrl}"
+    And the JSON response should not have "bookingInfo"

--- a/features/place/booking-info.feature
+++ b/features/place/booking-info.feature
@@ -108,3 +108,16 @@ Feature: Test place bookingInfo property
       """
       "The place with id \"0680f399-7768-4ba0-b33a-d4d15c21282e\" was not found."
       """
+
+  Scenario: Delete place booking info (with put)
+    Given I create a place from "places/place-with-all-fields.json" and save the "url" as "placeUrl"
+    When I set the JSON request payload to:
+    """
+    {
+      "bookingInfo": {}
+    }
+    """
+    And I send a PUT request to "%{placeUrl}/booking-info"
+    Then the response status should be "204"
+    When I get the place at "%{placeUrl}"
+    And the JSON response should not have "bookingInfo"

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -631,7 +631,11 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
 
         $offerLd = $document->getBody();
 
-        $offerLd->bookingInfo = $bookingInfoUpdated->getBookingInfo()->toJsonLd();
+        if (empty($bookingInfoUpdated->getBookingInfo()->toJsonLd())) {
+            unset($offerLd->bookingInfo);
+        } else {
+            $offerLd->bookingInfo = $bookingInfoUpdated->getBookingInfo()->toJsonLd();
+        }
 
         return $document->withBody($offerLd);
     }

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -17,6 +17,9 @@ use CultuurNet\UDB3\SameAsForUitInVlaanderen;
 
 final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
 {
+    // All fields that contain arrays but can be null, should be removed when array is empty
+    private const FILTERED_NULL_LABELS = ['labels', 'hiddenLabels', 'bookingInfo'];
+
     private ReadRepositoryInterface $labelReadRepository;
 
     private OfferType $offerType;
@@ -235,8 +238,9 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
                     return $json;
                 };
 
-                $json = $filterNullLabels($json, 'labels');
-                $json = $filterNullLabels($json, 'hiddenLabels');
+                foreach (self::FILTERED_NULL_LABELS as $filteredNullLabel) {
+                    $json = $filterNullLabels($json, $filteredNullLabel);
+                }
 
                 return $json;
             }

--- a/tests/Event/Events/BookingInfoUpdatedTest.php
+++ b/tests/Event/Events/BookingInfoUpdatedTest.php
@@ -70,9 +70,7 @@ class BookingInfoUpdatedTest extends TestCase
             'bookingInfoDeleted' => [
                 [
                     'item_id' => 'foo',
-                    'bookingInfo' => [
-
-                    ],
+                    'bookingInfo' => [],
                 ],
                 new BookingInfoUpdated(
                     'foo',

--- a/tests/Event/Events/BookingInfoUpdatedTest.php
+++ b/tests/Event/Events/BookingInfoUpdatedTest.php
@@ -67,6 +67,18 @@ class BookingInfoUpdatedTest extends TestCase
                     )
                 ),
             ],
+            'bookingInfoDeleted' => [
+                [
+                    'item_id' => 'foo',
+                    'bookingInfo' => [
+
+                    ],
+                ],
+                new BookingInfoUpdated(
+                    'foo',
+                    new BookingInfo()
+                ),
+            ],
         ];
     }
 }

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -2354,7 +2354,7 @@ class OfferLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_should_remove_bookinginfo_when_array_is_empty()
+    public function it_should_remove_bookinginfo_when_array_is_empty(): void
     {
         $id = 'e56e8eb6-dcd7-47e7-8106-8a149f1d241b';
 
@@ -2387,7 +2387,7 @@ class OfferLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_should_update_bookinginfo()
+    public function it_should_update_bookinginfo(): void
     {
         $id = 'e56e8eb6-dcd7-47e7-8106-8a149f1d241b';
 
@@ -2411,7 +2411,7 @@ class OfferLDProjectorTest extends TestCase
                 'phone' => '0471123456',
                 'email' => 'test@test.be',
                 'url' => 'http://www.google.be',
-                'urlLabel' => (object)['nl' => 'Dit is een booking info event']
+                'urlLabel' => (object)['nl' => 'Dit is een booking info event'],
             ],
             'modified' => $this->recordedOn->toString(),
             'playhead' => 1,

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -9,7 +9,6 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\EntityNotFoundException;
-use CultuurNet\UDB3\Event\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
@@ -25,9 +24,10 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Video;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\Events\AbstractEvent;
-use CultuurNet\UDB3\Offer\Item\Commands\UpdateBookingInfo;
 use CultuurNet\UDB3\Offer\Item\Events\AvailableFromUpdated;
+use CultuurNet\UDB3\Offer\Item\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\DescriptionDeleted;
 use CultuurNet\UDB3\Offer\Item\Events\DescriptionTranslated;
 use CultuurNet\UDB3\Offer\Item\Events\FacilitiesUpdated;
@@ -54,7 +54,6 @@ use CultuurNet\UDB3\Offer\Item\Events\VideoAdded;
 use CultuurNet\UDB3\Offer\Item\Events\VideoDeleted;
 use CultuurNet\UDB3\Offer\Item\Events\VideoUpdated;
 use CultuurNet\UDB3\Offer\Item\ReadModel\JSONLD\ItemLDProjector;
-use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\OrganizerService;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
@@ -64,6 +63,7 @@ use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\ReadModel\JsonDocumentNullEnricher;
 use CultuurNet\UDB3\RecordedOn;
+use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Title;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use DateTimeImmutable;
@@ -74,7 +74,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use stdClass;
-use CultuurNet\UDB3\StringLiteral;
 
 class OfferLDProjectorTest extends TestCase
 {
@@ -2365,7 +2364,7 @@ class OfferLDProjectorTest extends TestCase
                 [
                     'name' => ['nl' => 'Foo'],
                     'bookingInfo' => [
-                        ''
+
                     ],
                 ]
             )
@@ -2373,11 +2372,57 @@ class OfferLDProjectorTest extends TestCase
 
         $this->documentRepository->save($initialDocument);
 
-        $expectedBody = (object) [
-            'name' => (object) ['nl' => 'Foo'],
+        $expectedBody = (object)[
+            'name' => (object)['nl' => 'Foo'],
+            'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
         ];
 
-        $event = new BookingInfoUpdated($id, new BookingInfo('http://www.google.be/'));
+        $event = new BookingInfoUpdated($id, new BookingInfo());
+
+        $body = $this->project($event, $id, null, $this->recordedOn->toBroadwayDateTime());
+        $this->assertEquals($expectedBody, $body);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_update_bookinginfo()
+    {
+        $id = 'e56e8eb6-dcd7-47e7-8106-8a149f1d241b';
+
+        $initialDocument = new JsonDocument(
+            $id,
+            Json::encode(
+                [
+                    'name' => ['nl' => 'Foo'],
+                    'bookingInfo' => [
+
+                    ],
+                ]
+            )
+        );
+
+        $this->documentRepository->save($initialDocument);
+
+        $expectedBody = (object)[
+            'name' => (object)['nl' => 'Foo'],
+            'bookingInfo' => (object)[
+                'phone' => '0471123456',
+                'email' => 'test@test.be',
+                'url' => 'http://www.google.be',
+                'urlLabel' => (object)['nl' => 'Dit is een booking info event']
+            ],
+            'modified' => $this->recordedOn->toString(),
+            'playhead' => 1,
+        ];
+
+        $event = new BookingInfoUpdated($id, new BookingInfo(
+            'http://www.google.be',
+            new MultilingualString(new LegacyLanguage('nl'), new StringLiteral('Dit is een booking info event')),
+            '0471123456',
+            'test@test.be'
+        ));
 
         $body = $this->project($event, $id, null, $this->recordedOn->toBroadwayDateTime());
         $this->assertEquals($expectedBody, $body);

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -7,7 +7,9 @@ namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Event\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
@@ -24,6 +26,7 @@ use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Video;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Offer\Events\AbstractEvent;
+use CultuurNet\UDB3\Offer\Item\Commands\UpdateBookingInfo;
 use CultuurNet\UDB3\Offer\Item\Events\AvailableFromUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\DescriptionDeleted;
 use CultuurNet\UDB3\Offer\Item\Events\DescriptionTranslated;
@@ -2347,5 +2350,36 @@ class OfferLDProjectorTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_remove_bookinginfo_when_array_is_empty()
+    {
+        $id = 'e56e8eb6-dcd7-47e7-8106-8a149f1d241b';
+
+        $initialDocument = new JsonDocument(
+            $id,
+            Json::encode(
+                [
+                    'name' => ['nl' => 'Foo'],
+                    'bookingInfo' => [
+                        ''
+                    ],
+                ]
+            )
+        );
+
+        $this->documentRepository->save($initialDocument);
+
+        $expectedBody = (object) [
+            'name' => (object) ['nl' => 'Foo'],
+        ];
+
+        $event = new BookingInfoUpdated($id, new BookingInfo('http://www.google.be/'));
+
+        $body = $this->project($event, $id, null, $this->recordedOn->toBroadwayDateTime());
+        $this->assertEquals($expectedBody, $body);
     }
 }

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -130,6 +130,16 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
 
     /**
      * @test
+     */
+    public function it_should_polyfill_a_bookinfo_removed(): void
+    {
+        $this
+            ->given(['bookingInfo' => []])
+            ->assertReturnedDocumentDoesNotContainKey('bookingInfo');
+    }
+
+    /**
+     * @test
      * @dataProvider statusProvider
      */
     public function it_should_not_change_status_if_already_set_with_correct_format(array $status): void


### PR DESCRIPTION
### Changed
When one created an offer without bookingInfo, it does not contain a bookingInfo Node in the Json.
But when you would remove it (empty put) it stayed as an empty array.
Changed so the array is removed when empty from the projector.

---
Ticket: https://jira.uitdatabank.be/browse/III-5763
