### PR TITLE
III-5792 Use `delete` and `insert` instead of `replace` in Fuseki

### DIFF
--- a/app/Event/EventRdfServiceProvider.php
+++ b/app/Event/EventRdfServiceProvider.php
@@ -24,7 +24,8 @@ final class EventRdfServiceProvider extends AbstractServiceProvider
     public function register(): void
     {
         $graphStoreRepository = RdfServiceProvider::createGraphStoreRepository(
-            $this->container->get('config')['rdf']['eventsGraphStoreUrl']
+            $this->container->get('config')['rdf']['eventsGraphStoreUrl'],
+            $this->container->get('config')['rdf']['useDeleteAndInsert'] ?? false
         );
 
         $this->container->addShared(

--- a/app/Place/PlaceRdfServiceProvider.php
+++ b/app/Place/PlaceRdfServiceProvider.php
@@ -24,7 +24,8 @@ final class PlaceRdfServiceProvider extends AbstractServiceProvider
     public function register(): void
     {
         $graphStoreRepository = RdfServiceProvider::createGraphStoreRepository(
-            $this->container->get('config')['rdf']['placesGraphStoreUrl']
+            $this->container->get('config')['rdf']['placesGraphStoreUrl'],
+            $this->container->get('config')['rdf']['useDeleteAndInsert'] ?? false
         );
 
         $this->container->addShared(

--- a/app/RDF/RdfServiceProvider.php
+++ b/app/RDF/RdfServiceProvider.php
@@ -91,9 +91,9 @@ final class RdfServiceProvider extends AbstractServiceProvider
         );
     }
 
-    public static function createGraphStoreRepository(string $baseUri): GraphStoreRepository
+    public static function createGraphStoreRepository(string $baseUri, bool $useDeleteAndInsert): GraphStoreRepository
     {
-        return new GraphStoreRepository(new GraphStore(rtrim($baseUri, '/')));
+        return new GraphStoreRepository(new GraphStore(rtrim($baseUri, '/')), $useDeleteAndInsert);
     }
 
     public static function createIriGenerator(string $baseUri): IriGeneratorInterface

--- a/src/RDF/GraphStoreRepository.php
+++ b/src/RDF/GraphStoreRepository.php
@@ -12,15 +12,26 @@ final class GraphStoreRepository implements GraphRepository
 {
     private const GRAPH_URI_SUFFIX = '.ttl';
     private GraphStore $graphStore;
+    private bool $useDeleteAndInsert;
 
-    public function __construct(GraphStore $graphStore)
+    public function __construct(GraphStore $graphStore, bool $useDeleteAndInsert)
     {
         $this->graphStore = $graphStore;
+        $this->useDeleteAndInsert = $useDeleteAndInsert;
     }
 
     public function save(string $uri, Graph $graph): void
     {
-        $this->graphStore->replace($graph, $this->appendSuffix($uri));
+        if (!$this->useDeleteAndInsert) {
+            $this->graphStore->replace($graph, $this->appendSuffix($uri));
+            return;
+        }
+
+        try {
+            $this->graphStore->delete($this->appendSuffix($uri));
+        } catch (\Exception $e) {
+        }
+        $this->graphStore->insert($graph, $this->appendSuffix($uri));
     }
 
     public function get(string $uri): Graph


### PR DESCRIPTION
### Changed
- Refactored `save` from GraphStore to use `delete` and `insert`

### Note
- Requires https://github.com/cultuurnet/appconfig/pull/413 to become active

---
Ticket: https://jira.uitdatabank.be/browse/III-5792
