### PR TITLE
III-5800 Add RDF projection for organizer

### DIFF
--- a/app/Organizer/OrganizerRdfServiceProvider.php
+++ b/app/Organizer/OrganizerRdfServiceProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer;
+
+use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use CultuurNet\UDB3\Error\LoggerFactory;
+use CultuurNet\UDB3\Error\LoggerName;
+use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
+use CultuurNet\UDB3\Organizer\ReadModel\RDF\RdfProjector;
+use CultuurNet\UDB3\RDF\RdfServiceProvider;
+
+final class OrganizerRdfServiceProvider extends AbstractServiceProvider
+{
+    protected function getProvidedServiceNames(): array
+    {
+        return [
+            RdfProjector::class,
+        ];
+    }
+
+    public function register(): void
+    {
+        $graphStoreRepository = RdfServiceProvider::createGraphStoreRepository(
+            $this->container->get('config')['rdf']['organizersGraphStoreUrl'],
+            $this->container->get('config')['rdf']['useDeleteAndInsert'] ?? false
+        );
+
+        $this->container->addShared(
+            RdfProjector::class,
+            fn (): RdfProjector => new RdfProjector(
+                $graphStoreRepository,
+                RdfServiceProvider::createIriGenerator($this->container->get('config')['rdf']['organizersRdfBaseUri']),
+                $this->container->get('organizer_jsonld_repository'),
+                new OrganizerDenormalizer(),
+                LoggerFactory::create($this->getContainer(), LoggerName::forService('rdf'))
+            )
+        );
+    }
+}

--- a/app/RDF/RdfServiceProvider.php
+++ b/app/RDF/RdfServiceProvider.php
@@ -17,6 +17,8 @@ use CultuurNet\UDB3\Event\Events\EventProjectedToJSONLD;
 use CultuurNet\UDB3\Event\ReadModel\RDF\RdfProjector as EventRdfProjector;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Organizer\OrganizerProjectedToJSONLD;
+use CultuurNet\UDB3\Organizer\ReadModel\RDF\RdfProjector as OrganizerRdfProjector;
 use CultuurNet\UDB3\Place\Events\PlaceProjectedToJSONLD;
 use CultuurNet\UDB3\Place\ReadModel\RDF\RdfProjector as PlaceRdfProjector;
 use CultuurNet\UDB3\StringLiteral;
@@ -57,6 +59,7 @@ final class RdfServiceProvider extends AbstractServiceProvider
                 if (($this->container->get('config')['rdf']['enabled'] ?? false) === true) {
                     $eventBus->subscribe($this->container->get(PlaceRdfProjector::class));
                     $eventBus->subscribe($this->container->get(EventRdfProjector::class));
+                    $eventBus->subscribe($this->container->get(OrganizerRdfProjector::class));
                 }
 
                 $deserializerLocator = new SimpleDeserializerLocator();
@@ -65,6 +68,8 @@ final class RdfServiceProvider extends AbstractServiceProvider
                         'application/vnd.cultuurnet.udb3-events.event-projected-to-jsonld+json',
                     PlaceProjectedToJSONLD::class =>
                         'application/vnd.cultuurnet.udb3-events.place-projected-to-jsonld+json',
