### PR TITLE
III-5781 Handle invalid JSON during RDF creation

### DIFF
--- a/app/Event/EventRdfServiceProvider.php
+++ b/app/Event/EventRdfServiceProvider.php
@@ -6,6 +6,8 @@ namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Address\AddressParser;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use CultuurNet\UDB3\Error\LoggerFactory;
+use CultuurNet\UDB3\Error\LoggerName;
 use CultuurNet\UDB3\Event\ReadModel\RDF\RdfProjector;
 use CultuurNet\UDB3\Model\Serializer\Event\EventDenormalizer;
 use CultuurNet\UDB3\RDF\RdfServiceProvider;
@@ -34,7 +36,8 @@ final class EventRdfServiceProvider extends AbstractServiceProvider
                 RdfServiceProvider::createIriGenerator($this->container->get('config')['taxonomy']['terms']),
                 $this->container->get('event_jsonld_repository'),
                 new EventDenormalizer(),
-                $this->container->get(AddressParser::class)
+                $this->container->get(AddressParser::class),
+                LoggerFactory::create($this->getContainer(), LoggerName::forService('rdf'))
             )
         );
     }

--- a/app/Place/PlaceRdfServiceProvider.php
+++ b/app/Place/PlaceRdfServiceProvider.php
@@ -6,6 +6,8 @@ namespace CultuurNet\UDB3\Place;
 
 use CultuurNet\UDB3\Address\AddressParser;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use CultuurNet\UDB3\Error\LoggerFactory;
+use CultuurNet\UDB3\Error\LoggerName;
 use CultuurNet\UDB3\Model\Serializer\Place\PlaceDenormalizer;
 use CultuurNet\UDB3\Place\ReadModel\RDF\RdfProjector;
 use CultuurNet\UDB3\RDF\RdfServiceProvider;
@@ -33,7 +35,8 @@ final class PlaceRdfServiceProvider extends AbstractServiceProvider
                 RdfServiceProvider::createIriGenerator($this->container->get('config')['taxonomy']['terms']),
                 $this->container->get('place_jsonld_repository'),
                 new PlaceDenormalizer(),
-                $this->container->get(AddressParser::class)
+                $this->container->get(AddressParser::class),
+                LoggerFactory::create($this->getContainer(), LoggerName::forService('rdf'))
             )
         );
     }

--- a/src/Model/Serializer/Offer/OfferDenormalizer.php
+++ b/src/Model/Serializer/Offer/OfferDenormalizer.php
@@ -221,15 +221,11 @@ abstract class OfferDenormalizer implements DenormalizerInterface
     protected function denormalizeOrganizerReference(array $data, ImmutableOffer $offer): ImmutableOffer
     {
         if (isset($data['organizer'])) {
-            try {
-                $organizerReference = $this->organizerReferenceDenormalizer->denormalize(
-                    $data['organizer'],
-                    OrganizerReference::class
-                );
-                $offer = $offer->withOrganizerReference($organizerReference);
-            } catch (\InvalidArgumentException $ex) {
-                return $offer;
-            }
+            $organizerReference = $this->organizerReferenceDenormalizer->denormalize(
+                $data['organizer'],
+                OrganizerReference::class
+            );
+            $offer = $offer->withOrganizerReference($organizerReference);
         }
 
         return $offer;

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -1777,7 +1777,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_invalid_organizer_reference(): void
+    public function it_throws_on_invalid_organizer_reference(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1801,31 +1801,15 @@ class EventDenormalizerTest extends TestCase
             ],
         ];
 
-        $expected = new ImmutableEvent(
-            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
-            new Language('nl'),
-            new TranslatedTitle(
-                new Language('nl'),
-                new Title('Titel voorbeeld')
-            ),
-            new PermanentCalendar(new OpeningHours()),
-            PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
-            new Categories(
-                new Category(
-                    new CategoryID('0.50.1.0.1')
-                )
-            )
-        );
+        $this->expectException(\InvalidArgumentException::class);
 
