### PR TITLE
III-5703 Calendar summary sm with day

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "cakephp/chronos": "^1.3",
     "chrisboulton/php-resque": "dev-compat-1-2 as 1.2",
     "commerceguys/intl": "^0.7",
-    "cultuurnet/calendar-summary-v3": "^4.0",
+    "cultuurnet/calendar-summary-v3": "dev-III-5703-days-in-single-and-multiple",
     "cultuurnet/cdb": "~2.2.0",
     "cultuurnet/culturefeed-php": "dev-master",
     "cultuurnet/udb3-api-guard": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "cakephp/chronos": "^1.3",
     "chrisboulton/php-resque": "dev-compat-1-2 as 1.2",
     "commerceguys/intl": "^0.7",
-    "cultuurnet/calendar-summary-v3": "dev-III-5703-days-in-single-and-multiple",
+    "cultuurnet/calendar-summary-v3": "^4.0.4",
     "cultuurnet/cdb": "~2.2.0",
     "cultuurnet/culturefeed-php": "dev-master",
     "cultuurnet/udb3-api-guard": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "308de1b3b649aa063a8762f607015e3d",
+    "content-hash": "ade1f874983d7c58b61e2aad23b3394d",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -775,16 +775,16 @@
         },
         {
             "name": "cultuurnet/calendar-summary-v3",
-            "version": "dev-III-5703-days-in-single-and-multiple",
+            "version": "v4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/calendar-summary-v3.git",
-                "reference": "14e48d7d447755c46ebc643c58ea111ea1e91e98"
+                "reference": "80e07464d081471242e6c8f45176eb4d8d6a06fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/14e48d7d447755c46ebc643c58ea111ea1e91e98",
-                "reference": "14e48d7d447755c46ebc643c58ea111ea1e91e98",
+                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/80e07464d081471242e6c8f45176eb4d8d6a06fc",
+                "reference": "80e07464d081471242e6c8f45176eb4d8d6a06fc",
                 "shasum": ""
             },
             "require": {
@@ -821,9 +821,9 @@
             "description": "Library to convert cultuurnet dates to a readable summary",
             "support": {
                 "issues": "https://github.com/cultuurnet/calendar-summary-v3/issues",
-                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/III-5703-days-in-single-and-multiple"
+                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.4"
             },
-            "time": "2023-08-18T14:40:53+00:00"
+            "time": "2023-08-22T07:41:30+00:00"
         },
         {
             "name": "cultuurnet/cdb",
@@ -11153,7 +11153,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "chrisboulton/php-resque": 20,
-        "cultuurnet/calendar-summary-v3": 20,
         "cultuurnet/culturefeed-php": 20,
         "doctrine/migrations": 20,
         "publiq/udb3-json-schemas": 20

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c09dd645f4b24c8e7346ceeacceefd87",
+    "content-hash": "308de1b3b649aa063a8762f607015e3d",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -775,16 +775,16 @@
         },
         {
             "name": "cultuurnet/calendar-summary-v3",
-            "version": "v4.0.3",
+            "version": "dev-III-5703-days-in-single-and-multiple",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/calendar-summary-v3.git",
-                "reference": "bdd97cd998301bcb0468e44e24b864466f3fc60f"
+                "reference": "14e48d7d447755c46ebc643c58ea111ea1e91e98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/bdd97cd998301bcb0468e44e24b864466f3fc60f",
-                "reference": "bdd97cd998301bcb0468e44e24b864466f3fc60f",
+                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/14e48d7d447755c46ebc643c58ea111ea1e91e98",
+                "reference": "14e48d7d447755c46ebc643c58ea111ea1e91e98",
                 "shasum": ""
             },
             "require": {
@@ -821,9 +821,9 @@
             "description": "Library to convert cultuurnet dates to a readable summary",
             "support": {
                 "issues": "https://github.com/cultuurnet/calendar-summary-v3/issues",
-                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.3"
+                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/III-5703-days-in-single-and-multiple"
             },
-            "time": "2023-01-03T07:49:10+00:00"
+            "time": "2023-08-18T14:40:53+00:00"
         },
         {
             "name": "cultuurnet/cdb",
@@ -11153,6 +11153,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "chrisboulton/php-resque": 20,
+        "cultuurnet/calendar-summary-v3": 20,
         "cultuurnet/culturefeed-php": 20,
         "doctrine/migrations": 20,
         "publiq/udb3-json-schemas": 20

--- a/features/event/calendar-summary.feature
+++ b/features/event/calendar-summary.feature
@@ -16,6 +16,13 @@ Feature: Test calendar summary on events
     And the content type should be "text/plain"
     And the body should be "Van maandag 17 mei 2021 om 10:00 tot en met woensdag 19 mei 2021 om 00:00"
 
+  Scenario: Get the small text calendar summary of an event
+    Given I am not authorized
+    When I send a GET request to "%{eventUrl}/calendar-summary?format=sm&style=text"
+    Then the response status should be "200"
+    And the content type should be "text/plain"
+    And the body should be "Ma 17 mei - wo 19 mei"
+
   Scenario: Get the calendar summary of an event with legacy endpoint
     Given I am not authorized
     When I send a GET request to "%{eventUrl}/calsum"

--- a/features/place/calendar-summary.feature
+++ b/features/place/calendar-summary.feature
@@ -14,6 +14,13 @@ Feature: Test calendar summary on places
     And the content type should be "text/plain"
     And the body should be "Van zaterdag 1 januari 2022 tot en met donderdag 1 januari 2032"
 
+  Scenario: Get the small text calendar summary of a place
+    Given I am not authorized
+    When I send a GET request to "%{placeUrl}/calendar-summary?size=sm&style=text"
+    Then the response status should be "200"
+    And the content type should be "text/plain"
+    And the body should be "Tot do 1 jan 2032"
+
   Scenario: Get the calendar summary of a place with legacy endpoint
     Given I am not authorized
     When I send a GET request to "%{placeUrl}/calsum"

--- a/tests/EventExport/CalendarSummary/CalendarSummaryWithFormatterRepositoryTest.php
+++ b/tests/EventExport/CalendarSummary/CalendarSummaryWithFormatterRepositoryTest.php
@@ -105,7 +105,7 @@ final class CalendarSummaryWithFormatterRepositoryTest extends TestCase
                 'format' => Format::xs(),
             ],
             [
-                'result' => '23 sep - 7 okt',
+                'result' => 'Vr 23 sep - vr 7 okt',
                 'contentType' => ContentType::plain(),
                 'format' => Format::sm(),
             ],
@@ -129,7 +129,7 @@ final class CalendarSummaryWithFormatterRepositoryTest extends TestCase
                 'format' => Format::xs(),
             ],
             [
-                'result' => '<span class="cf-date">23 sep</span> <span class="cf-to cf-meta">-</span> <span class="cf-date">7 okt</span>',
+                'result' => '<span class="cf-weekday cf-meta">Vr</span> <span class="cf-date">23 sep</span> <span class="cf-to cf-meta">-</span> <span class="cf-weekday cf-meta">vr</span> <span class="cf-date">7 okt</span>',
                 'contentType' => ContentType::html(),
                 'format' => Format::sm(),
             ],


### PR DESCRIPTION
### Changed
- Upgrade `cultuurnet/calendar-summary-v3` to support small format with day of week

### Note
- See https://github.com/cultuurnet/calendar-summary-v3/pull/75 for the calendar summary changes

---
Ticket: https://jira.uitdatabank.be/browse/III-5703