+                    OrganizerProjectedToJSONLD::class =>
+                        'application/vnd.cultuurnet.udb3-events.organizer-projected-to-jsonld+json',
                 ];
                 foreach ($deserializerMapping as $payloadClass => $contentType) {
                     $deserializerLocator->registerDeserializer(

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -39,6 +39,7 @@ use CultuurNet\UDB3\Organizer\OrganizerCommandHandlerProvider;
 use CultuurNet\UDB3\Organizer\OrganizerGeoCoordinatesServiceProvider;
 use CultuurNet\UDB3\Organizer\OrganizerJSONLDServiceProvider;
 use CultuurNet\UDB3\Organizer\OrganizerPermissionServiceProvider;
+use CultuurNet\UDB3\Organizer\OrganizerRdfServiceProvider;
 use CultuurNet\UDB3\Organizer\OrganizerRequestHandlerServiceProvider;
 use CultuurNet\UDB3\Organizer\OrganizerServiceProvider;
 use CultuurNet\UDB3\Place\PlaceEditingServiceProvider;
@@ -205,6 +206,7 @@ RdfNamespaces::register();
 $container->addServiceProvider(new RdfServiceProvider());
 $container->addServiceProvider(new PlaceRdfServiceProvider());
 $container->addServiceProvider(new EventRdfServiceProvider());
+$container->addServiceProvider(new OrganizerRdfServiceProvider());
 
 if (isset($container->get('config')['bookable_event']['dummy_place_ids'])) {
     LocationId::setDummyPlaceForEducationIds($container->get('config')['bookable_event']['dummy_place_ids']);

--- a/features/Steps/OrganizerSteps.php
+++ b/features/Steps/OrganizerSteps.php
@@ -91,6 +91,18 @@ trait OrganizerSteps
     }
 
     /**
+     * @When I get the RDF of organizer with id :id
+     */
+    public function iGetTheRdfOfOrganizerWithId(string $id): void
+    {
+        $this->responseState->setResponse(
+            $this->getHttpClient()->getWithTimeout('/organizers/' . $id)
+        );
+
+        $this->theResponseStatusShouldBe(200);
+    }
+
+    /**
      * @When I delete the organizer at :url
      */
     public function iDeleteTheOrganizerAt(string $url): void

--- a/features/data/organizers/rdf/organizer.ttl
+++ b/features/data/organizers/rdf/organizer.ttl
@@ -1,0 +1,18 @@
+<http://host.docker.internal:8080/organizers/%{organizerId}>
+        a       <https://data.vlaanderen.be/ns/cultuurparticipatie#Organisator> ;
+        <http://purl.org/dc/terms/created>
+                "2023-09-07T10:22:16+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        <http://purl.org/dc/terms/modified>
+                "2023-09-07T10:22:16+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        <http://www.w3.org/ns/adms#identifier>
+                [ a       <http://www.w3.org/ns/adms#Identifier> ;
+                  <http://www.w3.org/2004/02/skos/core#notation>
+                          "http://host.docker.internal:8080/organizers/%{organizerId}"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
+                  <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>
+                          [ a       <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+                            <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator>
+                                    "%{organizerId}" ;
+                            <https://data.vlaanderen.be/ns/generiek#naamruimte>
+                                    "http://host.docker.internal:8080/organizers/"
+                          ]
+                ] .

--- a/features/organizer/rdf.feature
+++ b/features/organizer/rdf.feature
@@ -1,0 +1,14 @@
+Feature: Test RDF projection of organizers
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I send and accept "application/json"
+
+  Scenario: Create an organizer with only the required fields
+    Given I create an organizer from "organizers/organizer-minimal.json" and save the "id" as "organizerId"
+    And I am using the RDF base URL
+    And I accept "text/turtle"
+    When I get the RDF of organizer with id "%{organizerId}"
+    Then the RDF response should match "organizers/rdf/organizer.ttl"

--- a/src/Organizer/ReadModel/RDF/RdfProjector.php
+++ b/src/Organizer/ReadModel/RDF/RdfProjector.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\ReadModel\RDF;
+
+use Broadway\Domain\DomainMessage;
+use Broadway\EventHandling\EventListener;
+use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Model\Organizer\ImmutableOrganizer;
+use CultuurNet\UDB3\Model\Organizer\Organizer;
+use CultuurNet\UDB3\Organizer\OrganizerProjectedToJSONLD;
+use CultuurNet\UDB3\RDF\Editor\GraphEditor;
+use CultuurNet\UDB3\RDF\GraphRepository;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use DateTime;
+use EasyRdf\Graph;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class RdfProjector implements EventListener
+{
+    private GraphRepository $graphRepository;
+    private IriGeneratorInterface $iriGenerator;
+    private DocumentRepository $documentRepository;
+    private DenormalizerInterface $organizerDenormalizer;
+    private LoggerInterface $logger;
+
+    private const TYPE_ORGANISATOR = 'cp:Organisator';
+
+    public function __construct(
+        GraphRepository $graphRepository,
+        IriGeneratorInterface $iriGenerator,
+        DocumentRepository $documentRepository,
+        DenormalizerInterface $organizerDenormalizer,
+        LoggerInterface $logger
+    ) {
+        $this->graphRepository = $graphRepository;
+        $this->iriGenerator = $iriGenerator;
+        $this->documentRepository = $documentRepository;
+        $this->organizerDenormalizer = $organizerDenormalizer;
+        $this->logger = $logger;
+    }
+
+    public function handle(DomainMessage $domainMessage): void
+    {
+        if (get_class($domainMessage->getPayload()) !== OrganizerProjectedToJSONLD::class) {
+            return;
+        }
+
+        $organizerId = $domainMessage->getPayload()->getId();
+        $iri = $this->iriGenerator->iri($organizerId);
+        $graph = new Graph($iri);
+        $resource = $graph->resource($iri);
+
+        $organizerData = $this->fetchOrganizerData($domainMessage);
+        try {
+            $organizer = $this->getOrganizer($organizerData);
+        } catch (\Throwable $throwable) {
+            $this->logger->warning(
+                'Unable to project organizer ' . $organizerId . ' with invalid JSON to RDF.',
+                [
+                    'id' => $organizerId,
+                    'type' => 'organizer',
+                    'exception' => $throwable,
+                ]
+            );
+            return;
+        }
+
+        GraphEditor::for($graph)->setGeneralProperties(
+            $iri,
+            self::TYPE_ORGANISATOR,
+            DateTimeFactory::fromISO8601($organizerData['created'])->format(DateTime::ATOM),
+            $domainMessage->getRecordedOn()->toNative()->format(DateTime::ATOM)
+        );
+
+        $this->graphRepository->save($iri, $graph);
+    }
+
+    private function fetchOrganizerData(DomainMessage $domainMessage): array
+    {
+        $organizerId = $domainMessage->getPayload()->getId();
+        $organizerDocument = $this->documentRepository->fetch($organizerId);
+
+        return $organizerDocument->getAssocBody();
+    }
+
+    private function getOrganizer(array $organizerData): Organizer
+    {
+        /** @var ImmutableOrganizer $organizer */
+        $organizer = $this->organizerDenormalizer->denormalize($organizerData, Organizer::class);
+        return $organizer;
+    }
+}

--- a/tests/Organizer/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Organizer/ReadModel/RDF/RdfProjectorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\ReadModel\RDF;
+
+use Broadway\Domain\DateTime as BroadwayDateTime;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Iri\CallableIriGenerator;
+use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
+use CultuurNet\UDB3\Organizer\OrganizerProjectedToJSONLD;
+use CultuurNet\UDB3\RDF\GraphRepository;
+use CultuurNet\UDB3\RDF\InMemoryGraphRepository;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use DateTime;
+use EasyRdf\Serialiser\Turtle;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class RdfProjectorTest extends TestCase
+{
+    private GraphRepository $graphRepository;
+
+    private DocumentRepository $documentRepository;
+
+    private RdfProjector $rdfProjector;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->graphRepository = new InMemoryGraphRepository();
+        $this->documentRepository = new InMemoryDocumentRepository();
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->rdfProjector = new RdfProjector(
+            $this->graphRepository,
+            new CallableIriGenerator(fn (string $item): string => 'https://mock.data.publiq.be/organizers/' . $item),
+            $this->documentRepository,
+            new OrganizerDenormalizer(),
+            $this->logger
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_a_simple_organizer(): void
+    {
+        $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';
+
+        $organizer = [
+            '@id' => 'https://mock.io.uitdatabank.be/organizers/' . $organizerId,
+            'mainLanguage' => 'nl',
+            'url' => 'https://www.publiq.be',
+            'name' => [
+                'nl' => 'publiq',
+            ],
+            'created' => '2023-01-01T12:30:15+01:00',
+        ];
+
+        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+
+        $this->project(
+            $organizerId,
+            [
+                new OrganizerProjectedToJSONLD($organizerId, 'https://mock.io.uitdatabank.be/organizer/' . $organizerId),
+            ]
+        );
+
+        $this->assertTurtleData($organizerId, file_get_contents(__DIR__ . '/ttl/organizer.ttl'));
+    }
+
+    private function project(string $organizerId, array $events): void
+    {
+        $playhead = -1;
+        $recordedOn = new DateTime('2022-12-31T12:30:15+01:00');
+        foreach ($events as $event) {
+            $playhead++;
+            $recordedOn->modify('+1 day');
+            $domainMessage = new DomainMessage(
+                $organizerId,
+                $playhead,
+                new Metadata(),
+                $event,
+                BroadwayDateTime::fromString($recordedOn->format(DateTime::ATOM))
+            );
+            $this->rdfProjector->handle($domainMessage);
+        }
+    }
+
+    private function assertTurtleData(string $placeId, string $expectedTurtleData): void
+    {
+        $uri = 'https://mock.data.publiq.be/organizers/' . $placeId;
+        $actualTurtleData = (new Turtle())->serialise($this->graphRepository->get($uri), 'turtle');
+        $this->assertEquals(trim($expectedTurtleData), trim($actualTurtleData));
+    }
+}

--- a/tests/Organizer/ReadModel/RDF/ttl/organizer.ttl
+++ b/tests/Organizer/ReadModel/RDF/ttl/organizer.ttl
@@ -1,0 +1,20 @@
+@prefix cp: <https://data.vlaanderen.be/ns/cultuurparticipatie#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+
+<https://mock.data.publiq.be/organizers/56f1efdb-fe25-44f6-b9d7-4a6a836799d7>
+  a cp:Organisator ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/organizers/56f1efdb-fe25-44f6-b9d7-4a6a836799d7"^^xsd:anyURI ;
+    generiek:gestructureerdeIdentificator [
+      a generiek:GestructureerdeIdentificator ;
+      generiek:naamruimte "https://mock.data.publiq.be/organizers/" ;
+      generiek:lokaleIdentificator "56f1efdb-fe25-44f6-b9d7-4a6a836799d7"
+    ]
+  ] .


### PR DESCRIPTION
### Added
- Added RDF projector for organizers which projects the identifier, created and modified
- Subscribed to `OrganizerProjectedToJSONLD`

### Note
- Related config changes https://github.com/cultuurnet/appconfig/pull/425

---
Ticket: https://jira.uitdatabank.be/browse/III-5800
