### PR TITLE
Prevent geopunt uncaught exceptions

### DIFF
--- a/src/Address/GeopuntAddressParser.php
+++ b/src/Address/GeopuntAddressParser.php
@@ -26,7 +26,7 @@ final class GeopuntAddressParser implements AddressParser, LoggerAwareInterface
         string $apiUrlV4,
         ?ClientInterface $httpClient = null
     ) {
-        $this->httpClient = $httpClient ?? new Client();
+        $this->httpClient = $httpClient ?? Client::createWithConfig(['http_errors' => false]);
         $this->apiUrlV4 = new Uri(rtrim($apiUrlV4, '/'));
         $this->logger = new NullLogger();
     }


### PR DESCRIPTION
### Fixed
- Prevent geopunt uncaught exceptions. By default Guzzle throws HTTP errors as exceptions, but the code was written to handle the response instead
