### PR TITLE
III-3853 StringLiteral cleanup security

### DIFF
--- a/app/Console/Command/ChangeOfferOwnerInBulk.php
+++ b/app/Console/Command/ChangeOfferOwnerInBulk.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
-use CultuurNet\UDB3\StringLiteral;
 
 class ChangeOfferOwnerInBulk extends AbstractCommand
 {
@@ -54,7 +53,7 @@ class ChangeOfferOwnerInBulk extends AbstractCommand
 
         $success = 0;
         $errors = 0;
-        foreach ($this->permissionQuery->getEditableResourceIds(new StringLiteral($originalOwnerId)) as $editableOffer) {
+        foreach ($this->permissionQuery->getEditableResourceIds($originalOwnerId) as $editableOffer) {
             $offerId = $editableOffer->toNative();
             try {
                 $this->commandBus->dispatch(

--- a/app/Console/Command/ChangeOfferOwnerInBulk.php
+++ b/app/Console/Command/ChangeOfferOwnerInBulk.php
@@ -13,12 +13,9 @@ use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
-class ChangeOfferOwnerInBulk extends AbstractCommand
+final class ChangeOfferOwnerInBulk extends AbstractCommand
 {
-    /**
-     * @var ResourceOwnerQuery
-     */
-    private $permissionQuery;
+    private ResourceOwnerQuery $permissionQuery;
 
     public function __construct(
         CommandBus $commandBus,

--- a/app/Console/Command/ChangeOfferOwnerInBulk.php
+++ b/app/Console/Command/ChangeOfferOwnerInBulk.php
@@ -54,7 +54,7 @@ class ChangeOfferOwnerInBulk extends AbstractCommand
         $success = 0;
         $errors = 0;
         foreach ($this->permissionQuery->getEditableResourceIds($originalOwnerId) as $editableOffer) {
-            $offerId = $editableOffer->toNative();
+            $offerId = $editableOffer;
             try {
                 $this->commandBus->dispatch(
                     new ChangeOwner(

--- a/app/Console/Command/ChangeOrganizerOwnerInBulk.php
+++ b/app/Console/Command/ChangeOrganizerOwnerInBulk.php
@@ -51,7 +51,7 @@ final class ChangeOrganizerOwnerInBulk extends AbstractCommand
         $success = 0;
         $errors = 0;
         foreach ($this->permissionQuery->getEditableResourceIds($originalOwnerId) as $editableOrganizers) {
-            $organizerId = $editableOrganizers->toNative();
+            $organizerId = $editableOrganizers;
             try {
                 $this->commandBus->dispatch(
                     new ChangeOwner(

--- a/app/Console/Command/ChangeOrganizerOwnerInBulk.php
+++ b/app/Console/Command/ChangeOrganizerOwnerInBulk.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Console\Command;
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Organizer\Commands\ChangeOwner;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
-use CultuurNet\UDB3\StringLiteral;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
@@ -51,7 +50,7 @@ final class ChangeOrganizerOwnerInBulk extends AbstractCommand
 
         $success = 0;
         $errors = 0;
-        foreach ($this->permissionQuery->getEditableResourceIds(new StringLiteral($originalOwnerId)) as $editableOrganizers) {
+        foreach ($this->permissionQuery->getEditableResourceIds($originalOwnerId) as $editableOrganizers) {
             $organizerId = $editableOrganizers->toNative();
             try {
                 $this->commandBus->dispatch(

--- a/app/Event/EventPermissionServiceProvider.php
+++ b/app/Event/EventPermissionServiceProvider.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Event;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Event\ReadModel\Permission\Projector;
 use CultuurNet\UDB3\Security\ResourceOwner\Doctrine\DBALResourceOwnerRepository;
-use CultuurNet\UDB3\StringLiteral;
 
 final class EventPermissionServiceProvider extends AbstractServiceProvider
 {
@@ -27,9 +26,9 @@ final class EventPermissionServiceProvider extends AbstractServiceProvider
             'event_owner.repository',
             function () use ($container): DBALResourceOwnerRepository {
                 return new DBALResourceOwnerRepository(
-                    new StringLiteral('event_permission_readmodel'),
+                    'event_permission_readmodel',
                     $container->get('dbal_connection'),
-                    new StringLiteral('event_id')
+                    'event_id'
                 );
             }
         );

--- a/app/Organizer/OrganizerPermissionServiceProvider.php
+++ b/app/Organizer/OrganizerPermissionServiceProvider.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Organizer;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Organizer\ReadModel\Permission\Projector;
 use CultuurNet\UDB3\Security\ResourceOwner\Doctrine\DBALResourceOwnerRepository;
-use CultuurNet\UDB3\StringLiteral;
 
 final class OrganizerPermissionServiceProvider extends AbstractServiceProvider
 {
@@ -29,9 +28,9 @@ final class OrganizerPermissionServiceProvider extends AbstractServiceProvider
             'organizer_owner.repository',
             function () use ($container) {
                 return new DBALResourceOwnerRepository(
-                    new StringLiteral('organizer_permission_readmodel'),
+                    'organizer_permission_readmodel',
                     $container->get('dbal_connection'),
-                    new StringLiteral('organizer_id')
+                    'organizer_id'
                 );
             }
         );

--- a/app/Place/PlacePermissionServiceProvider.php
+++ b/app/Place/PlacePermissionServiceProvider.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Place;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Security\ResourceOwner\Doctrine\DBALResourceOwnerRepository;
 use CultuurNet\UDB3\Place\ReadModel\Permission\Projector;
-use CultuurNet\UDB3\StringLiteral;
 
 final class PlacePermissionServiceProvider extends AbstractServiceProvider
 {
@@ -27,9 +26,9 @@ final class PlacePermissionServiceProvider extends AbstractServiceProvider
             'place_owner.repository',
             function () use ($container) {
                 return new DBALResourceOwnerRepository(
-                    new StringLiteral('place_permission_readmodel'),
+                    'place_permission_readmodel',
                     $container->get('dbal_connection'),
-                    new StringLiteral('place_id')
+                    'place_id'
                 );
             }
         );

--- a/src/CommandHandling/AuthorizedCommandBus.php
+++ b/src/CommandHandling/AuthorizedCommandBus.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Security\CommandAuthorizationException;
 use CultuurNet\UDB3\Security\CommandBusSecurity;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
-use CultuurNet\UDB3\StringLiteral;
 
 class AuthorizedCommandBus extends CommandBusDecoratorBase implements AuthorizedCommandBusInterface, LoggerAwareInterface, ContextAwareInterface
 {
@@ -44,7 +43,7 @@ class AuthorizedCommandBus extends CommandBusDecoratorBase implements Authorized
             parent::dispatch($command);
         } else {
             throw new CommandAuthorizationException(
-                new StringLiteral($this->userId),
+                $this->userId,
                 $command
             );
         }

--- a/src/CommandHandling/ResqueCommandBus.php
+++ b/src/CommandHandling/ResqueCommandBus.php
@@ -12,7 +12,6 @@ use Psr\Log\LoggerAwareTrait;
 use Broadway\Domain\Metadata;
 use Broadway\EventDispatcher\EventDispatcher;
 use Psr\Log\LoggerInterface;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Command bus decorator for asynchronous processing with PHP-Resque.
@@ -72,7 +71,7 @@ class ResqueCommandBus extends CommandBusDecoratorBase implements ContextAwareIn
             $command instanceof AuthorizableCommand) {
             if (!$this->decoratee->isAuthorized($command)) {
                 throw new CommandAuthorizationException(
-                    new StringLiteral($this->decoratee->getUserId()),
+                    $this->decoratee->getUserId(),
                     $command
                 );
             }

--- a/src/Contributor/ContributorEnrichedRepository.php
+++ b/src/Contributor/ContributorEnrichedRepository.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Security\Permission\PermissionVoter;
-use CultuurNet\UDB3\StringLiteral;
 
 final class ContributorEnrichedRepository extends DocumentRepositoryDecorator
 {
@@ -74,8 +73,8 @@ final class ContributorEnrichedRepository extends DocumentRepositoryDecorator
         return $this->currentUserId !== null &&
             $this->permissionVoter->isAllowed(
                 Permission::aanbodBewerken(),
-                new StringLiteral($id),
-                new StringLiteral($this->currentUserId)
+                $id,
+                $this->currentUserId
             );
     }
 }

--- a/src/Event/ReadModel/Permission/Projector.php
+++ b/src/Event/ReadModel/Permission/Projector.php
@@ -75,8 +75,8 @@ class Projector implements EventListener
     protected function applyOwnerChanged(OwnerChanged $ownerChanged): void
     {
         $this->permissionRepository->markResourceEditableByNewUser(
-            new StringLiteral($ownerChanged->getOfferId()),
-            new StringLiteral($ownerChanged->getNewOwnerId())
+            $ownerChanged->getOfferId(),
+            $ownerChanged->getNewOwnerId()
         );
     }
 

--- a/src/Event/ReadModel/Permission/Projector.php
+++ b/src/Event/ReadModel/Permission/Projector.php
@@ -52,8 +52,8 @@ class Projector implements EventListener
             }
 
             $this->permissionRepository->markResourceEditableByUser(
-                new StringLiteral($eventImportedFromUDB2->getEventId()),
-                $ownerId
+                $eventImportedFromUDB2->getEventId(),
+                $ownerId->toNative()
             );
         }
     }
@@ -85,10 +85,10 @@ class Projector implements EventListener
         DomainMessage $domainMessage
     ): void {
         $metadata = $domainMessage->getMetadata()->serialize();
-        $ownerId = new StringLiteral($metadata['user_id']);
+        $ownerId = $metadata['user_id'];
 
         $this->permissionRepository->markResourceEditableByUser(
-            new StringLiteral($offerId),
+            $offerId,
             $ownerId
         );
     }

--- a/src/Event/ReadModel/Permission/Projector.php
+++ b/src/Event/ReadModel/Permission/Projector.php
@@ -16,7 +16,7 @@ use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
 use CultuurNet\UDB3\StringLiteral;
 
-class Projector implements EventListener
+final class Projector implements EventListener
 {
     use DelegateEventHandlingToSpecificMethodTrait;
 

--- a/src/Http/ApiProblem/ApiProblemFactory.php
+++ b/src/Http/ApiProblem/ApiProblemFactory.php
@@ -52,7 +52,7 @@ final class ApiProblemFactory
                 return ApiProblem::forbidden(
                     sprintf(
                         'User %s has no permission "%s" on resource %s',
-                        $e->getUserId()->toNative(),
+                        $e->getUserId(),
                         $e->getCommand()->getPermission()->toString(),
                         $e->getCommand()->getItemId()
                     )

--- a/src/Http/Offer/GetContributorsRequestHandler.php
+++ b/src/Http/Offer/GetContributorsRequestHandler.php
@@ -14,7 +14,6 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Offer\OfferRepository;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Security\Permission\PermissionVoter;
-use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -56,8 +55,8 @@ final class GetContributorsRequestHandler implements RequestHandlerInterface
         if (
             !$this->permissionVoter->isAllowed(
                 Permission::aanbodBewerken(),
-                new StringLiteral($offerId),
-                new StringLiteral($this->currentUserId)
+                $offerId,
+                $this->currentUserId
             )
         ) {
             throw ApiProblem::forbidden(

--- a/src/Http/Organizer/GetContributorsRequestHandler.php
+++ b/src/Http/Organizer/GetContributorsRequestHandler.php
@@ -14,7 +14,6 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Organizer\OrganizerRepository;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Security\Permission\PermissionVoter;
-use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -55,8 +54,8 @@ final class GetContributorsRequestHandler implements RequestHandlerInterface
         if (
             !$this->permissionVoter->isAllowed(
                 Permission::aanbodBewerken(),
-                new StringLiteral($organizerId),
-                new StringLiteral($this->currentUserId)
+                $organizerId,
+                $this->currentUserId
             )
         ) {
             throw ApiProblem::forbidden(

--- a/src/Offer/CommandHandlers/ChangeOwnerHandler.php
+++ b/src/Offer/CommandHandlers/ChangeOwnerHandler.php
@@ -43,9 +43,7 @@ final class ChangeOwnerHandler implements CommandHandler
         // doesn't pass that info to the applyEventCreated() etc methods.
         $offersOwnedByNewOwner = $this->permissionQuery->getEditableResourceIds($newOwnerId);
 
-        // Don't use strict comparison here in in_array because getEditableOffers() returns StringLiterals. They will
-        // get cast to strings automatically when comparing.
-        if (!in_array($offerId, $offersOwnedByNewOwner, false)) {
+        if (!in_array($offerId, $offersOwnedByNewOwner)) {
             $offer = $this->offerRepository->load($command->getOfferId());
             $offer->changeOwner($command->getNewOwnerId());
             $this->offerRepository->save($offer);

--- a/src/Offer/CommandHandlers/ChangeOwnerHandler.php
+++ b/src/Offer/CommandHandlers/ChangeOwnerHandler.php
@@ -11,15 +11,9 @@ use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
 
 final class ChangeOwnerHandler implements CommandHandler
 {
-    /**
-     * @var OfferRepository
-     */
-    private $offerRepository;
+    private OfferRepository $offerRepository;
 
-    /**
-     * @var ResourceOwnerQuery
-     */
-    private $permissionQuery;
+    private ResourceOwnerQuery $permissionQuery;
 
     public function __construct(
         OfferRepository $offerRepository,

--- a/src/Offer/CommandHandlers/ChangeOwnerHandler.php
+++ b/src/Offer/CommandHandlers/ChangeOwnerHandler.php
@@ -8,7 +8,6 @@ use Broadway\CommandHandling\CommandHandler;
 use CultuurNet\UDB3\Offer\Commands\ChangeOwner;
 use CultuurNet\UDB3\Offer\OfferRepository;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
-use CultuurNet\UDB3\StringLiteral;
 
 final class ChangeOwnerHandler implements CommandHandler
 {
@@ -42,7 +41,7 @@ final class ChangeOwnerHandler implements CommandHandler
         // The aggregate cannot check who was the initial owner, because that's stored in the metadata (!) of the
         // EventCreated/PlaceCreated/EventImportedFromUDB2/PlaceImportedFromUDB2 events and the base class of broadway
         // doesn't pass that info to the applyEventCreated() etc methods.
-        $offersOwnedByNewOwner = $this->permissionQuery->getEditableResourceIds(new StringLiteral($newOwnerId));
+        $offersOwnedByNewOwner = $this->permissionQuery->getEditableResourceIds($newOwnerId);
 
         // Don't use strict comparison here in in_array because getEditableOffers() returns StringLiterals. They will
         // get cast to strings automatically when comparing.

--- a/src/Organizer/ReadModel/Permission/Projector.php
+++ b/src/Organizer/ReadModel/Permission/Projector.php
@@ -81,8 +81,8 @@ class Projector implements EventListener
     protected function applyOwnerChanged(OwnerChanged $ownerChanged): void
     {
         $this->permissionRepository->markResourceEditableByNewUser(
-            new StringLiteral($ownerChanged->getOrganizerId()),
-            new StringLiteral($ownerChanged->getNewOwnerId())
+            $ownerChanged->getOrganizerId(),
+            $ownerChanged->getNewOwnerId()
         );
     }
 

--- a/src/Organizer/ReadModel/Permission/Projector.php
+++ b/src/Organizer/ReadModel/Permission/Projector.php
@@ -16,7 +16,7 @@ use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
 use CultuurNet\UDB3\Organizer\Events\OrganizerImportedFromUDB2;
 use CultuurNet\UDB3\StringLiteral;
 
-class Projector implements EventListener
+final class Projector implements EventListener
 {
     use DelegateEventHandlingToSpecificMethodTrait;
 

--- a/src/Organizer/ReadModel/Permission/Projector.php
+++ b/src/Organizer/ReadModel/Permission/Projector.php
@@ -52,8 +52,8 @@ class Projector implements EventListener
             }
 
             $this->permissionRepository->markResourceEditableByUser(
-                new StringLiteral($organizerImportedFromUDB2->getActorId()),
-                $ownerId
+                $organizerImportedFromUDB2->getActorId(),
+                $ownerId->toNative()
             );
         }
     }
@@ -91,10 +91,10 @@ class Projector implements EventListener
         DomainMessage $domainMessage
     ): void {
         $metadata = $domainMessage->getMetadata()->serialize();
-        $ownerId = new StringLiteral($metadata['user_id']);
+        $ownerId = $metadata['user_id'];
 
         $this->permissionRepository->markResourceEditableByUser(
-            new StringLiteral($organizerId),
+            $organizerId,
             $ownerId
         );
     }

--- a/src/Place/ReadModel/Permission/Projector.php
+++ b/src/Place/ReadModel/Permission/Projector.php
@@ -15,7 +15,7 @@ use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use CultuurNet\UDB3\StringLiteral;
 
-class Projector implements EventListener
+final class Projector implements EventListener
 {
     use DelegateEventHandlingToSpecificMethodTrait;
 

--- a/src/Place/ReadModel/Permission/Projector.php
+++ b/src/Place/ReadModel/Permission/Projector.php
@@ -51,8 +51,8 @@ class Projector implements EventListener
             }
 
             $this->permissionRepository->markResourceEditableByUser(
-                new StringLiteral($placeImportedFromUDB2->getActorId()),
-                $ownerId
+                $placeImportedFromUDB2->getActorId(),
+                $ownerId->toNative()
             );
         }
     }
@@ -62,10 +62,10 @@ class Projector implements EventListener
         DomainMessage $domainMessage
     ): void {
         $metadata = $domainMessage->getMetadata()->serialize();
-        $ownerId = new StringLiteral($metadata['user_id']);
+        $ownerId = $metadata['user_id'];
 
         $this->permissionRepository->markResourceEditableByUser(
-            new StringLiteral($placeCreated->getPlaceId()),
+            $placeCreated->getPlaceId(),
             $ownerId
         );
     }

--- a/src/Place/ReadModel/Permission/Projector.php
+++ b/src/Place/ReadModel/Permission/Projector.php
@@ -73,8 +73,8 @@ class Projector implements EventListener
     protected function applyOwnerChanged(OwnerChanged $ownerChanged): void
     {
         $this->permissionRepository->markResourceEditableByNewUser(
-            new StringLiteral($ownerChanged->getOfferId()),
-            new StringLiteral($ownerChanged->getNewOwnerId())
+            $ownerChanged->getOfferId(),
+            $ownerChanged->getNewOwnerId()
         );
     }
 }

--- a/src/Security/CommandAuthorizationException.php
+++ b/src/Security/CommandAuthorizationException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security;
 
-class CommandAuthorizationException extends \Exception
+final class CommandAuthorizationException extends \Exception
 {
     private string $userId;
 

--- a/src/Security/CommandAuthorizationException.php
+++ b/src/Security/CommandAuthorizationException.php
@@ -4,25 +4,20 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security;
 
-use CultuurNet\UDB3\StringLiteral;
-
 class CommandAuthorizationException extends \Exception
 {
-    private StringLiteral $userId;
+    private string $userId;
 
     private AuthorizableCommand $command;
 
-    /**
-     * CommandAuthorizationException constructor.
-     */
     public function __construct(
-        StringLiteral $userId,
+        string $userId,
         AuthorizableCommand $command
     ) {
         parent::__construct(
             sprintf(
                 'User with id: %s has no permission: "%s" on item: %s when executing command: %s',
-                $userId->toNative(),
+                $userId,
                 $command->getPermission()->toString(),
                 $command->getItemId(),
                 get_class($command)
@@ -34,7 +29,7 @@ class CommandAuthorizationException extends \Exception
         $this->command = $command;
     }
 
-    public function getUserId(): StringLiteral
+    public function getUserId(): string
     {
         return $this->userId;
     }

--- a/src/Security/Permission/AnyOfVoter.php
+++ b/src/Security/Permission/AnyOfVoter.php
@@ -6,16 +6,13 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
-class AnyOfVoter implements PermissionVoter
+final class AnyOfVoter implements PermissionVoter
 {
     /**
      * @var PermissionVoter[]
      */
-    private $voters;
+    private array $voters;
 
-    /**
-     * @param PermissionVoter[] ...$voters
-     */
     public function __construct(PermissionVoter ...$voters)
     {
         $this->voters = $voters;

--- a/src/Security/Permission/AnyOfVoter.php
+++ b/src/Security/Permission/AnyOfVoter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use CultuurNet\UDB3\StringLiteral;
 
 class AnyOfVoter implements PermissionVoter
 {
@@ -24,8 +23,8 @@ class AnyOfVoter implements PermissionVoter
 
     public function isAllowed(
         Permission $permission,
-        StringLiteral $itemId,
-        StringLiteral $userId
+        string $itemId,
+        string $userId
     ): bool {
         foreach ($this->voters as $voter) {
             if ($voter->isAllowed($permission, $itemId, $userId)) {

--- a/src/Security/Permission/ContributorVoter.php
+++ b/src/Security/Permission/ContributorVoter.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Contributor\ContributorRepository;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Security\UserEmailAddressRepository;
-use CultuurNet\UDB3\StringLiteral;
 
 final class ContributorVoter implements PermissionVoter
 {
@@ -24,9 +23,9 @@ final class ContributorVoter implements PermissionVoter
         $this->contributorRepository = $contributorRepository;
     }
 
-    public function isAllowed(Permission $permission, StringLiteral $itemId, StringLiteral $userId): bool
+    public function isAllowed(Permission $permission, string $itemId, string $userId): bool
     {
-        $email = $this->userEmailAddressRepository->getEmailForUserId($userId->toNative());
-        return $email && $this->contributorRepository->isContributor(new UUID($itemId->toNative()), $email);
+        $email = $this->userEmailAddressRepository->getEmailForUserId($userId);
+        return $email && $this->contributorRepository->isContributor(new UUID($itemId), $email);
     }
 }

--- a/src/Security/Permission/GodUserVoter.php
+++ b/src/Security/Permission/GodUserVoter.php
@@ -6,17 +6,17 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
-class GodUserVoter implements PermissionVoter
+final class GodUserVoter implements PermissionVoter
 {
     /**
-     * @var string[]
+     * @var array
      */
-    private array $godUserIds;
+    private $godUserIds;
 
     /**
      * @param string[] $godUserIds
      */
-    public function __construct(string ...$godUserIds)
+    public function __construct(array $godUserIds)
     {
         $this->godUserIds = $godUserIds;
     }

--- a/src/Security/Permission/GodUserVoter.php
+++ b/src/Security/Permission/GodUserVoter.php
@@ -9,14 +9,14 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 class GodUserVoter implements PermissionVoter
 {
     /**
-     * @var array
+     * @var string[]
      */
-    private $godUserIds;
+    private array $godUserIds;
 
     /**
      * @param string[] $godUserIds
      */
-    public function __construct(array $godUserIds)
+    public function __construct(string ...$godUserIds)
     {
         $this->godUserIds = $godUserIds;
     }

--- a/src/Security/Permission/GodUserVoter.php
+++ b/src/Security/Permission/GodUserVoter.php
@@ -9,9 +9,9 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 final class GodUserVoter implements PermissionVoter
 {
     /**
-     * @var array
+     * @var string[]
      */
-    private $godUserIds;
+    private array $godUserIds;
 
     /**
      * @param string[] $godUserIds

--- a/src/Security/Permission/GodUserVoter.php
+++ b/src/Security/Permission/GodUserVoter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use CultuurNet\UDB3\StringLiteral;
 
 class GodUserVoter implements PermissionVoter
 {
@@ -24,9 +23,9 @@ class GodUserVoter implements PermissionVoter
 
     public function isAllowed(
         Permission $permission,
-        StringLiteral $itemId,
-        StringLiteral $userId
+        string $itemId,
+        string $userId
     ): bool {
-        return in_array($userId->toNative(), $this->godUserIds);
+        return in_array($userId, $this->godUserIds);
     }
 }

--- a/src/Security/Permission/PermissionSwitchVoter.php
+++ b/src/Security/Permission/PermissionSwitchVoter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Delegates voting to another voter based on which permission needs checking.
@@ -24,8 +23,8 @@ final class PermissionSwitchVoter implements PermissionVoter
 
     public function isAllowed(
         Permission $permission,
-        StringLiteral $itemId,
-        StringLiteral $userId
+        string $itemId,
+        string $userId
     ): bool {
         if (!isset($this->mapping[$permission->toString()])) {
             return isset($this->defaultVoter) && $this->defaultVoter->isAllowed($permission, $itemId, $userId);

--- a/src/Security/Permission/PermissionSwitchVoter.php
+++ b/src/Security/Permission/PermissionSwitchVoter.php
@@ -6,9 +6,6 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
-/**
- * Delegates voting to another voter based on which permission needs checking.
- */
 final class PermissionSwitchVoter implements PermissionVoter
 {
     /**
@@ -16,10 +13,7 @@ final class PermissionSwitchVoter implements PermissionVoter
      */
     private array $mapping;
 
-    /**
-     * @var PermissionVoter|null
-     */
-    private $defaultVoter;
+    private ?PermissionVoter $defaultVoter;
 
     public function isAllowed(
         Permission $permission,

--- a/src/Security/Permission/PermissionSwitchVoter.php
+++ b/src/Security/Permission/PermissionSwitchVoter.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 final class PermissionSwitchVoter implements PermissionVoter
 {
     /**
-     * @var \CultuurNet\UDB3\Security\Permission\PermissionVoter[]
+     * @var PermissionVoter[]
      */
     private array $mapping;
 

--- a/src/Security/Permission/PermissionVoter.php
+++ b/src/Security/Permission/PermissionVoter.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use CultuurNet\UDB3\StringLiteral;
 
 interface PermissionVoter
 {
     public function isAllowed(
         Permission $permission,
-        StringLiteral $itemId,
-        StringLiteral $userId
+        string $itemId,
+        string $userId
     ): bool;
 }

--- a/src/Security/Permission/ResourceOwnerVoter.php
+++ b/src/Security/Permission/ResourceOwnerVoter.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Security\Permission;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
-class ResourceOwnerVoter implements PermissionVoter
+final class ResourceOwnerVoter implements PermissionVoter
 {
     private ResourceOwnerQuery $permissionRepository;
 

--- a/src/Security/Permission/ResourceOwnerVoter.php
+++ b/src/Security/Permission/ResourceOwnerVoter.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use CultuurNet\UDB3\StringLiteral;
 
 class ResourceOwnerVoter implements PermissionVoter
 {
@@ -24,19 +23,19 @@ class ResourceOwnerVoter implements PermissionVoter
 
     public function isAllowed(
         Permission $permission,
-        StringLiteral $itemId,
-        StringLiteral $userId
+        string $itemId,
+        string $userId
     ): bool {
         if (!$this->enableCache) {
-            return in_array($itemId, $this->permissionRepository->getEditableResourceIds($userId->toNative()));
+            return in_array($itemId, $this->permissionRepository->getEditableResourceIds($userId));
         }
 
-        $cacheKey = $itemId->toNative() . $userId->toNative();
+        $cacheKey = $itemId . $userId;
         if (isset($this->cache[$cacheKey])) {
             return $this->cache[$cacheKey];
         }
 
-        $this->cache[$cacheKey] = in_array($itemId, $this->permissionRepository->getEditableResourceIds($userId->toNative()));
+        $this->cache[$cacheKey] = in_array($itemId, $this->permissionRepository->getEditableResourceIds($userId));
 
         return $this->cache[$cacheKey];
     }

--- a/src/Security/Permission/ResourceOwnerVoter.php
+++ b/src/Security/Permission/ResourceOwnerVoter.php
@@ -28,7 +28,7 @@ class ResourceOwnerVoter implements PermissionVoter
         StringLiteral $userId
     ): bool {
         if (!$this->enableCache) {
-            return in_array($itemId, $this->permissionRepository->getEditableResourceIds($userId));
+            return in_array($itemId, $this->permissionRepository->getEditableResourceIds($userId->toNative()));
         }
 
         $cacheKey = $itemId->toNative() . $userId->toNative();
@@ -36,7 +36,7 @@ class ResourceOwnerVoter implements PermissionVoter
             return $this->cache[$cacheKey];
         }
 
-        $this->cache[$cacheKey] = in_array($itemId, $this->permissionRepository->getEditableResourceIds($userId));
+        $this->cache[$cacheKey] = in_array($itemId, $this->permissionRepository->getEditableResourceIds($userId->toNative()));
 
         return $this->cache[$cacheKey];
     }

--- a/src/Security/Permission/Sapi3RoleConstraintVoter.php
+++ b/src/Security/Permission/Sapi3RoleConstraintVoter.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ReadModel\Constraints\UserConstraintsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\StringLiteral;
 use GuzzleHttp\Psr7\Request;
 use Http\Client\HttpClient;
 use Psr\Http\Message\UriInterface;

--- a/src/Security/Permission/Sapi3RoleConstraintVoter.php
+++ b/src/Security/Permission/Sapi3RoleConstraintVoter.php
@@ -54,11 +54,11 @@ class Sapi3RoleConstraintVoter implements PermissionVoter
 
     public function isAllowed(
         Permission $permission,
-        StringLiteral $itemId,
-        StringLiteral $userId
+        string $itemId,
+        string $userId
     ): bool {
         $constraints = $this->userConstraintsReadRepository->getByUserAndPermission(
-            $userId,
+            new StringLiteral($userId),
             $permission
         );
         if (count($constraints) < 1) {
@@ -67,7 +67,7 @@ class Sapi3RoleConstraintVoter implements PermissionVoter
 
         $query = $this->createQueryFromConstraints(
             $constraints,
-            $itemId
+            new StringLiteral($itemId)
         );
 
         $totalItems = $this->search($query);

--- a/src/Security/Permission/Sapi3RoleConstraintVoter.php
+++ b/src/Security/Permission/Sapi3RoleConstraintVoter.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use GuzzleHttp\Psr7\Request;
 use Http\Client\HttpClient;
 use Psr\Http\Message\UriInterface;
-use CultuurNet\UDB3\StringLiteral;
 
 final class Sapi3RoleConstraintVoter implements PermissionVoter
 {
@@ -52,7 +51,7 @@ final class Sapi3RoleConstraintVoter implements PermissionVoter
 
         $query = $this->createQueryFromConstraints(
             $constraints,
-            new StringLiteral($itemId)
+            $itemId
         );
 
         $totalItems = $this->search($query);
@@ -61,18 +60,18 @@ final class Sapi3RoleConstraintVoter implements PermissionVoter
     }
 
     private function createQueryString(
-        StringLiteral $constraint,
-        StringLiteral $resourceId
+        string $constraint,
+        string $resourceId
     ): string {
-        $constraintStr = '(' . $constraint->toNative() . ')';
-        $resourceIdStr = $resourceId->toNative();
+        $constraintStr = '(' . $constraint . ')';
+        $resourceIdStr = $resourceId;
 
         return '(' . $constraintStr . ' AND id:' . $resourceIdStr . ')';
     }
 
     private function createQueryFromConstraints(
         array $constraints,
-        StringLiteral $resourceId
+        string $resourceId
     ): string {
         $queryString = '';
 

--- a/src/Security/Permission/Sapi3RoleConstraintVoter.php
+++ b/src/Security/Permission/Sapi3RoleConstraintVoter.php
@@ -11,32 +11,17 @@ use Http\Client\HttpClient;
 use Psr\Http\Message\UriInterface;
 use CultuurNet\UDB3\StringLiteral;
 
-class Sapi3RoleConstraintVoter implements PermissionVoter
+final class Sapi3RoleConstraintVoter implements PermissionVoter
 {
-    /**
-     * @var UserConstraintsReadRepositoryInterface
-     */
-    private $userConstraintsReadRepository;
+    private UserConstraintsReadRepositoryInterface $userConstraintsReadRepository;
 
-    /**
-     * @var UriInterface
-     */
-    private $searchLocation;
+    private UriInterface $searchLocation;
 
-    /**
-     * @var HttpClient
-     */
-    private $httpClient;
+    private HttpClient $httpClient;
 
-    /**
-     * @var string|null
-     */
-    private $apiKey;
+    private ?string $apiKey;
 
-    /**
-     * @var array
-     */
-    private $queryParameters;
+    private array $queryParameters;
 
     public function __construct(
         UserConstraintsReadRepositoryInterface $userConstraintsReadRepository,

--- a/src/Security/Permission/UserPermissionChecker.php
+++ b/src/Security/Permission/UserPermissionChecker.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security\Permission;
 
-use CultuurNet\UDB3\StringLiteral;
-
 final class UserPermissionChecker
 {
     private array $permissions;
@@ -24,8 +22,8 @@ final class UserPermissionChecker
         foreach ($this->permissions as $permission) {
             $hasPermission = $this->permissionVoter->isAllowed(
                 $permission,
-                new StringLiteral($resourceId),
-                new StringLiteral($userId)
+                $resourceId,
+                $userId
             );
 
             if ($hasPermission) {
@@ -40,8 +38,8 @@ final class UserPermissionChecker
     {
         return $this->permissionVoter->isAllowed(
             $this->permissions[0],
-            new StringLiteral($offerId),
-            new StringLiteral($userId)
+            $offerId,
+            $userId
         );
     }
 }

--- a/src/Security/Permission/UserPermissionVoter.php
+++ b/src/Security/Permission/UserPermissionVoter.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionVoter implements PermissionVoter
 {
@@ -21,9 +20,9 @@ class UserPermissionVoter implements PermissionVoter
 
     public function isAllowed(
         Permission $requiredPermission,
-        StringLiteral $itemId,
-        StringLiteral $userId
+        string $itemId,
+        string $userId
     ): bool {
-        return $this->userPermissionsReadRepository->hasPermission($userId->toNative(), $requiredPermission);
+        return $this->userPermissionsReadRepository->hasPermission($userId, $requiredPermission);
     }
 }

--- a/src/Security/Permission/UserPermissionVoter.php
+++ b/src/Security/Permission/UserPermissionVoter.php
@@ -7,10 +7,9 @@ namespace CultuurNet\UDB3\Security\Permission;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
-class UserPermissionVoter implements PermissionVoter
+final class UserPermissionVoter implements PermissionVoter
 {
     private UserPermissionsReadRepositoryInterface $userPermissionsReadRepository;
-
 
     public function __construct(
         UserPermissionsReadRepositoryInterface $userPermissionsReadRepository

--- a/src/Security/Permission/UserPermissionVoter.php
+++ b/src/Security/Permission/UserPermissionVoter.php
@@ -18,10 +18,10 @@ final class UserPermissionVoter implements PermissionVoter
     }
 
     public function isAllowed(
-        Permission $requiredPermission,
+        Permission $permission,
         string $itemId,
         string $userId
     ): bool {
-        return $this->userPermissionsReadRepository->hasPermission($userId, $requiredPermission);
+        return $this->userPermissionsReadRepository->hasPermission($userId, $permission);
     }
 }

--- a/src/Security/PermissionVoterCommandBusSecurity.php
+++ b/src/Security/PermissionVoterCommandBusSecurity.php
@@ -6,17 +6,11 @@ namespace CultuurNet\UDB3\Security;
 
 use CultuurNet\UDB3\Security\Permission\PermissionVoter;
 
-class PermissionVoterCommandBusSecurity implements CommandBusSecurity
+final class PermissionVoterCommandBusSecurity implements CommandBusSecurity
 {
-    /**
-     * @var string
-     */
-    private $userId;
+    private string $userId;
 
-    /**
-     * @var PermissionVoter
-     */
-    private $permissionVoter;
+    private PermissionVoter $permissionVoter;
 
     public function __construct(
         ?string $userId = null,

--- a/src/Security/PermissionVoterCommandBusSecurity.php
+++ b/src/Security/PermissionVoterCommandBusSecurity.php
@@ -13,7 +13,7 @@ final class PermissionVoterCommandBusSecurity implements CommandBusSecurity
     private PermissionVoter $permissionVoter;
 
     public function __construct(
-        ?string $userId = null,
+        ?string $userId,
         PermissionVoter $permissionVoter
     ) {
         $this->userId = $userId;

--- a/src/Security/PermissionVoterCommandBusSecurity.php
+++ b/src/Security/PermissionVoterCommandBusSecurity.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Security;
 
 use CultuurNet\UDB3\Security\Permission\PermissionVoter;
-use CultuurNet\UDB3\StringLiteral;
 
 class PermissionVoterCommandBusSecurity implements CommandBusSecurity
 {
@@ -29,12 +28,11 @@ class PermissionVoterCommandBusSecurity implements CommandBusSecurity
 
     public function isAuthorized(AuthorizableCommand $command): bool
     {
-        $itemId = new StringLiteral($command->getItemId());
-        return $this->currentUserCanEditItem($itemId, $command);
+        return $this->currentUserCanEditItem($command->getItemId(), $command);
     }
 
     private function currentUserCanEditItem(
-        StringLiteral $itemId,
+        string $itemId,
         AuthorizableCommand $command
     ): bool {
         if (!$this->userId) {
@@ -44,7 +42,7 @@ class PermissionVoterCommandBusSecurity implements CommandBusSecurity
         return $this->permissionVoter->isAllowed(
             $command->getPermission(),
             $itemId,
-            new StringLiteral($this->userId)
+            $this->userId
         );
     }
 }

--- a/src/Security/ResourceOwner/CombinedResourceOwnerQuery.php
+++ b/src/Security/ResourceOwner/CombinedResourceOwnerQuery.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security\ResourceOwner;
 
-class CombinedResourceOwnerQuery implements ResourceOwnerQuery
+final class CombinedResourceOwnerQuery implements ResourceOwnerQuery
 {
     /**
      * @var ResourceOwnerQuery[]
      */
-    private $permissionQueries;
+    private array $permissionQueries;
 
     /**
-     * CombinedPermissionQuery constructor.
      * @param ResourceOwnerQuery[] $permissionQueries
      */
     public function __construct(array $permissionQueries)

--- a/src/Security/ResourceOwner/CombinedResourceOwnerQuery.php
+++ b/src/Security/ResourceOwner/CombinedResourceOwnerQuery.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security\ResourceOwner;
 
-use CultuurNet\UDB3\StringLiteral;
-
 class CombinedResourceOwnerQuery implements ResourceOwnerQuery
 {
     /**
@@ -22,7 +20,7 @@ class CombinedResourceOwnerQuery implements ResourceOwnerQuery
         $this->permissionQueries = $permissionQueries;
     }
 
-    public function getEditableResourceIds(StringLiteral $userId): array
+    public function getEditableResourceIds(string $userId): array
     {
         $editableResourceIds = [];
 

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -82,12 +82,12 @@ class DBALResourceOwnerRepository implements ResourceOwnerRepository, ResourceOw
         }
     }
 
-    public function markResourceEditableByNewUser(StringLiteral $eventId, StringLiteral $userId): void
+    public function markResourceEditableByNewUser(string $eventId, string $userId): void
     {
         $this->connection->update(
             $this->tableName->toNative(),
-            ['user_id' => $userId->toNative()],
-            [$this->idField->toNative() => $eventId->toNative()]
+            ['user_id' => $userId],
+            [$this->idField->toNative() => $eventId]
         );
     }
 }

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -48,13 +48,13 @@ class DBALResourceOwnerRepository implements ResourceOwnerRepository, ResourceOw
         $this->idField = $idField;
     }
 
-    public function getEditableResourceIds(StringLiteral $userId): array
+    public function getEditableResourceIds(string $userId): array
     {
         $q = $this->connection->createQueryBuilder();
         $q->select($this->idField->toNative())
             ->from($this->tableName->toNative())
             ->where('user_id = :userId')
-            ->setParameter(':userId', $userId->toNative());
+            ->setParameter(':userId', $userId);
 
         $results = $q->execute();
 

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -66,14 +66,14 @@ class DBALResourceOwnerRepository implements ResourceOwnerRepository, ResourceOw
         return $events;
     }
 
-    public function markResourceEditableByUser(StringLiteral $eventId, StringLiteral $userId): void
+    public function markResourceEditableByUser(string $eventId, string $userId): void
     {
         try {
             $this->connection->insert(
                 $this->tableName->toNative(),
                 [
-                    $this->idField->toNative() => $eventId->toNative(),
-                    'user_id' => $userId->toNative(),
+                    $this->idField->toNative() => $eventId,
+                    'user_id' => $userId,
                 ]
             );
         } catch (UniqueConstraintViolationException $e) {

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -60,7 +60,7 @@ class DBALResourceOwnerRepository implements ResourceOwnerRepository, ResourceOw
 
         $events = [];
         while ($id = $results->fetchColumn(0)) {
-            $events[] = new StringLiteral($id);
+            $events[] =$id;
         }
 
         return $events;

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -8,40 +8,19 @@ use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
-use CultuurNet\UDB3\StringLiteral;
 
-class DBALResourceOwnerRepository implements ResourceOwnerRepository, ResourceOwnerQuery
+final class DBALResourceOwnerRepository implements ResourceOwnerRepository, ResourceOwnerQuery
 {
-    /**
-     * @var Connection
-     */
-    protected $connection;
+    private Connection $connection;
 
-    /**
-     * @var StringLiteral
-     */
-    protected $idField;
+    private string $idField;
 
-    /**
-     * @var StringLiteral
-     */
-    protected $tableName;
+    private string $tableName;
 
-    /**
-     * @param StringLiteral $tableName
-     *  The name of the table where the permissions are stored.
-     *
-     * @param Connection $connection
-     *  A database connection.
-     *
-     * @param StringLiteral $idField
-     *  The name of the column that holds the resource identifier.
-     *
-     */
     public function __construct(
-        StringLiteral $tableName,
+        string $tableName,
         Connection $connection,
-        StringLiteral $idField
+        string $idField
     ) {
         $this->tableName = $tableName;
         $this->connection = $connection;
@@ -51,8 +30,8 @@ class DBALResourceOwnerRepository implements ResourceOwnerRepository, ResourceOw
     public function getEditableResourceIds(string $userId): array
     {
         $q = $this->connection->createQueryBuilder();
-        $q->select($this->idField->toNative())
-            ->from($this->tableName->toNative())
+        $q->select($this->idField)
+            ->from($this->tableName)
             ->where('user_id = :userId')
             ->setParameter(':userId', $userId);
 
@@ -66,13 +45,13 @@ class DBALResourceOwnerRepository implements ResourceOwnerRepository, ResourceOw
         return $events;
     }
 
-    public function markResourceEditableByUser(string $eventId, string $userId): void
+    public function markResourceEditableByUser(string $resourceId, string $userId): void
     {
         try {
             $this->connection->insert(
-                $this->tableName->toNative(),
+                $this->tableName,
                 [
-                    $this->idField->toNative() => $eventId,
+                    $this->idField => $resourceId,
                     'user_id' => $userId,
                 ]
             );
@@ -82,12 +61,12 @@ class DBALResourceOwnerRepository implements ResourceOwnerRepository, ResourceOw
         }
     }
 
-    public function markResourceEditableByNewUser(string $eventId, string $userId): void
+    public function markResourceEditableByNewUser(string $resourceId, string $userId): void
     {
         $this->connection->update(
-            $this->tableName->toNative(),
+            $this->tableName,
             ['user_id' => $userId],
-            [$this->idField->toNative() => $eventId]
+            [$this->idField => $resourceId]
         );
     }
 }

--- a/src/Security/ResourceOwner/ResourceOwnerQuery.php
+++ b/src/Security/ResourceOwner/ResourceOwnerQuery.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security\ResourceOwner;
 
-use CultuurNet\UDB3\StringLiteral;
-
 interface ResourceOwnerQuery
 {
     /**
-     * @return StringLiteral[] A list of resource ids that the given user can edit.
+     * @return string[] A list of resource ids that the given user can edit.
      */
     public function getEditableResourceIds(string $userId): array;
 }

--- a/src/Security/ResourceOwner/ResourceOwnerQuery.php
+++ b/src/Security/ResourceOwner/ResourceOwnerQuery.php
@@ -11,5 +11,5 @@ interface ResourceOwnerQuery
     /**
      * @return StringLiteral[] A list of resource ids that the given user can edit.
      */
-    public function getEditableResourceIds(StringLiteral $userId): array;
+    public function getEditableResourceIds(string $userId): array;
 }

--- a/src/Security/ResourceOwner/ResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/ResourceOwnerRepository.php
@@ -9,8 +9,8 @@ use CultuurNet\UDB3\StringLiteral;
 interface ResourceOwnerRepository
 {
     public function markResourceEditableByUser(
-        StringLiteral $resourceId,
-        StringLiteral $userId
+        string $resourceId,
+        string $userId
     ): void;
 
     public function markResourceEditableByNewUser(

--- a/src/Security/ResourceOwner/ResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/ResourceOwnerRepository.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security\ResourceOwner;
 
-use CultuurNet\UDB3\StringLiteral;
-
 interface ResourceOwnerRepository
 {
     public function markResourceEditableByUser(
@@ -14,7 +12,7 @@ interface ResourceOwnerRepository
     ): void;
 
     public function markResourceEditableByNewUser(
-        StringLiteral $resourceId,
-        StringLiteral $userId
+        string $resourceId,
+        string $userId
     ): void;
 }

--- a/tests/Event/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Event/ReadModel/Permission/ProjectorTest.php
@@ -22,17 +22,15 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use CultuurNet\UDB3\StringLiteral;
 
-class ProjectorTest extends TestCase
+final class ProjectorTest extends TestCase
 {
     /**
      * @var ResourceOwnerRepository|MockObject
      */
     private $repository;
 
-    /**
-     * @var Projector
-     */
-    private $projector;
+
+    private Projector $projector;
 
     /**
      * @var CreatedByToUserIdResolverInterface|MockObject

--- a/tests/Event/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Event/ReadModel/Permission/ProjectorTest.php
@@ -209,8 +209,8 @@ class ProjectorTest extends TestCase
         $this->repository->expects($this->once())
             ->method('markResourceEditableByNewUser')
             ->with(
-                new StringLiteral($eventId),
-                new StringLiteral($newOwnerId)
+                $eventId,
+                $newOwnerId
             );
 
         $this->projector->handle($domainMessage);

--- a/tests/Organizer/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Organizer/ReadModel/Permission/ProjectorTest.php
@@ -9,7 +9,6 @@ use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Cdb\CreatedByToUserIdResolverInterface;
 use CultuurNet\UDB3\Organizer\Events\OwnerChanged;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
-use CultuurNet\UDB3\StringLiteral;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -57,8 +56,8 @@ final class ProjectorTest extends TestCase
         $this->repository->expects($this->once())
             ->method('markResourceEditableByNewUser')
             ->with(
-                new StringLiteral($organizerId),
-                new StringLiteral($newOwnerId)
+                $organizerId,
+                $newOwnerId
             );
 
         $this->projector->handle($domainMessage);

--- a/tests/Organizer/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Organizer/ReadModel/Permission/ProjectorTest.php
@@ -19,21 +19,16 @@ final class ProjectorTest extends TestCase
      */
     private $repository;
 
-    /**
-     * @var CreatedByToUserIdResolverInterface|MockObject
-     */
-    private $userIdResolver;
-
     private Projector $projector;
 
     public function setUp(): void
     {
         $this->repository = $this->createMock(ResourceOwnerRepository::class);
-        $this->userIdResolver = $this->createMock(CreatedByToUserIdResolverInterface::class);
+        $userIdResolver = $this->createMock(CreatedByToUserIdResolverInterface::class);
 
         $this->projector = new Projector(
             $this->repository,
-            $this->userIdResolver
+            $userIdResolver
         );
     }
 

--- a/tests/Place/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Place/ReadModel/Permission/ProjectorTest.php
@@ -25,17 +25,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use CultuurNet\UDB3\StringLiteral;
 
-class ProjectorTest extends TestCase
+final class ProjectorTest extends TestCase
 {
     /**
      * @var ResourceOwnerRepository|MockObject
      */
     private $repository;
 
-    /**
-     * @var Projector
-     */
-    private $projector;
+    private Projector $projector;
 
     /**
      * @var CreatedByToUserIdResolverInterface|MockObject

--- a/tests/Place/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Place/ReadModel/Permission/ProjectorTest.php
@@ -183,8 +183,8 @@ class ProjectorTest extends TestCase
         $this->repository->expects($this->once())
             ->method('markResourceEditableByNewUser')
             ->with(
-                new StringLiteral($placeId),
-                new StringLiteral($newOwnerId)
+                $placeId,
+                $newOwnerId
             );
 
         $this->projector->handle($domainMessage);

--- a/tests/Security/CommandAuthorizationExceptionTest.php
+++ b/tests/Security/CommandAuthorizationExceptionTest.php
@@ -7,11 +7,10 @@ namespace CultuurNet\UDB3\Security;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class CommandAuthorizationExceptionTest extends TestCase
 {
-    private StringLiteral $userId;
+    private string $userId;
 
     private Permission $permission;
 
@@ -26,7 +25,7 @@ class CommandAuthorizationExceptionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->userId = new StringLiteral('85b040e5-766a-4ca7-a01b-e21e9250165f');
+        $this->userId = '85b040e5-766a-4ca7-a01b-e21e9250165f';
         $this->permission = Permission::aanbodBewerken();
         $this->itemId = '69aa5d8d-5d56-4774-9320-d8e7c1721693';
 
@@ -69,7 +68,7 @@ class CommandAuthorizationExceptionTest extends TestCase
      */
     public function it_creates_a_message(): void
     {
-        $expectedMessage = 'User with id: ' . $this->userId->toNative() .
+        $expectedMessage = 'User with id: ' . $this->userId .
             ' has no permission: "' . $this->permission->toString() .
             '" on item: ' . $this->itemId .
             ' when executing command: ' . get_class($this->command);

--- a/tests/Security/Permission/ContributorVoterTest.php
+++ b/tests/Security/Permission/ContributorVoterTest.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Security\UserEmailAddressRepository;
-use CultuurNet\UDB3\StringLiteral;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -64,8 +63,8 @@ final class ContributorVoterTest extends TestCase
         $this->assertTrue(
             $this->contributorVoter->isAllowed(
                 Permission::aanbodBewerken(),
-                new StringLiteral($this->itemId),
-                new StringLiteral($this->userId)
+                $this->itemId,
+                $this->userId
             )
         );
     }
@@ -88,8 +87,8 @@ final class ContributorVoterTest extends TestCase
         $this->assertFalse(
             $this->contributorVoter->isAllowed(
                 Permission::aanbodBewerken(),
-                new StringLiteral($this->itemId),
-                new StringLiteral($this->userId)
+                $this->itemId,
+                $this->userId
             )
         );
     }
@@ -110,8 +109,8 @@ final class ContributorVoterTest extends TestCase
         $this->assertFalse(
             $this->contributorVoter->isAllowed(
                 Permission::aanbodBewerken(),
-                new StringLiteral($this->itemId),
-                new StringLiteral($this->userId)
+                $this->itemId,
+                $this->userId
             )
         );
     }

--- a/tests/Security/Permission/PermissionSwitchVoterTest.php
+++ b/tests/Security/Permission/PermissionSwitchVoterTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class PermissionSwitchVoterTest extends TestCase
 {
@@ -15,9 +14,9 @@ class PermissionSwitchVoterTest extends TestCase
      */
     public function it_delegates_to_a_voter_responsible_for_the_permission(): void
     {
-        $offerId = new StringLiteral('232');
-        $userId = new StringLiteral('john_doe');
-        $organizerId = new StringLiteral('organizer_abc');
+        $offerId = '232';
+        $userId = 'john_doe';
+        $organizerId = 'organizer_abc';
 
         $a = $this->getMockBuilder(PermissionVoter::class)->getMock();
         $b = $this->getMockBuilder(PermissionVoter::class)->getMock();
@@ -53,8 +52,8 @@ class PermissionSwitchVoterTest extends TestCase
      */
     public function it_can_use_a_default_voter_for_permissions_that_do_not_have_a_specific_voter(): void
     {
-        $offerId = new StringLiteral('232');
-        $userId = new StringLiteral('john_doe');
+        $offerId = '232';
+        $userId = 'john_doe';
 
         $specific = $this->getMockBuilder(PermissionVoter::class)->getMock();
         $default = $this->getMockBuilder(PermissionVoter::class)->getMock();

--- a/tests/Security/Permission/PermissionSwitchVoterTest.php
+++ b/tests/Security/Permission/PermissionSwitchVoterTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Security\Permission;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\TestCase;
 
-class PermissionSwitchVoterTest extends TestCase
+final class PermissionSwitchVoterTest extends TestCase
 {
     /**
      * @test

--- a/tests/Security/Permission/UserPermissionVoterTest.php
+++ b/tests/Security/Permission/UserPermissionVoterTest.php
@@ -6,28 +6,22 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class UserPermissionVoterTest extends TestCase
 {
-    /**
-     * @var UserPermissionsReadRepositoryInterface|MockObject
-     */
-    private $userPermissionsReadRepository;
-
     private UserPermissionVoter $userPermissionVoter;
 
     private string $userId;
 
     protected function setUp(): void
     {
-        $this->userPermissionsReadRepository = $this->createMock(
+        $userPermissionsReadRepository = $this->createMock(
             UserPermissionsReadRepositoryInterface::class
         );
 
         $this->userId = '7fdc57a4-1bdc-40d3-8441-a7d83528a15c';
-        $this->userPermissionsReadRepository->expects($this->once())
+        $userPermissionsReadRepository->expects($this->once())
             ->method('hasPermission')
             ->willReturnCallback(
                 function (string $userId, Permission $permission) {
@@ -40,7 +34,7 @@ class UserPermissionVoterTest extends TestCase
                 }
             );
 
-        $this->userPermissionVoter = new UserPermissionVoter($this->userPermissionsReadRepository);
+        $this->userPermissionVoter = new UserPermissionVoter($userPermissionsReadRepository);
     }
 
     /**

--- a/tests/Security/Permission/UserPermissionVoterTest.php
+++ b/tests/Security/Permission/UserPermissionVoterTest.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsReadRepositoryInte
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionVoterTest extends TestCase
 {
@@ -19,7 +18,7 @@ class UserPermissionVoterTest extends TestCase
 
     private UserPermissionVoter $userPermissionVoter;
 
-    private StringLiteral $userId;
+    private string $userId;
 
     protected function setUp(): void
     {
@@ -27,7 +26,7 @@ class UserPermissionVoterTest extends TestCase
             UserPermissionsReadRepositoryInterface::class
         );
 
-        $this->userId = new StringLiteral('7fdc57a4-1bdc-40d3-8441-a7d83528a15c');
+        $this->userId = '7fdc57a4-1bdc-40d3-8441-a7d83528a15c';
         $this->userPermissionsReadRepository->expects($this->once())
             ->method('hasPermission')
             ->willReturnCallback(
@@ -36,7 +35,7 @@ class UserPermissionVoterTest extends TestCase
                         Permission::aanbodBewerken()->toString(),
                         Permission::voorzieningenBewerken()->toString(),
                     ];
-                    return $userId === $this->userId->toNative() &&
+                    return $userId === $this->userId &&
                         in_array($permission->toString(), $permissions, true);
                 }
             );
@@ -52,7 +51,7 @@ class UserPermissionVoterTest extends TestCase
         $this->assertTrue(
             $this->userPermissionVoter->isAllowed(
                 Permission::voorzieningenBewerken(),
-                new StringLiteral(''),
+                '',
                 $this->userId
             )
         );
@@ -66,7 +65,7 @@ class UserPermissionVoterTest extends TestCase
         $this->assertFalse(
             $this->userPermissionVoter->isAllowed(
                 Permission::gebruikersBeheren(),
-                new StringLiteral(''),
+                '',
                 $this->userId
             )
         );
@@ -80,8 +79,8 @@ class UserPermissionVoterTest extends TestCase
         $this->assertFalse(
             $this->userPermissionVoter->isAllowed(
                 Permission::voorzieningenBewerken(),
-                new StringLiteral(''),
-                new StringLiteral('')
+                '',
+                ''
             )
         );
     }

--- a/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
+++ b/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
@@ -47,7 +47,7 @@ class CombinedResourceOwnerQueryTest extends TestCase
         }
 
         $this->combinedPermissionQuery->getEditableResourceIds(
-            new StringLiteral('userId')
+            'userId'
         );
     }
 
@@ -56,9 +56,7 @@ class CombinedResourceOwnerQueryTest extends TestCase
      */
     public function it_returns_merged_array_from_all_permission_queries(): void
     {
-        $editableOffers = $this->combinedPermissionQuery->getEditableResourceIds(
-            new StringLiteral('userId')
-        );
+        $editableOffers = $this->combinedPermissionQuery->getEditableResourceIds('userId');
 
         $expectedEditableOffers = [
             new StringLiteral('offerId1'),
@@ -81,9 +79,7 @@ class CombinedResourceOwnerQueryTest extends TestCase
             $permissionQueries
         );
 
-        $this->assertEmpty($combinedPermissionQuery->getEditableResourceIds(
-            new StringLiteral('userId')
-        ));
+        $this->assertEmpty($combinedPermissionQuery->getEditableResourceIds('userId'));
     }
 
     /**

--- a/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
+++ b/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
@@ -8,17 +8,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use CultuurNet\UDB3\StringLiteral;
 
-class CombinedResourceOwnerQueryTest extends TestCase
+final class CombinedResourceOwnerQueryTest extends TestCase
 {
     /**
      * @var ResourceOwnerQuery[]|MockObject[]
      */
     private $permissionQueries;
 
-    /**
-     * @var CombinedResourceOwnerQuery
-     */
-    private $combinedPermissionQuery;
+    private CombinedResourceOwnerQuery $combinedPermissionQuery;
 
     protected function setUp(): void
     {

--- a/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
+++ b/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Security\ResourceOwner;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 final class CombinedResourceOwnerQueryTest extends TestCase
 {
@@ -20,12 +19,12 @@ final class CombinedResourceOwnerQueryTest extends TestCase
     protected function setUp(): void
     {
         $this->permissionQueries[] = $this->createPermissionQuery([
-            new StringLiteral('offerId1'),
-            new StringLiteral('offerId2'),
+            'offerId1',
+            'offerId2',
         ]);
 
         $this->permissionQueries[] = $this->createPermissionQuery([
-            new StringLiteral('offerId3'),
+            'offerId3',
         ]);
 
         $this->combinedPermissionQuery = new CombinedResourceOwnerQuery(
@@ -80,7 +79,7 @@ final class CombinedResourceOwnerQueryTest extends TestCase
     }
 
     /**
-     * @param StringLiteral[] $editableOffers
+     * @param string[] $editableOffers
      * @return ResourceOwnerQuery|MockObject
      */
     private function createPermissionQuery(array $editableOffers)

--- a/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
+++ b/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
@@ -59,9 +59,9 @@ class CombinedResourceOwnerQueryTest extends TestCase
         $editableOffers = $this->combinedPermissionQuery->getEditableResourceIds('userId');
 
         $expectedEditableOffers = [
-            new StringLiteral('offerId1'),
-            new StringLiteral('offerId2'),
-            new StringLiteral('offerId3'),
+            'offerId1',
+            'offerId2',
+            'offerId3',
         ];
 
         $this->assertEquals($expectedEditableOffers, $editableOffers);

--- a/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
+++ b/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
@@ -38,13 +38,13 @@ class DBALResourceOwnerRepositoryTest extends TestCase
      */
     public function it_can_add_and_query_offer_permissions(): void
     {
-        $johnDoe = new StringLiteral('abc');
+        $johnDoe = 'abc';
         $editableByJohnDoe = [
             new StringLiteral('123'),
             new StringLiteral('456'),
             new StringLiteral('789'),
         ];
-        $janeDoe = new StringLiteral('def');
+        $janeDoe = 'def';
         $editableByJaneDoe = [
             new StringLiteral('101112'),
             new StringLiteral('131415'),
@@ -61,8 +61,8 @@ class DBALResourceOwnerRepositoryTest extends TestCase
             $this->repository->getEditableResourceIds($janeDoe)
         );
 
-        array_walk($editableByJohnDoe, [$this, 'markEditable'], $johnDoe);
-        array_walk($editableByJaneDoe, [$this, 'markEditable'], $janeDoe);
+        array_walk($editableByJohnDoe, [$this, 'markEditable'], new StringLiteral($johnDoe));
+        array_walk($editableByJaneDoe, [$this, 'markEditable'], new StringLiteral($janeDoe));
 
         $this->assertEquals(
             $editableByJohnDoe,
@@ -88,16 +88,16 @@ class DBALResourceOwnerRepositoryTest extends TestCase
      */
     public function it_silently_ignores_adding_duplicate_permissions(): void
     {
-        $johnDoe = new StringLiteral('abc');
+        $johnDoe = 'abc';
         $editableByJohnDoe = [
             new StringLiteral('123'),
             new StringLiteral('456'),
             new StringLiteral('789'),
         ];
 
-        array_walk($editableByJohnDoe, [$this, 'markEditable'], $johnDoe);
+        array_walk($editableByJohnDoe, [$this, 'markEditable'], new StringLiteral($johnDoe));
 
-        $this->repository->markResourceEditableByUser(new StringLiteral('456'), $johnDoe);
+        $this->repository->markResourceEditableByUser(new StringLiteral('456'), new StringLiteral($johnDoe));
 
         $this->assertEquals(
             $editableByJohnDoe,
@@ -110,17 +110,17 @@ class DBALResourceOwnerRepositoryTest extends TestCase
      */
     public function it_updates_the_user_id_if_explicitly_requested(): void
     {
-        $johnDoe = new StringLiteral('abc');
-        $janeDoe = new StringLiteral('def');
+        $johnDoe = 'abc';
+        $janeDoe = 'def';
         $editableByJohnDoe = [
             new StringLiteral('123'),
             new StringLiteral('456'),
             new StringLiteral('789'),
         ];
 
-        array_walk($editableByJohnDoe, [$this, 'markEditable'], $johnDoe);
+        array_walk($editableByJohnDoe, [$this, 'markEditable'], new StringLiteral($johnDoe));
 
-        $this->repository->markResourceEditableByNewUser(new StringLiteral('456'), $janeDoe);
+        $this->repository->markResourceEditableByNewUser(new StringLiteral('456'), new StringLiteral($janeDoe));
 
         $this->assertEquals(
             [

--- a/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
+++ b/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\DBALTestConnectionTrait;
 use PHPUnit\Framework\TestCase;
 use CultuurNet\UDB3\StringLiteral;
 
-class DBALResourceOwnerRepositoryTest extends TestCase
+final class DBALResourceOwnerRepositoryTest extends TestCase
 {
     use DBALTestConnectionTrait;
 
@@ -40,15 +40,15 @@ class DBALResourceOwnerRepositoryTest extends TestCase
     {
         $johnDoe = 'abc';
         $editableByJohnDoe = [
-            new StringLiteral('123'),
-            new StringLiteral('456'),
-            new StringLiteral('789'),
+            '123',
+            '456',
+            '789',
         ];
         $janeDoe = 'def';
         $editableByJaneDoe = [
-            new StringLiteral('101112'),
-            new StringLiteral('131415'),
-            new StringLiteral('456'),
+            '101112',
+            '131415',
+            '456',
         ];
 
         $this->assertEquals(
@@ -61,8 +61,8 @@ class DBALResourceOwnerRepositoryTest extends TestCase
             $this->repository->getEditableResourceIds($janeDoe)
         );
 
-        array_walk($editableByJohnDoe, [$this, 'markEditable'], new StringLiteral($johnDoe));
-        array_walk($editableByJaneDoe, [$this, 'markEditable'], new StringLiteral($janeDoe));
+        array_walk($editableByJohnDoe, [$this, 'markEditable'], $johnDoe);
+        array_walk($editableByJaneDoe, [$this, 'markEditable'], $janeDoe);
 
         $this->assertEquals(
             $editableByJohnDoe,
@@ -87,9 +87,9 @@ class DBALResourceOwnerRepositoryTest extends TestCase
     {
         $johnDoe = 'abc';
         $editableByJohnDoe = [
-            new StringLiteral('123'),
-            new StringLiteral('456'),
-            new StringLiteral('789'),
+            '123',
+            '456',
+            '789',
         ];
 
         array_walk($editableByJohnDoe, [$this, 'markEditable'], $johnDoe);
@@ -110,25 +110,25 @@ class DBALResourceOwnerRepositoryTest extends TestCase
         $johnDoe = 'abc';
         $janeDoe = 'def';
         $editableByJohnDoe = [
-            new StringLiteral('123'),
-            new StringLiteral('456'),
-            new StringLiteral('789'),
+            '123',
+            '456',
+            '789',
         ];
 
-        array_walk($editableByJohnDoe, [$this, 'markEditable'], new StringLiteral($johnDoe));
+        array_walk($editableByJohnDoe, [$this, 'markEditable'], $johnDoe);
 
         $this->repository->markResourceEditableByNewUser('456', $janeDoe);
 
         $this->assertEquals(
             [
-                new StringLiteral('456'),
+                '456',
             ],
             $this->repository->getEditableResourceIds($janeDoe)
         );
         $this->assertEquals(
             [
-                new StringLiteral('123'),
-                new StringLiteral('789'),
+                '123',
+                '789',
             ],
             $this->repository->getEditableResourceIds($johnDoe)
         );

--- a/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
+++ b/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
@@ -12,17 +12,14 @@ final class DBALResourceOwnerRepositoryTest extends TestCase
 {
     use DBALTestConnectionTrait;
 
-    /**
-     * @var DBALResourceOwnerRepository
-     */
-    private $repository;
+    private DBALResourceOwnerRepository $repository;
 
     public function setUp(): void
     {
-        $table = new StringLiteral('event_permission');
-        $idField = new StringLiteral('event_id');
+        $table = 'event_permission';
+        $idField = 'event_id';
 
-        (new SchemaConfigurator($table, $idField))->configure(
+        (new SchemaConfigurator(new StringLiteral($table), new StringLiteral($idField)))->configure(
             $this->getConnection()->getSchemaManager()
         );
 

--- a/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
+++ b/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
@@ -75,10 +75,7 @@ class DBALResourceOwnerRepositoryTest extends TestCase
         );
     }
 
-    /**
-     * @param string $key
-     */
-    private function markEditable(StringLiteral $eventId, $key, StringLiteral $userId): void
+    private function markEditable(string $eventId, string $key, string $userId): void
     {
         $this->repository->markResourceEditableByUser($eventId, $userId);
     }
@@ -95,9 +92,9 @@ class DBALResourceOwnerRepositoryTest extends TestCase
             new StringLiteral('789'),
         ];
 
-        array_walk($editableByJohnDoe, [$this, 'markEditable'], new StringLiteral($johnDoe));
+        array_walk($editableByJohnDoe, [$this, 'markEditable'], $johnDoe);
 
-        $this->repository->markResourceEditableByUser(new StringLiteral('456'), new StringLiteral($johnDoe));
+        $this->repository->markResourceEditableByUser('456', $johnDoe);
 
         $this->assertEquals(
             $editableByJohnDoe,

--- a/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
+++ b/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
@@ -117,7 +117,7 @@ class DBALResourceOwnerRepositoryTest extends TestCase
 
         array_walk($editableByJohnDoe, [$this, 'markEditable'], new StringLiteral($johnDoe));
 
-        $this->repository->markResourceEditableByNewUser(new StringLiteral('456'), new StringLiteral($janeDoe));
+        $this->repository->markResourceEditableByNewUser('456', $janeDoe);
 
         $this->assertEquals(
             [

--- a/tests/Security/Sapi3RoleConstraintVoterTest.php
+++ b/tests/Security/Sapi3RoleConstraintVoterTest.php
@@ -13,7 +13,6 @@ use GuzzleHttp\Psr7\Uri;
 use Http\Client\HttpClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class Sapi3RoleConstraintVoterTest extends TestCase
 {
@@ -60,7 +59,7 @@ class Sapi3RoleConstraintVoterTest extends TestCase
         $userId = 'ff085fed-8500-4dd9-8ac0-459233c642f4';
         $permission = Permission::aanbodBewerken();
         $constraints = [
-            new StringLiteral('address.\*.postalCode:3000'),
+            'address.\*.postalCode:3000',
         ];
         $offerId = '625a4e74-a1ca-4bee-9e85-39869457d531';
         $query = '((address.\*.postalCode:3000) AND id:625a4e74-a1ca-4bee-9e85-39869457d531)';

--- a/tests/Security/Sapi3RoleConstraintVoterTest.php
+++ b/tests/Security/Sapi3RoleConstraintVoterTest.php
@@ -57,12 +57,12 @@ class Sapi3RoleConstraintVoterTest extends TestCase
         int $totalItems,
         bool $expected
     ): void {
-        $userId = new StringLiteral('ff085fed-8500-4dd9-8ac0-459233c642f4');
+        $userId = 'ff085fed-8500-4dd9-8ac0-459233c642f4';
         $permission = Permission::aanbodBewerken();
         $constraints = [
             new StringLiteral('address.\*.postalCode:3000'),
         ];
-        $offerId = new StringLiteral('625a4e74-a1ca-4bee-9e85-39869457d531');
+        $offerId = '625a4e74-a1ca-4bee-9e85-39869457d531';
         $query = '((address.\*.postalCode:3000) AND id:625a4e74-a1ca-4bee-9e85-39869457d531)';
 
         $this->userConstraintsReadRepository->expects($this->once())
@@ -120,9 +120,9 @@ class Sapi3RoleConstraintVoterTest extends TestCase
      */
     public function it_does_not_match_offer_when_user_has_no_matching_constraints(): void
     {
-        $userId = new StringLiteral('ff085fed-8500-4dd9-8ac0-459233c642f4');
+        $userId = 'ff085fed-8500-4dd9-8ac0-459233c642f4';
         $permission = Permission::aanbodBewerken();
-        $offerId = new StringLiteral('625a4e74-a1ca-4bee-9e85-39869457d531');
+        $offerId = '625a4e74-a1ca-4bee-9e85-39869457d531';
 
         $this->userConstraintsReadRepository->expects($this->once())
             ->method('getByUserAndPermission')


### PR DESCRIPTION
### Changed
- Refactored the `Security` namespace to use native `string` instead of deprecated `StringLiteral`

---
Ticket: https://jira.uitdatabank.be/browse/III-3853
