### PR TITLE
III-3853 Refactored `DeserializerInterface` to use `string`

### DIFF
--- a/app/RDF/DomainMessageJSONDeserializer.php
+++ b/app/RDF/DomainMessageJSONDeserializer.php
@@ -10,7 +10,6 @@ use Broadway\Domain\Metadata;
 use Broadway\Serializer\Serializable;
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Json;
-use CultuurNet\UDB3\StringLiteral;
 use InvalidArgumentException;
 
 final class DomainMessageJSONDeserializer implements DeserializerInterface
@@ -31,9 +30,9 @@ final class DomainMessageJSONDeserializer implements DeserializerInterface
         $this->payloadClass = $payloadClass;
     }
 
-    public function deserialize(StringLiteral $data): DomainMessage
+    public function deserialize(string $data): DomainMessage
     {
-        $data = Json::decodeAssociatively($data->toNative());
+        $data = Json::decodeAssociatively($data);
 
         if (null === $data) {
             throw new InvalidArgumentException('Invalid JSON');

--- a/src/Broadway/AMQP/AbstractConsumer.php
+++ b/src/Broadway/AMQP/AbstractConsumer.php
@@ -95,9 +95,7 @@ abstract class AbstractConsumer implements ConsumerInterface
                 $contentType
             );
 
-            $deserializedMessage = $deserializer->deserialize(
-                new StringLiteral($message->body)
-            );
+            $deserializedMessage = $deserializer->deserialize($message->body);
 
             $this->delayIfNecessary();
 

--- a/src/Deserializer/DeserializerInterface.php
+++ b/src/Deserializer/DeserializerInterface.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Deserializer;
 
-use CultuurNet\UDB3\StringLiteral;
-
 interface DeserializerInterface
 {
     /**
      * @return array|object
      */
-    public function deserialize(StringLiteral $data);
+    public function deserialize(string $data);
 }

--- a/src/Deserializer/JSONDeserializer.php
+++ b/src/Deserializer/JSONDeserializer.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Deserializer;
 
-use CultuurNet\UDB3\StringLiteral;
-
 class JSONDeserializer implements DeserializerInterface
 {
     private bool $assoc;
@@ -20,9 +18,9 @@ class JSONDeserializer implements DeserializerInterface
      *
      * @return object|object[]
      */
-    public function deserialize(StringLiteral $data)
+    public function deserialize(string $data)
     {
-        $data = json_decode($data->toNative(), $this->assoc);
+        $data = json_decode($data, $this->assoc);
 
         if (null === $data) {
             throw new NotWellFormedException('Invalid JSON');

--- a/src/EventExport/Command/ExportEventsAsPDFJSONDeserializer.php
+++ b/src/EventExport/Command/ExportEventsAsPDFJSONDeserializer.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Publisher;
 use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Subtitle;
 use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Title;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -21,7 +20,7 @@ use CultuurNet\UDB3\StringLiteral;
  */
 class ExportEventsAsPDFJSONDeserializer extends JSONDeserializer
 {
-    public function deserialize(StringLiteral $data): ExportEventsAsPDF
+    public function deserialize(string $data): ExportEventsAsPDF
     {
         $json = parent::deserialize($data);
 

--- a/src/EventExport/Command/ExportEventsJSONDeserializer.php
+++ b/src/EventExport/Command/ExportEventsJSONDeserializer.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\EventExport\EventExportQuery;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -16,7 +15,7 @@ use CultuurNet\UDB3\StringLiteral;
  */
 abstract class ExportEventsJSONDeserializer extends JSONDeserializer
 {
-    public function deserialize(StringLiteral $data): ExportEvents
+    public function deserialize(string $data): ExportEvents
     {
         $data = parent::deserialize($data);
 

--- a/src/Http/Deserializer/Address/AddressJSONDeserializer.php
+++ b/src/Http/Deserializer/Address/AddressJSONDeserializer.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Deserializer\Address;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Address\Address;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -27,7 +26,7 @@ class AddressJSONDeserializer extends JSONDeserializer
     /**
      * @throws DataValidationException
      */
-    public function deserialize(StringLiteral $data): Address
+    public function deserialize(string $data): Address
     {
         $data = parent::deserialize($data);
         $this->validator->validate($data);

--- a/src/Http/Deserializer/BookingInfo/BookingInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/BookingInfo/BookingInfoJSONDeserializer.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -21,7 +20,7 @@ class BookingInfoJSONDeserializer extends JSONDeserializer
         parent::__construct(true);
     }
 
-    public function deserialize(StringLiteral $data): BookingInfo
+    public function deserialize(string $data): BookingInfo
     {
         /* @var array $data */
         $data = parent::deserialize($data);

--- a/src/Http/Deserializer/Calendar/CalendarJSONDeserializer.php
+++ b/src/Http/Deserializer/Calendar/CalendarJSONDeserializer.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -30,7 +29,7 @@ class CalendarJSONDeserializer extends JSONDeserializer
         $this->calendarDataValidator = $calendarDataValidator;
     }
 
-    public function deserialize(StringLiteral $data): Calendar
+    public function deserialize(string $data): Calendar
     {
         $data = (array) parent::deserialize($data);
 

--- a/src/Http/Deserializer/ContactPoint/ContactPointJSONDeserializer.php
+++ b/src/Http/Deserializer/ContactPoint/ContactPointJSONDeserializer.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Http\Deserializer\ContactPoint;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\ContactPoint;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -23,7 +22,7 @@ class ContactPointJSONDeserializer extends JSONDeserializer
         $this->validator = new ContactPointDataValidator();
     }
 
-    public function deserialize(StringLiteral $data): ContactPoint
+    public function deserialize(string $data): ContactPoint
     {
         $data = parent::deserialize($data);
         $this->validator->validate($data);

--- a/src/Http/Deserializer/Event/CreateEventJSONDeserializer.php
+++ b/src/Http/Deserializer/Event/CreateEventJSONDeserializer.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Deserializer\Event;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Language;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -31,7 +30,7 @@ class CreateEventJSONDeserializer extends JSONDeserializer
     /**
      * @throws DataValidationException
      */
-    public function deserialize(StringLiteral $data): CreateEvent
+    public function deserialize(string $data): CreateEvent
     {
         /** @var array $deserializedData */
         $deserializedData = parent::deserialize($data);

--- a/src/Http/Deserializer/Event/EventTypeJSONDeserializer.php
+++ b/src/Http/Deserializer/Event/EventTypeJSONDeserializer.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Deserializer\Event;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Event\EventType;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -27,7 +26,7 @@ class EventTypeJSONDeserializer extends JSONDeserializer
     /**
      * @throws DataValidationException
      */
-    public function deserialize(StringLiteral $data): EventType
+    public function deserialize(string $data): EventType
     {
         $data = parent::deserialize($data);
         $this->validator->validate($data);

--- a/src/Http/Deserializer/Event/MajorInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/Event/MajorInfoJSONDeserializer.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONDeserializer;
 use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONParser;
 use CultuurNet\UDB3\Http\Deserializer\Theme\ThemeJSONDeserializer;
 use CultuurNet\UDB3\Title;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -45,18 +44,14 @@ class MajorInfoJSONDeserializer extends JSONDeserializer
     /**
      * @throws DataValidationException
      */
-    public function deserialize(StringLiteral $data): MajorInfo
+    public function deserialize(string $data): MajorInfo
     {
         $data = parent::deserialize($data);
         $this->validator->validate($data);
 
-        $type = $this->typeDeserializer->deserialize(
-            new StringLiteral(json_encode($data['type']))
-        );
+        $type = $this->typeDeserializer->deserialize(json_encode($data['type']));
 
-        $calendar = $this->calendarDeserializer->deserialize(
-            new StringLiteral(json_encode($data['calendar']))
-        );
+        $calendar = $this->calendarDeserializer->deserialize(json_encode($data['calendar']));
 
         $locationId = $data['location'];
         if (is_array($locationId) && isset($locationId['id'])) {
@@ -66,9 +61,7 @@ class MajorInfoJSONDeserializer extends JSONDeserializer
 
         $theme = null;
         if (!empty($data['theme'])) {
-            $theme = $this->themeDeserializer->deserialize(
-                new StringLiteral(json_encode($data['theme']))
-            );
+            $theme = $this->themeDeserializer->deserialize(json_encode($data['theme']));
         }
 
         return new MajorInfo(

--- a/src/Http/Deserializer/Organizer/OrganizerCreationPayloadJSONDeserializer.php
+++ b/src/Http/Deserializer/Organizer/OrganizerCreationPayloadJSONDeserializer.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Http\Deserializer\Address\AddressJSONDeserializer;
 use CultuurNet\UDB3\Http\Deserializer\ContactPoint\ContactPointJSONDeserializer;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Title;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -34,7 +33,7 @@ class OrganizerCreationPayloadJSONDeserializer extends JSONDeserializer
         $this->contactPointDeserializer = new ContactPointJSONDeserializer();
     }
 
-    public function deserialize(StringLiteral $data): OrganizerCreationPayload
+    public function deserialize(string $data): OrganizerCreationPayload
     {
         $data = parent::deserialize($data);
         $this->validator->validate($data);
@@ -44,19 +43,11 @@ class OrganizerCreationPayloadJSONDeserializer extends JSONDeserializer
         $contactPoint = null;
 
         if (isset($data['address'])) {
-            $address = $this->addressDeserializer->deserialize(
-                new StringLiteral(
-                    json_encode($data['address'])
-                )
-            );
+            $address = $this->addressDeserializer->deserialize(json_encode($data['address']));
         }
 
         if (isset($data['contact'])) {
-            $contactPoint = $this->contactPointDeserializer->deserialize(
-                new StringLiteral(
-                    json_encode($data['contact'])
-                )
-            );
+            $contactPoint = $this->contactPointDeserializer->deserialize(json_encode($data['contact']));
         }
 
         return new OrganizerCreationPayload(

--- a/src/Http/Deserializer/Organizer/UrlJSONDeserializer.php
+++ b/src/Http/Deserializer/Organizer/UrlJSONDeserializer.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Deserializer\Organizer;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -15,7 +14,7 @@ use CultuurNet\UDB3\StringLiteral;
  */
 class UrlJSONDeserializer extends JSONDeserializer
 {
-    public function deserialize(StringLiteral $data): Url
+    public function deserialize(string $data): Url
     {
         $data = parent::deserialize($data);
 

--- a/src/Http/Deserializer/Place/CreatePlaceJSONDeserializer.php
+++ b/src/Http/Deserializer/Place/CreatePlaceJSONDeserializer.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Deserializer\Place;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Language;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -31,7 +30,7 @@ class CreatePlaceJSONDeserializer extends JSONDeserializer
     /**
      * @throws DataValidationException
      */
-    public function deserialize(StringLiteral $data): CreatePlace
+    public function deserialize(string $data): CreatePlace
     {
         /** @var array $deserializedData */
         $deserializedData = parent::deserialize($data);

--- a/src/Http/Deserializer/Place/FacilitiesJSONDeserializer.php
+++ b/src/Http/Deserializer/Place/FacilitiesJSONDeserializer.php
@@ -34,7 +34,7 @@ class FacilitiesJSONDeserializer extends JSONDeserializer
      * @throws DataValidationException
      * @return Facility[]
      */
-    public function deserialize(StringLiteral $data): array
+    public function deserialize(string $data): array
     {
         $data = parent::deserialize($data);
         $this->validator->validate($data);

--- a/src/Http/Deserializer/Place/MajorInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/Place/MajorInfoJSONDeserializer.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONDeserializer;
 use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONParser;
 use CultuurNet\UDB3\Http\Deserializer\Event\EventTypeJSONDeserializer;
 use CultuurNet\UDB3\Title;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -45,22 +44,16 @@ class MajorInfoJSONDeserializer extends JSONDeserializer
     /**
      * @throws DataValidationException
      */
-    public function deserialize(StringLiteral $data): MajorInfo
+    public function deserialize(string $data): MajorInfo
     {
         $data = parent::deserialize($data);
         $this->validator->validate($data);
 
-        $type = $this->typeDeserializer->deserialize(
-            new StringLiteral(json_encode($data['type']))
-        );
+        $type = $this->typeDeserializer->deserialize(json_encode($data['type']));
 
-        $address = $this->addressDeserializer->deserialize(
-            new StringLiteral(json_encode($data['address']))
-        );
+        $address = $this->addressDeserializer->deserialize(json_encode($data['address']));
 
-        $calendar = $this->calendarDeserializer->deserialize(
-            new StringLiteral(json_encode($data['calendar']))
-        );
+        $calendar = $this->calendarDeserializer->deserialize(json_encode($data['calendar']));
 
         return new MajorInfo(
             new Title($data['name']),

--- a/src/Http/Deserializer/Theme/ThemeJSONDeserializer.php
+++ b/src/Http/Deserializer/Theme/ThemeJSONDeserializer.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Deserializer\Theme;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Theme;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -27,7 +26,7 @@ class ThemeJSONDeserializer extends JSONDeserializer
     /**
      * @throws DataValidationException
      */
-    public function deserialize(StringLiteral $data): Theme
+    public function deserialize(string $data): Theme
     {
         $data = parent::deserialize($data);
         $this->validator->validate($data);

--- a/src/Http/Deserializer/TitleJSONDeserializer.php
+++ b/src/Http/Deserializer/TitleJSONDeserializer.php
@@ -30,7 +30,7 @@ class TitleJSONDeserializer extends JSONDeserializer
         $this->propertyName = $propertyName;
     }
 
-    public function deserialize(StringLiteral $data): Title
+    public function deserialize(string $data): Title
     {
         $data = parent::deserialize($data);
 

--- a/src/Http/Event/UpdateMajorInfoRequestHandler.php
+++ b/src/Http/Event/UpdateMajorInfoRequestHandler.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use CultuurNet\UDB3\StringLiteral;
 
 class UpdateMajorInfoRequestHandler implements RequestHandlerInterface
 {
@@ -32,7 +31,7 @@ class UpdateMajorInfoRequestHandler implements RequestHandlerInterface
         $routeParameters = new RouteParameters($request);
         $eventId = $routeParameters->getEventId();
 
-        $majorInfo = $this->majorInfoDeserializer->deserialize(new StringLiteral((string) $request->getBody()));
+        $majorInfo = $this->majorInfoDeserializer->deserialize((string) $request->getBody());
 
         $this->commandBus->dispatch(
             new UpdateMajorInfo(

--- a/src/Http/Export/ExportEventsAsJsonLdRequestHandler.php
+++ b/src/Http/Export/ExportEventsAsJsonLdRequestHandler.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\EventExport\Command\ExportEventsAsJsonLDJSONDeserializer;
 use CultuurNet\UDB3\Http\AsyncDispatchTrait;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
-use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -31,9 +30,7 @@ final class ExportEventsAsJsonLdRequestHandler implements RequestHandlerInterfac
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $command = $this->deserializer->deserialize(
-            new StringLiteral($request->getBody()->getContents())
-        );
+        $command = $this->deserializer->deserialize($request->getBody()->getContents());
         $commandId = $this->dispatchAsyncCommand($this->commandBus, $command);
 
         return new JsonResponse(['commandId' => $commandId]);

--- a/src/Http/Export/ExportEventsAsOoXmlRequestHandler.php
+++ b/src/Http/Export/ExportEventsAsOoXmlRequestHandler.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\EventExport\Command\ExportEventsAsOOXMLJSONDeserializer;
 use CultuurNet\UDB3\Http\AsyncDispatchTrait;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
-use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -31,9 +30,7 @@ final class ExportEventsAsOoXmlRequestHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $command = $this->deserializer->deserialize(
-            new StringLiteral($request->getBody()->getContents())
-        );
+        $command = $this->deserializer->deserialize($request->getBody()->getContents());
         $commandId = $this->dispatchAsyncCommand($this->commandBus, $command);
 
         return new JsonResponse(['commandId' => $commandId]);

--- a/src/Http/Export/ExportEventsAsPdfRequestHandler.php
+++ b/src/Http/Export/ExportEventsAsPdfRequestHandler.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\EventExport\Command\ExportEventsAsPDFJSONDeserializer;
 use CultuurNet\UDB3\Http\AsyncDispatchTrait;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
-use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -31,9 +30,7 @@ final class ExportEventsAsPdfRequestHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $command = $this->deserializer->deserialize(
-            new StringLiteral($request->getBody()->getContents())
-        );
+        $command = $this->deserializer->deserialize($request->getBody()->getContents());
         $commandId = $this->dispatchAsyncCommand($this->commandBus, $command);
 
         return new JsonResponse(['commandId' => $commandId]);

--- a/src/Http/Offer/AddLabelFromJsonBodyRequestHandler.php
+++ b/src/Http/Offer/AddLabelFromJsonBodyRequestHandler.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
-use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -35,7 +34,7 @@ final class AddLabelFromJsonBodyRequestHandler implements RequestHandlerInterfac
         $offerId = $routeParameters->getOfferId();
         $bodyContent = $request->getBody()->getContents();
         try {
-            $label = $this->labelJsonDeserializer->deserialize(new StringLiteral($bodyContent));
+            $label = $this->labelJsonDeserializer->deserialize($bodyContent);
         } catch (\InvalidArgumentException $exception) {
             throw ApiProblem::bodyInvalidDataWithDetail('The label should match pattern: ^[^;]{2,255}$');
         }

--- a/src/Http/Offer/AddLabelToMultipleRequestHandler.php
+++ b/src/Http/Offer/AddLabelToMultipleRequestHandler.php
@@ -8,7 +8,6 @@ use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Http\AsyncDispatchTrait;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
-use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -31,9 +30,7 @@ final class AddLabelToMultipleRequestHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $command = $this->deserializer->deserialize(
-            new StringLiteral($request->getBody()->getContents())
-        );
+        $command = $this->deserializer->deserialize($request->getBody()->getContents());
         $commandId = $this->dispatchAsyncCommand($this->commandBus, $command);
 
         return new JsonResponse(['commandId' => $commandId]);

--- a/src/Http/Offer/AddLabelToQueryRequestHandler.php
+++ b/src/Http/Offer/AddLabelToQueryRequestHandler.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Http\AsyncDispatchTrait;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
 use CultuurNet\UDB3\Offer\Commands\AddLabelToQueryJSONDeserializer;
-use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -31,9 +30,7 @@ final class AddLabelToQueryRequestHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $command = $this->deserializer->deserialize(
-            new StringLiteral($request->getBody()->getContents())
-        );
+        $command = $this->deserializer->deserialize($request->getBody()->getContents());
         $commandId = $this->dispatchAsyncCommand($this->commandBus, $command);
 
         return new JsonResponse(['commandId' => $commandId]);

--- a/src/Http/Place/UpdateMajorInfoRequestHandler.php
+++ b/src/Http/Place/UpdateMajorInfoRequestHandler.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use CultuurNet\UDB3\StringLiteral;
 
 class UpdateMajorInfoRequestHandler implements RequestHandlerInterface
 {
@@ -32,7 +31,7 @@ class UpdateMajorInfoRequestHandler implements RequestHandlerInterface
         $routeParameters = new RouteParameters($request);
         $placeId = $routeParameters->getPlaceId();
 
-        $majorInfo = $this->majorInfoDeserializer->deserialize(new StringLiteral((string) $request->getBody()));
+        $majorInfo = $this->majorInfoDeserializer->deserialize((string) $request->getBody());
 
         $this->commandBus->dispatch(
             new UpdateMajorInfo(

--- a/src/Http/SavedSearches/CreateSavedSearchRequestHandler.php
+++ b/src/Http/SavedSearches/CreateSavedSearchRequestHandler.php
@@ -33,9 +33,7 @@ final class CreateSavedSearchRequestHandler implements RequestHandlerInterface
             new StringLiteral($this->userId)
         );
 
-        $command = $commandDeserializer->deserialize(
-            new StringLiteral($request->getBody()->getContents())
-        );
+        $command = $commandDeserializer->deserialize($request->getBody()->getContents());
 
         $this->commandBus->dispatch($command);
 

--- a/src/LabelJSONDeserializer.php
+++ b/src/LabelJSONDeserializer.php
@@ -15,7 +15,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
  */
 class LabelJSONDeserializer extends JSONDeserializer
 {
-    public function deserialize(StringLiteral $data): Label
+    public function deserialize(string $data): Label
     {
         $data = parent::deserialize($data);
 

--- a/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
+++ b/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -30,7 +29,7 @@ class AddLabelToMultipleJSONDeserializer extends JSONDeserializer
     /**
      * @throws NotWellFormedException
      */
-    public function deserialize(StringLiteral $data): AddLabelToMultiple
+    public function deserialize(string $data): AddLabelToMultiple
     {
         $data = parent::deserialize($data);
 
@@ -46,11 +45,7 @@ class AddLabelToMultipleJSONDeserializer extends JSONDeserializer
 
         foreach ($data->offers as $offer) {
             $offers = $offers->with(
-                $this->offerIdentifierDeserializer->deserialize(
-                    new StringLiteral(
-                        json_encode($offer)
-                    )
-                )
+                $this->offerIdentifierDeserializer->deserialize(json_encode($offer))
             );
         }
 

--- a/src/Offer/Commands/AddLabelToQueryJSONDeserializer.php
+++ b/src/Offer/Commands/AddLabelToQueryJSONDeserializer.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -16,7 +15,7 @@ use CultuurNet\UDB3\StringLiteral;
  */
 class AddLabelToQueryJSONDeserializer extends JSONDeserializer
 {
-    public function deserialize(StringLiteral $data): AddLabelToQuery
+    public function deserialize(string $data): AddLabelToQuery
     {
         $data = parent::deserialize($data);
 

--- a/src/Offer/IriOfferIdentifierJSONDeserializer.php
+++ b/src/Offer/IriOfferIdentifierJSONDeserializer.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -26,9 +25,9 @@ class IriOfferIdentifierJSONDeserializer implements DeserializerInterface
         $this->iriOfferIdentifierFactory = $iriOfferIdentifierFactory;
     }
 
-    public function deserialize(StringLiteral $data): IriOfferIdentifier
+    public function deserialize(string $data): IriOfferIdentifier
     {
-        $data = json_decode($data->toNative(), true);
+        $data = json_decode($data, true);
 
         if (null === $data) {
             throw new NotWellFormedException('Invalid JSON');

--- a/src/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializer.php
+++ b/src/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializer.php
@@ -23,7 +23,7 @@ class SubscribeToSavedSearchJSONDeserializer extends JSONDeserializer
         $this->userId = $userId;
     }
 
-    public function deserialize(StringLiteral $data): SubscribeToSavedSearch
+    public function deserialize(string $data): SubscribeToSavedSearch
     {
         $json = parent::deserialize($data);
 

--- a/src/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializer.php
+++ b/src/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializer.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\StringLiteral;
  */
 class EventCardSystemsUpdatedDeserializer extends JSONDeserializer
 {
-    public function deserialize(StringLiteral $data): EventCardSystemsUpdated
+    public function deserialize(string $data): EventCardSystemsUpdated
     {
         $dto = parent::deserialize($data);
 

--- a/src/UiTPAS/Event/Event/PricesUpdatedDeserializer.php
+++ b/src/UiTPAS/Event/Event/PricesUpdatedDeserializer.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\Model\ValueObject\Price\Tariffs;
 use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\MoneyFactory;
-use CultuurNet\UDB3\StringLiteral;
 use Money\Currency;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Validator;
@@ -53,7 +52,7 @@ final class PricesUpdatedDeserializer extends JSONDeserializer
         ],
     ];
 
-    public function deserialize(StringLiteral $data): PricesUpdated
+    public function deserialize(string $data): PricesUpdated
     {
         /** @var stdClass $dto */
         $dto = parent::deserialize($data);

--- a/tests/Deserializer/JSONDeserializerTest.php
+++ b/tests/Deserializer/JSONDeserializerTest.php
@@ -5,19 +5,12 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Deserializer;
 
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class JSONDeserializerTest extends TestCase
 {
-    /**
-     * @var JSONDeserializer
-     */
-    protected $deserializer;
+    private JSONDeserializer $deserializer;
 
-    /**
-     * @var JSONDeserializer
-     */
-    private $assocDeserializer;
+    private JSONDeserializer $assocDeserializer;
 
     public function setUp(): void
     {
@@ -35,11 +28,9 @@ class JSONDeserializerTest extends TestCase
         $this->expectExceptionMessage('Invalid JSON');
 
         $this->deserializer->deserialize(
-            new StringLiteral(
-                '{
-                  "eventId": "foo"
-                '
-            )
+            '{
+              "eventId": "foo"
+            '
         );
     }
 
@@ -48,9 +39,7 @@ class JSONDeserializerTest extends TestCase
      */
     public function itCanDeserializeToAnObject(): void
     {
-        $jsonString = new StringLiteral(
-            '{"key1":"value1","key2":{"key3":"value3"}}'
-        );
+        $jsonString = '{"key1":"value1","key2":{"key3":"value3"}}';
 
         $actualObject = $this->deserializer->deserialize($jsonString);
 
@@ -64,9 +53,7 @@ class JSONDeserializerTest extends TestCase
      */
     public function itCanDeserializeToAnAssociativeArray(): void
     {
-        $jsonString = new StringLiteral(
-            '{"key1":"value1","key2":{"key3":"value3"}}'
-        );
+        $jsonString = '{"key1":"value1","key2":{"key3":"value3"}}';
 
         $actualArray = $this->assocDeserializer->deserialize($jsonString);
 
@@ -75,10 +62,7 @@ class JSONDeserializerTest extends TestCase
         $this->assertEquals($expectedArray, $actualArray);
     }
 
-    /**
-     * @return \stdClass
-     */
-    private function createExpectedObject()
+    private function createExpectedObject(): \stdClass
     {
         $expectedObject = new \stdClass();
         $expectedObject->key1 = 'value1';
@@ -89,10 +73,7 @@ class JSONDeserializerTest extends TestCase
         return $expectedObject;
     }
 
-    /**
-     * @return array
-     */
-    private function createExpectedArray()
+    private function createExpectedArray(): array
     {
         $expectedArray = [];
         $expectedArray['key1'] = 'value1';

--- a/tests/EventExport/Command/ExportEventsAsPDFJSONDeserializerTest.php
+++ b/tests/EventExport/Command/ExportEventsAsPDFJSONDeserializerTest.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Subtitle;
 use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Title;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class ExportEventsAsPDFJSONDeserializerTest extends TestCase
 {
@@ -111,12 +110,8 @@ class ExportEventsAsPDFJSONDeserializerTest extends TestCase
         ];
     }
 
-    private function getJSONStringFromFile(string $fileName): StringLiteral
+    private function getJSONStringFromFile(string $fileName): string
     {
-        $json = file_get_contents(
-            __DIR__ . '/' . $fileName
-        );
-
-        return new StringLiteral($json);
+        return file_get_contents(__DIR__ . '/' . $fileName);
     }
 }

--- a/tests/EventExport/Command/ExportEventsJSONDeserializerTest.php
+++ b/tests/EventExport/Command/ExportEventsJSONDeserializerTest.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\EventExport\EventExportQuery;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class ExportEventsJSONDeserializerTest extends TestCase
 {
@@ -29,9 +28,7 @@ class ExportEventsJSONDeserializerTest extends TestCase
      */
     public function it_deserializes_a_minimal_export_command(): void
     {
-        $data = new StringLiteral(
-            $this->getJsonData('export_data_query.json')
-        );
+        $data = $this->getJsonData('export_data_query.json');
 
         $this->deserializer->expects($this->once())
             ->method('createCommand')
@@ -51,9 +48,7 @@ class ExportEventsJSONDeserializerTest extends TestCase
      */
     public function it_deserializes_a_complete_export_command(): void
     {
-        $data = new StringLiteral(
-            $this->getJsonData('export_data.json')
-        );
+        $data = $this->getJsonData('export_data.json');
 
         $this->deserializer->expects($this->once())
             ->method('createCommand')
@@ -81,7 +76,7 @@ class ExportEventsJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_query_is_missing(): void
     {
-        $data = new StringLiteral('{"email":"foo@bar.com"}');
+        $data = '{"email":"foo@bar.com"}';
         $this->expectException(MissingValueException::class);
         $this->deserializer->deserialize($data);
     }
@@ -89,16 +84,12 @@ class ExportEventsJSONDeserializerTest extends TestCase
     /**
      * @test
      * @dataProvider commandDataProvider
-     *
-     * @param string                $expectedCommandType
      */
     public function it_can_create_different_command_types(
         DeserializerInterface $deserializer,
-        $expectedCommandType
+        string $expectedCommandType
     ): void {
-        $data = new StringLiteral(
-            $this->getJsonData('export_data.json')
-        );
+        $data = $this->getJsonData('export_data.json');
 
         $command = $deserializer->deserialize($data);
 
@@ -120,10 +111,7 @@ class ExportEventsJSONDeserializerTest extends TestCase
         $this->assertEquals($expectedCommand, $command);
     }
 
-    /**
-     * @return array
-     */
-    public function commandDataProvider()
+    public function commandDataProvider(): array
     {
         return [
             [
@@ -137,11 +125,7 @@ class ExportEventsJSONDeserializerTest extends TestCase
         ];
     }
 
-    /**
-     * @param string $fileName
-     * @return string
-     */
-    private function getJsonData($fileName)
+    private function getJsonData(string $fileName): string
     {
         return file_get_contents(__DIR__ . '/' . $fileName);
     }

--- a/tests/Http/Deserializer/Address/AddressJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Address/AddressJSONDeserializerTest.php
@@ -11,14 +11,10 @@ use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class AddressJSONDeserializerTest extends TestCase
 {
-    /**
-     * @var AddressJSONDeserializer
-     */
-    private $deserializer;
+    private AddressJSONDeserializer $deserializer;
 
     public function setUp(): void
     {
@@ -30,7 +26,7 @@ class AddressJSONDeserializerTest extends TestCase
      */
     public function it_checks_all_required_fields_are_present(): void
     {
-        $data = new StringLiteral('{}');
+        $data = '{}';
 
         $expectedException = new DataValidationException();
         $expectedException->setValidationMessages(
@@ -55,15 +51,13 @@ class AddressJSONDeserializerTest extends TestCase
      */
     public function it_returns_an_address_object(): void
     {
-        $data = new StringLiteral(
-            json_encode(
-                [
-                    'streetAddress' => 'Wetstraat 1',
-                    'postalCode' => '1000',
-                    'addressLocality' => 'Brussel',
-                    'addressCountry' => 'BE',
-                ]
-            )
+        $data = json_encode(
+            [
+                'streetAddress' => 'Wetstraat 1',
+                'postalCode' => '1000',
+                'addressLocality' => 'Brussel',
+                'addressCountry' => 'BE',
+            ]
         );
 
         $expectedAddress = new Address(

--- a/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
@@ -22,7 +22,6 @@ use CultuurNet\UDB3\Timestamp;
 use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class CalendarJSONDeserializerTest extends TestCase
 {
@@ -41,9 +40,7 @@ class CalendarJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_json_to_calendar(): void
     {
-        $calendarAsJsonString = new StringLiteral(
-            file_get_contents(__DIR__ . '/samples/calendar.json')
-        );
+        $calendarAsJsonString = file_get_contents(__DIR__ . '/samples/calendar.json');
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),
@@ -101,9 +98,7 @@ class CalendarJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_json_to_calendar_with_status(): void
     {
-        $calendarAsJsonString = new StringLiteral(
-            file_get_contents(__DIR__ . '/samples/calendar_with_status.json')
-        );
+        $calendarAsJsonString = file_get_contents(__DIR__ . '/samples/calendar_with_status.json');
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),
@@ -137,9 +132,7 @@ class CalendarJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_json_to_calendar_with_booking_availability(): void
     {
-        $calendarAsJsonString = new StringLiteral(
-            file_get_contents(__DIR__ . '/samples/calendar_with_booking_availability.json')
-        );
+        $calendarAsJsonString = file_get_contents(__DIR__ . '/samples/calendar_with_booking_availability.json');
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),
@@ -169,9 +162,7 @@ class CalendarJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_json_to_calendar_with_status_on_time_spans(): void
     {
-        $calendarAsJsonString = new StringLiteral(
-            file_get_contents(__DIR__ . '/samples/calendar_with_status_on_time_spans.json')
-        );
+        $calendarAsJsonString = file_get_contents(__DIR__ . '/samples/calendar_with_status_on_time_spans.json');
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),
@@ -239,9 +230,7 @@ class CalendarJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_json_to_calendar_with_booking_availability_on_time_spans(): void
     {
-        $calendarAsJsonString = new StringLiteral(
-            file_get_contents(__DIR__ . '/samples/calendar_with_booking_availability_on_time_spans.json')
-        );
+        $calendarAsJsonString = file_get_contents(__DIR__ . '/samples/calendar_with_booking_availability_on_time_spans.json');
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),
@@ -286,7 +275,7 @@ class CalendarJSONDeserializerTest extends TestCase
         string $calendarData,
         CalendarType $expectedCalendarType
     ): void {
-        $calendarAsJsonString = new StringLiteral($calendarData);
+        $calendarAsJsonString = $calendarData;
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),

--- a/tests/Http/Deserializer/ContactPoint/ContactPointJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/ContactPoint/ContactPointJSONDeserializerTest.php
@@ -7,14 +7,10 @@ namespace CultuurNet\UDB3\Http\Deserializer\ContactPoint;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\ContactPoint;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class ContactPointJSONDeserializerTest extends TestCase
 {
-    /**
-     * @var ContactPointJSONDeserializer
-     */
-    private $contactPointJSONDeserializer;
+    private ContactPointJSONDeserializer $contactPointJSONDeserializer;
 
     protected function setUp(): void
     {
@@ -26,7 +22,7 @@ class ContactPointJSONDeserializerTest extends TestCase
      */
     public function it_validates_data_on_deserialize_and_throws_exception_when_invalid(): void
     {
-        $data = new StringLiteral('[{"type":"foo","value":"0123456789"}]');
+        $data = '[{"type":"foo","value":"0123456789"}]';
 
         $this->expectException(DataValidationException::class);
 
@@ -41,7 +37,7 @@ class ContactPointJSONDeserializerTest extends TestCase
         $phone1 = '{"type":"phone","value":"0123456789"}';
         $phone2 = '{"type":"phone","value":"9876543210"}';
         $email = '{"type":"email","value":"user@company.be"}';
-        $data = new StringLiteral('[' . $phone1 . ', ' . $phone2 . ', ' . $email . ']');
+        $data = '[' . $phone1 . ', ' . $phone2 . ', ' . $email . ']';
 
         $expectedContactPoint = new ContactPoint(
             ['0123456789', '9876543210'],

--- a/tests/Http/Deserializer/Event/CreateEventJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Event/CreateEventJSONDeserializerTest.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Language;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class CreateEventJSONDeserializerTest extends TestCase
 {
@@ -23,7 +22,7 @@ class CreateEventJSONDeserializerTest extends TestCase
 
         $createEventJSONDeserializer = new CreateEventJSONDeserializer();
 
-        $createEvent = $createEventJSONDeserializer->deserialize(new StringLiteral($createEventAsJson));
+        $createEvent = $createEventJSONDeserializer->deserialize($createEventAsJson);
 
         $expectedLocation = new LocationId('28cf728d-441b-4912-b3b0-f03df0d22491');
 

--- a/tests/Http/Deserializer/Event/MajorInfoJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Event/MajorInfoJSONDeserializerTest.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class MajorInfoJSONDeserializerTest extends TestCase
 {
@@ -22,7 +21,7 @@ class MajorInfoJSONDeserializerTest extends TestCase
 
         $majorInfoJSONDeserializer = new MajorInfoJSONDeserializer();
 
-        $majorInfo = $majorInfoJSONDeserializer->deserialize(new StringLiteral($majorInfoAsJson));
+        $majorInfo = $majorInfoJSONDeserializer->deserialize($majorInfoAsJson);
 
         $expectedLocation = new LocationId('28cf728d-441b-4912-b3b0-f03df0d22491');
 
@@ -41,7 +40,7 @@ class MajorInfoJSONDeserializerTest extends TestCase
 
         $majorInfoJSONDeserializer = new MajorInfoJSONDeserializer();
 
-        $majorInfo = $majorInfoJSONDeserializer->deserialize(new StringLiteral($majorInfoAsJson));
+        $majorInfo = $majorInfoJSONDeserializer->deserialize($majorInfoAsJson);
 
         $expectedLocation = new LocationId('28cf728d-441b-4912-b3b0-f03df0d22491');
 

--- a/tests/Http/Deserializer/Organizer/UrlJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Organizer/UrlJSONDeserializerTest.php
@@ -7,14 +7,10 @@ namespace CultuurNet\UDB3\Http\Deserializer\Organizer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class UrlJSONDeserializerTest extends TestCase
 {
-    /**
-     * @var UrlJSONDeserializer
-     */
-    private $urlJSONDeserializer;
+    private UrlJSONDeserializer $urlJSONDeserializer;
 
     protected function setUp(): void
     {
@@ -26,7 +22,7 @@ class UrlJSONDeserializerTest extends TestCase
      */
     public function it_can_serialize_a_valid_url(): void
     {
-        $json = new StringLiteral('{"url":"http://www.depot.be"}');
+        $json = '{"url":"http://www.depot.be"}';
 
         $actual = $this->urlJSONDeserializer->deserialize($json);
 
@@ -41,7 +37,7 @@ class UrlJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_url_is_missing(): void
     {
-        $json = new StringLiteral('{"foo":"http://www.depot.be"}');
+        $json = '{"foo":"http://www.depot.be"}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing value for "url".');
@@ -54,7 +50,7 @@ class UrlJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_url_is_invalid(): void
     {
-        $json = new StringLiteral('{"url":"http:/www.depot.be"}');
+        $json = '{"url":"http:/www.depot.be"}';
 
         $this->expectException(\InvalidArgumentException::class);
 

--- a/tests/Http/Deserializer/Place/CreatePlaceJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Place/CreatePlaceJSONDeserializerTest.php
@@ -14,7 +14,6 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class CreatePlaceJSONDeserializerTest extends TestCase
 {
@@ -27,7 +26,7 @@ class CreatePlaceJSONDeserializerTest extends TestCase
 
         $createPlaceJSONDeserializer = new CreatePlaceJSONDeserializer();
 
-        $createPlace = $createPlaceJSONDeserializer->deserialize(new StringLiteral($createPlaceAsJson));
+        $createPlace = $createPlaceJSONDeserializer->deserialize($createPlaceAsJson);
 
         $expectedAddress = new Address(
             new Street('Kerkstraat 1'),

--- a/tests/Http/Deserializer/Place/MajorInfoJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Place/MajorInfoJSONDeserializerTest.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class MajorInfoJSONDeserializerTest extends TestCase
 {
@@ -26,7 +25,7 @@ class MajorInfoJSONDeserializerTest extends TestCase
 
         $majorInfoJSONDeserializer = new MajorInfoJSONDeserializer();
 
-        $majorInfo = $majorInfoJSONDeserializer->deserialize(new StringLiteral($majorInfoAsJson));
+        $majorInfo = $majorInfoJSONDeserializer->deserialize($majorInfoAsJson);
 
         $expectedAddress = new Address(
             new Street('Kerkstraat 1'),

--- a/tests/Http/Deserializer/TitleJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/TitleJSONDeserializerTest.php
@@ -11,10 +11,7 @@ use CultuurNet\UDB3\StringLiteral;
 
 class TitleJSONDeserializerTest extends TestCase
 {
-    /**
-     * @var TitleJSONDeserializer
-     */
-    private $deserializer;
+    private TitleJSONDeserializer $deserializer;
 
     public function setUp(): void
     {
@@ -26,7 +23,7 @@ class TitleJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_a_valid_title(): void
     {
-        $json = new StringLiteral('{"title": "Lorem ipsum"}');
+        $json = '{"title": "Lorem ipsum"}';
         $expected = new Title('Lorem ipsum');
         $actual = $this->deserializer->deserialize($json);
         $this->assertEquals($expected, $actual);
@@ -39,7 +36,7 @@ class TitleJSONDeserializerTest extends TestCase
     {
         $deserializer = new TitleJSONDeserializer(false, new StringLiteral('name'));
 
-        $json = new StringLiteral('{"name": "Lorem ipsum"}');
+        $json = '{"name": "Lorem ipsum"}';
         $expected = new Title('Lorem ipsum');
 
         $actual = $deserializer->deserialize($json);
@@ -51,7 +48,7 @@ class TitleJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_a_title_is_missing(): void
     {
-        $json = new StringLiteral('{"foo": "bar"}');
+        $json = '{"foo": "bar"}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing value for "title".');

--- a/tests/Http/Place/FacilitiesJSONDeserializerTest.php
+++ b/tests/Http/Place/FacilitiesJSONDeserializerTest.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Offer\OfferFacilityResolverInterface;
 use CultuurNet\UDB3\Place\PlaceFacilityResolver;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class FacilitiesJSONDeserializerTest extends TestCase
 {
@@ -35,7 +34,7 @@ class FacilitiesJSONDeserializerTest extends TestCase
         $this->expectException(DataValidationException::class);
         $this->expectExceptionMessage('The facilities property should contain a list of ids');
 
-        $deserializer->deserialize(new StringLiteral('{"facilities": "C92E4A28-4A59-43DD-999E-7F53F735D30C"}'));
+        $deserializer->deserialize('{"facilities": "C92E4A28-4A59-43DD-999E-7F53F735D30C"}');
     }
 
     /**
@@ -53,9 +52,7 @@ class FacilitiesJSONDeserializerTest extends TestCase
 
         $expectedFacilities = [$facility];
 
-        $facilities = $deserializer->deserialize(new StringLiteral(
-            '{"facilities": ["3.23.1.0.0"]}'
-        ));
+        $facilities = $deserializer->deserialize('{"facilities": ["3.23.1.0.0"]}');
 
         $this->assertEquals($expectedFacilities, $facilities);
     }
@@ -75,9 +72,7 @@ class FacilitiesJSONDeserializerTest extends TestCase
 
         $expectedFacilities = [$facility];
 
-        $facilities = $deserializer->deserialize(new StringLiteral(
-            '{"facilities": ["3.23.1.0.0", "3.23.1.0.0"]}'
-        ));
+        $facilities = $deserializer->deserialize('{"facilities": ["3.23.1.0.0", "3.23.1.0.0"]}');
 
         $this->assertEquals($expectedFacilities, $facilities);
     }
@@ -94,9 +89,7 @@ class FacilitiesJSONDeserializerTest extends TestCase
 
         $expectedFacilities = [$wheelchairFacility, $audioDescriptionFacility];
 
-        $facilities = $deserializer->deserialize(new StringLiteral(
-            '{"facilities": ["3.13.1.0.0", "3.25.0.0.0"]}'
-        ));
+        $facilities = $deserializer->deserialize('{"facilities": ["3.13.1.0.0", "3.25.0.0.0"]}');
 
         $this->assertEquals($expectedFacilities, $facilities);
     }
@@ -110,8 +103,6 @@ class FacilitiesJSONDeserializerTest extends TestCase
 
         $this->expectExceptionMessage("Unknown facility id '1.8.2'");
 
-        $deserializer->deserialize(new StringLiteral(
-            '{"facilities": ["3.25.0.0.0", "1.8.2"]}'
-        ));
+        $deserializer->deserialize('{"facilities": ["3.25.0.0.0", "1.8.2"]}');
     }
 }

--- a/tests/LabelJSONDeserializerTest.php
+++ b/tests/LabelJSONDeserializerTest.php
@@ -26,7 +26,7 @@ class LabelJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_a_valid_label(): void
     {
-        $json = new StringLiteral('{"label": "test-label"}');
+        $json = '{"label": "test-label"}';
         $label = $this->deserializer->deserialize($json);
         $this->assertEquals($this->label, $label);
     }
@@ -36,7 +36,7 @@ class LabelJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_no_label_is_found(): void
     {
-        $json = new StringLiteral('{"foo": "bar"}');
+        $json = '{"foo": "bar"}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing value "label"!');

--- a/tests/Offer/Commands/AddLabelToMultipleJSONDeserializerTest.php
+++ b/tests/Offer/Commands/AddLabelToMultipleJSONDeserializerTest.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\Offer\IriOfferIdentifier;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
 use CultuurNet\UDB3\Offer\OfferType;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class AddLabelToMultipleJSONDeserializerTest extends TestCase
 {
@@ -26,10 +25,10 @@ class AddLabelToMultipleJSONDeserializerTest extends TestCase
         $offerIdentifierDeserializer->expects($this->any())
             ->method('deserialize')
             ->willReturnCallback(
-                function (StringLiteral $id) {
+                function (string $id) {
                     return new IriOfferIdentifier(
                         new Url("http://du.de/event/{$id}"),
-                        $id->toNative(),
+                        $id,
                         OfferType::event()
                     );
                 }
@@ -45,7 +44,7 @@ class AddLabelToMultipleJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_a_valid_add_label_to_multiple_command(): void
     {
-        $json = new StringLiteral('{"label":"foo", "offers": [1, 2, 3]}');
+        $json = '{"label":"foo", "offers": [1, 2, 3]}';
 
         $expected = new AddLabelToMultiple(
             (new OfferIdentifierCollection())
@@ -83,7 +82,7 @@ class AddLabelToMultipleJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_label_is_missing(): void
     {
-        $json = new StringLiteral('{"offers":[]}');
+        $json = '{"offers":[]}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing value "label".');
@@ -96,7 +95,7 @@ class AddLabelToMultipleJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_offers_are_missing(): void
     {
-        $json = new StringLiteral('{"label":"foo"}');
+        $json = '{"label":"foo"}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing value "offers".');

--- a/tests/Offer/Commands/AddLabelToQueryJSONDeserializerTest.php
+++ b/tests/Offer/Commands/AddLabelToQueryJSONDeserializerTest.php
@@ -8,14 +8,10 @@ use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class AddLabelToQueryJSONDeserializerTest extends TestCase
 {
-    /**
-     * @var AddLabelToQueryJSONDeserializer
-     */
-    private $deserializer;
+    private AddLabelToQueryJSONDeserializer $deserializer;
 
     public function setUp(): void
     {
@@ -30,7 +26,7 @@ class AddLabelToQueryJSONDeserializerTest extends TestCase
         $expectedLabel = new Label(new LabelName('foo'));
         $expectedQuery = 'city:leuven';
 
-        $json = new StringLiteral('{"label":"foo", "query":"city:leuven"}');
+        $json = '{"label":"foo", "query":"city:leuven"}';
 
         $command = $this->deserializer->deserialize($json);
 
@@ -43,7 +39,7 @@ class AddLabelToQueryJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_label_is_missing(): void
     {
-        $json = new StringLiteral('{"query": "city:leuven"}');
+        $json = '{"query": "city:leuven"}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing value "label".');
@@ -56,7 +52,7 @@ class AddLabelToQueryJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_label_is_empty(): void
     {
-        $json = new StringLiteral('{"label": "", "query": "city:leuven"}');
+        $json = '{"label": "", "query": "city:leuven"}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing value "label".');
@@ -69,7 +65,7 @@ class AddLabelToQueryJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_query_is_missing(): void
     {
-        $json = new StringLiteral('{"label": "foo"}');
+        $json = '{"label": "foo"}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing value "query".');
@@ -82,7 +78,7 @@ class AddLabelToQueryJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_query_is_empty(): void
     {
-        $json = new StringLiteral('{"label": "foo", "query": ""}');
+        $json = '{"label": "foo", "query": ""}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing value "query".');

--- a/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
+++ b/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
@@ -9,14 +9,10 @@ use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class IriOfferIdentifierJSONDeserializerTest extends TestCase
 {
-    /**
-     * @var IriOfferIdentifierJSONDeserializer
-     */
-    private $deserializer;
+    private IriOfferIdentifierJSONDeserializer $deserializer;
 
     /**
      * @var IriOfferIdentifierFactoryInterface|MockObject
@@ -36,7 +32,7 @@ class IriOfferIdentifierJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_a_valid_iri_offer_identifier(): void
     {
-        $json = new StringLiteral('{"@id":"http://du.de/event/1","@type":"Event"}');
+        $json = '{"@id":"http://du.de/event/1","@type":"Event"}';
 
         $expected = new IriOfferIdentifier(
             new Url('http://du.de/event/1'),
@@ -59,7 +55,7 @@ class IriOfferIdentifierJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_the_json_is_malformed(): void
     {
-        $json = new StringLiteral('{"foo"');
+        $json = '{"foo"';
 
         $this->expectException(NotWellFormedException::class);
         $this->expectExceptionMessage('Invalid JSON');
@@ -72,7 +68,7 @@ class IriOfferIdentifierJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_id_is_missing(): void
     {
-        $json = new StringLiteral('{"@type":"Event"}');
+        $json = '{"@type":"Event"}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing property "@id".');
@@ -85,7 +81,7 @@ class IriOfferIdentifierJSONDeserializerTest extends TestCase
      */
     public function it_throws_an_exception_when_type_is_missing(): void
     {
-        $json = new StringLiteral('{"@id":"http://du.de/event/1"}');
+        $json = '{"@id":"http://du.de/event/1"}';
 
         $this->expectException(MissingValueException::class);
         $this->expectExceptionMessage('Missing property "@type".');

--- a/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
+++ b/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
@@ -69,12 +69,8 @@ class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
         );
     }
 
-    private function getStringFromFile(string $fileName): StringLiteral
+    private function getStringFromFile(string $fileName): string
     {
-        $json = file_get_contents(
-            __DIR__ . '/' . $fileName
-        );
-
-        return new StringLiteral($json);
+        return file_get_contents(__DIR__ . '/' . $fileName);
     }
 }

--- a/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
+++ b/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
@@ -10,10 +10,7 @@ use CultuurNet\UDB3\StringLiteral;
 
 class EventCardSystemsUpdatedDeserializerTest extends TestCase
 {
-    /**
-     * @var EventCardSystemsUpdatedDeserializer
-     */
-    private $deserializer;
+    private EventCardSystemsUpdatedDeserializer $deserializer;
 
     public function setUp(): void
     {
@@ -41,7 +38,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
             ]
         );
 
-        $event = $this->deserializer->deserialize(new StringLiteral($json));
+        $event = $this->deserializer->deserialize($json);
         $cardSystems = $event->getCardSystems();
 
         $this->assertEquals('48ef34b0-e34a-4a15-9ae2-a5a01f189f90', $event->getId());
@@ -69,7 +66,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
             ]
         );
 
-        $event = $this->deserializer->deserialize(new StringLiteral($json));
+        $event = $this->deserializer->deserialize($json);
         $cardSystems = $event->getCardSystems();
 
         $this->assertEquals('48ef34b0-e34a-4a15-9ae2-a5a01f189f90', $event->getId());
@@ -90,7 +87,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
             ]
         );
 
-        $event = $this->deserializer->deserialize(new StringLiteral($json));
+        $event = $this->deserializer->deserialize($json);
         $cardSystems = $event->getCardSystems();
 
         $this->assertEquals('48ef34b0-e34a-4a15-9ae2-a5a01f189f90', $event->getId());
@@ -110,7 +107,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
             ]
         );
 
-        $this->deserializer->deserialize(new StringLiteral($json));
+        $this->deserializer->deserialize($json);
     }
 
     /**
@@ -126,7 +123,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
             ]
         );
 
-        $this->deserializer->deserialize(new StringLiteral($json));
+        $this->deserializer->deserialize($json);
     }
 
     /**
@@ -143,7 +140,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
             ]
         );
 
-        $this->deserializer->deserialize(new StringLiteral($json));
+        $this->deserializer->deserialize($json);
     }
 
     /**
@@ -164,7 +161,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
             ]
         );
 
-        $this->deserializer->deserialize(new StringLiteral($json));
+        $this->deserializer->deserialize($json);
     }
 
     /**
@@ -185,6 +182,6 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
             ]
         );
 
-        $this->deserializer->deserialize(new StringLiteral($json));
+        $this->deserializer->deserialize($json);
     }
 }

--- a/tests/UiTPAS/Event/Event/PricesUpdatedDeserializerTest.php
+++ b/tests/UiTPAS/Event/Event/PricesUpdatedDeserializerTest.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Model\ValueObject\Price\TariffName;
 use CultuurNet\UDB3\Model\ValueObject\Price\Tariffs;
 use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
-use CultuurNet\UDB3\StringLiteral;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
@@ -69,9 +68,7 @@ final class PricesUpdatedDeserializerTest extends TestCase
                     )
                 )
             ),
-            $this->pricesUpdatedDeserializer->deserialize(
-                new StringLiteral(Json::encode($pricesUpdatedAsArray))
-            )
+            $this->pricesUpdatedDeserializer->deserialize(Json::encode($pricesUpdatedAsArray))
         );
     }
 
@@ -84,9 +81,7 @@ final class PricesUpdatedDeserializerTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage($exceptionMessage);
 
-        $this->pricesUpdatedDeserializer->deserialize(
-            new StringLiteral(Json::encode($invalidData))
-        );
+        $this->pricesUpdatedDeserializer->deserialize(Json::encode($invalidData));
     }
 
     public function invalidDataProvider(): array


### PR DESCRIPTION
### Changed
- Refactored `DeserializerInterface` to use `string` instead of `StringLiteral`

---
Ticket: https://jira.uitdatabank.be/browse/III-3853