-        $actual = $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
-
-        $this->assertEquals($expected, $actual);
+        $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
     }
 
     /**
      * @test
      */
-    public function it_handles_missing_organizer_reference_id(): void
+    public function it_throws_on_missing_organizer_reference_id(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1849,25 +1833,9 @@ class EventDenormalizerTest extends TestCase
             ],
         ];
 
-        $expected = new ImmutableEvent(
-            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
-            new Language('nl'),
-            new TranslatedTitle(
-                new Language('nl'),
-                new Title('Titel voorbeeld')
-            ),
-            new PermanentCalendar(new OpeningHours()),
-            PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
-            new Categories(
-                new Category(
-                    new CategoryID('0.50.1.0.1')
-                )
-            )
-        );
+        $this->expectException(\InvalidArgumentException::class);
 
-        $actual = $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
-
-        $this->assertEquals($expected, $actual);
+        $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
     }
 
     /**

--- a/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
+++ b/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
@@ -971,7 +971,7 @@ class PlaceDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_place_with_invalid_organizer_id(): void
+    public function it_throws_on_invalid_organizer_id(): void
     {
         $placeData = [
             '@id' => 'https://io.uitdatabank.be/place/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1000,39 +1000,15 @@ class PlaceDenormalizerTest extends TestCase
             ],
         ];
 
-        $expected = new ImmutablePlace(
-            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
-            new Language('nl'),
-            new TranslatedTitle(
-                new Language('nl'),
-                new Title('Titel voorbeeld')
-            ),
-            new PermanentCalendar(new OpeningHours()),
-            new TranslatedAddress(
-                new Language('nl'),
-                new Address(
-                    new Street('Henegouwenkaai 41-43'),
-                    new PostalCode('1080'),
-                    new Locality('Brussel'),
-                    new CountryCode('BE')
-                )
-            ),
-            new Categories(
-                new Category(
-                    new CategoryID('0.50.1.0.1')
-                )
-            )
-        );
+        $this->expectException(\InvalidArgumentException::class);
 
-        $actual = $this->denormalizer->denormalize($placeData, ImmutablePlace::class);
-
-        $this->assertEquals($expected, $actual);
+        $this->denormalizer->denormalize($placeData, ImmutablePlace::class);
     }
 
     /**
      * @test
      */
-    public function it_handles_place_with_organizer_with_missing_id(): void
+    public function it_throws_on_organizer_with_missing_id(): void
     {
         $placeData = [
             '@id' => 'https://io.uitdatabank.be/place/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1061,33 +1037,9 @@ class PlaceDenormalizerTest extends TestCase
             ],
         ];
 
-        $expected = new ImmutablePlace(
-            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
-            new Language('nl'),
-            new TranslatedTitle(
-                new Language('nl'),
-                new Title('Titel voorbeeld')
-            ),
-            new PermanentCalendar(new OpeningHours()),
-            new TranslatedAddress(
-                new Language('nl'),
-                new Address(
-                    new Street('Henegouwenkaai 41-43'),
-                    new PostalCode('1080'),
-                    new Locality('Brussel'),
-                    new CountryCode('BE')
-                )
-            ),
-            new Categories(
-                new Category(
-                    new CategoryID('0.50.1.0.1')
-                )
-            )
-        );
+        $this->expectException(\InvalidArgumentException::class);
 
-        $actual = $this->denormalizer->denormalize($placeData, ImmutablePlace::class);
-
-        $this->assertEquals($expected, $actual);
+        $this->denormalizer->denormalize($placeData, ImmutablePlace::class);
     }
 
     /**


### PR DESCRIPTION
### Added
- Added logging when JSON parsing fails during RDF creation. This approach is much more robust and handles all possible parsing exceptions. These exceptions should not occur because place and event imports have a strict JSON schema for validation, but now they occurred during an import of all events and places, which includes incorrect historical data

### Removed
- Rollback catching parsing exceptions

---
Ticket: https://jira.uitdatabank.be/browse/III-5781
