### PR TITLE
III-5753 Handle organizer with missing id

### DIFF
--- a/src/Model/Serializer/Organizer/OrganizerDenormalizer.php
+++ b/src/Model/Serializer/Organizer/OrganizerDenormalizer.php
@@ -110,6 +110,10 @@ class OrganizerDenormalizer implements DenormalizerInterface
             throw new UnsupportedException('Organizer data should be an associative array.');
         }
 
+        if (!isset($data['@id'])) {
+            throw new UnsupportedException('Organizer data should contain an @id property.');
+        }
+
         $idUrl = new Url($data['@id']);
         $id = $this->organizerIDParser->fromUrl($idUrl);
 

--- a/src/Model/Serializer/Organizer/OrganizerReferenceDenormalizer.php
+++ b/src/Model/Serializer/Organizer/OrganizerReferenceDenormalizer.php
@@ -29,6 +29,10 @@ class OrganizerReferenceDenormalizer implements DenormalizerInterface
             throw new UnsupportedException('Organizer data should be an associative array.');
         }
 
+        if (!isset($data['@id'])) {
+            throw new UnsupportedException('Organizer data should contain an @id property.');
+        }
+
         $organizerIdUrl = new Url($data['@id']);
         $organizerId = $this->organizerIDParser->fromUrl($organizerIdUrl);
 

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -1825,6 +1825,54 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
+    public function it_handles_missing_organizer_reference_id(): void
+    {
+        $eventData = [
+            '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
+            '@type' => 'Event',
+            '@context' => '/contexts/event',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Titel voorbeeld',
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.be/place/dbe91250-4e4b-495c-b692-3da9563b0d52',
+            ],
+            'organizer' => [
+                'id' => 'https://io.uitdatabank.be/organizers/236f736e-5308-4c3a-94f3-da0bd768da7d',
+            ],
+            'calendarType' => 'permanent',
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.1',
+                ],
+            ],
+        ];
+
+        $expected = new ImmutableEvent(
+            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
+            new Language('nl'),
+            new TranslatedTitle(
+                new Language('nl'),
+                new Title('Titel voorbeeld')
+            ),
+            new PermanentCalendar(new OpeningHours()),
+            PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
+            new Categories(
+                new Category(
+                    new CategoryID('0.50.1.0.1')
+                )
+            )
+        );
+
+        $actual = $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_throw_an_exception_when_trying_to_denormalize_to_an_unsupported_class(): void
     {
         $this->expectException(UnsupportedException::class);

--- a/tests/Model/Serializer/Organizer/OrganizerDenormalizerTest.php
+++ b/tests/Model/Serializer/Organizer/OrganizerDenormalizerTest.php
@@ -320,4 +320,24 @@ class OrganizerDenormalizerTest extends TestCase
             $this->denormalizer->supportsDenormalization([], ImmutableOrganizer::class)
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_throws_an_exception_when_id_is_missing(): void
+    {
+        $organizerData = [
+            '@type' => 'Organizer',
+            '@context' => '/contexts/organizer',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Titel voorbeeld',
+            ],
+        ];
+
+        $this->expectException(UnsupportedException::class);
+        $this->expectExceptionMessage('Organizer data should contain an @id property.');
+
+        $this->denormalizer->denormalize($organizerData, ImmutableOrganizer::class);
+    }
 }

--- a/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
+++ b/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
@@ -971,6 +971,128 @@ class PlaceDenormalizerTest extends TestCase
     /**
      * @test
      */
+    public function it_handles_place_with_invalid_organizer_id(): void
+    {
+        $placeData = [
+            '@id' => 'https://io.uitdatabank.be/place/9f34efc7-a528-4ea8-a53e-a183f21abbab',
+            '@type' => 'Place',
+            '@context' => '/contexts/place',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Titel voorbeeld',
+            ],
+            'address' => [
+                'nl' => [
+                    'streetAddress' => 'Henegouwenkaai 41-43',
+                    'postalCode' => '1080',
+                    'addressLocality' => 'Brussel',
+                    'addressCountry' => 'BE',
+                ],
+            ],
+            'calendarType' => 'permanent',
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.1',
+                ],
+            ],
+            'organizer' => [
+                '@id' => 'Invalid id',
+            ],
+        ];
+
+        $expected = new ImmutablePlace(
+            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
+            new Language('nl'),
+            new TranslatedTitle(
+                new Language('nl'),
+                new Title('Titel voorbeeld')
+            ),
+            new PermanentCalendar(new OpeningHours()),
+            new TranslatedAddress(
+                new Language('nl'),
+                new Address(
+                    new Street('Henegouwenkaai 41-43'),
+                    new PostalCode('1080'),
+                    new Locality('Brussel'),
+                    new CountryCode('BE')
+                )
+            ),
+            new Categories(
+                new Category(
+                    new CategoryID('0.50.1.0.1')
+                )
+            )
+        );
+
+        $actual = $this->denormalizer->denormalize($placeData, ImmutablePlace::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_place_with_organizer_with_missing_id(): void
+    {
+        $placeData = [
+            '@id' => 'https://io.uitdatabank.be/place/9f34efc7-a528-4ea8-a53e-a183f21abbab',
+            '@type' => 'Place',
+            '@context' => '/contexts/place',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Titel voorbeeld',
+            ],
+            'address' => [
+                'nl' => [
+                    'streetAddress' => 'Henegouwenkaai 41-43',
+                    'postalCode' => '1080',
+                    'addressLocality' => 'Brussel',
+                    'addressCountry' => 'BE',
+                ],
+            ],
+            'calendarType' => 'permanent',
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.1',
+                ],
+            ],
+            'organizer' => [
+                'id' => 'https://io.uitdatabank.be/organizers/236f736e-5308-4c3a-94f3-da0bd768da7d',
+            ],
+        ];
+
+        $expected = new ImmutablePlace(
+            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
+            new Language('nl'),
+            new TranslatedTitle(
+                new Language('nl'),
+                new Title('Titel voorbeeld')
+            ),
+            new PermanentCalendar(new OpeningHours()),
+            new TranslatedAddress(
+                new Language('nl'),
+                new Address(
+                    new Street('Henegouwenkaai 41-43'),
+                    new PostalCode('1080'),
+                    new Locality('Brussel'),
+                    new CountryCode('BE')
+                )
+            ),
+            new Categories(
+                new Category(
+                    new CategoryID('0.50.1.0.1')
+                )
+            )
+        );
+
+        $actual = $this->denormalizer->denormalize($placeData, ImmutablePlace::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_throw_an_exception_when_trying_to_denormalize_to_an_unsupported_class(): void
     {
         $this->expectException(UnsupportedException::class);


### PR DESCRIPTION
### Changed
- Handle organizers with missing id when denormalizing. This was still causing an uncaught exception because the missing value `data['@id']` was converted to `null` which was passed to the `Url` constructor which expects a `string`

---
Ticket: https://jira.uitdatabank.be/browse/III-5753
