### PR TITLE
Prevent sentry logging

### DIFF
--- a/src/Event/ReadModel/RDF/RdfProjector.php
+++ b/src/Event/ReadModel/RDF/RdfProjector.php
@@ -101,14 +101,13 @@ final class RdfProjector implements EventListener
         $eventData = $this->fetchEventData($domainMessage);
         try {
             $event = $this->getEvent($eventData);
-        } catch (\Exception $exception) {
-            $this->logger->error(
+        } catch (\Throwable $throwable) {
             $this->logger->warning(
                 'Unable to project event ' . $eventId . ' with invalid JSON to RDF.',
                 [
                     'id' => $eventId,
                     'type' => 'event',
-                    'exception' => $exception,
+                    'exception' => $throwable,
                 ]
             );
             return;

--- a/src/Event/ReadModel/RDF/RdfProjector.php
+++ b/src/Event/ReadModel/RDF/RdfProjector.php
@@ -103,6 +103,7 @@ final class RdfProjector implements EventListener
             $event = $this->getEvent($eventData);
         } catch (\Exception $exception) {
             $this->logger->error(
+            $this->logger->warning(
                 'Unable to project event ' . $eventId . ' with invalid JSON to RDF.',
                 [
                     'id' => $eventId,

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -83,6 +83,7 @@ final class RdfProjector implements EventListener
             $place = $this->getPlace($placeData);
         } catch (\Exception $exception) {
             $this->logger->error(
+            $this->logger->warning(
                 'Unable to project place ' . $placeId . ' with invalid JSON to RDF.',
                 [
                     'id' => $placeId,

--- a/src/Place/ReadModel/RDF/RdfProjector.php
+++ b/src/Place/ReadModel/RDF/RdfProjector.php
@@ -81,14 +81,13 @@ final class RdfProjector implements EventListener
         $placeData = $this->fetchPlaceData($domainMessage);
         try {
             $place = $this->getPlace($placeData);
-        } catch (\Exception $exception) {
-            $this->logger->error(
+        } catch (\Throwable $throwable) {
             $this->logger->warning(
                 'Unable to project place ' . $placeId . ' with invalid JSON to RDF.',
                 [
                     'id' => $placeId,
                     'type' => 'place',
-                    'exception' => $exception,
+                    'exception' => $throwable,
                 ]
             );
             return;

--- a/tests/Event/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Event/ReadModel/RDF/RdfProjectorTest.php
@@ -77,7 +77,7 @@ class RdfProjectorTest extends TestCase
         $this->documentRepository->save(new JsonDocument($eventId, json_encode($event)));
 
         $this->logger->expects($this->once())
-            ->method('error')
+            ->method('warning')
             ->with('Unable to project event d4b46fba-6433-4f86-bcb5-edeef6689fea with invalid JSON to RDF.');
 
         $this->project(

--- a/tests/Place/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Place/ReadModel/RDF/RdfProjectorTest.php
@@ -98,7 +98,7 @@ class RdfProjectorTest extends TestCase
         $this->documentRepository->save(new JsonDocument($placeId, json_encode($place)));
 
         $this->logger->expects($this->once())
-            ->method('error')
+            ->method('warning')
             ->with('Unable to project place d4b46fba-6433-4f86-bcb5-edeef6689fea with invalid JSON to RDF.');
 
         $this->project(


### PR DESCRIPTION
### Changed
- Replaced `error` method `warning` method
- Catch every throwable and not only exceptions

### Note
- The error logger also posts an error to Sentry, this is not needed for failing JOSN transformations in the RDF projector
