### PR TITLE
III-3853 Remove stringliteral from description and add unittests

### DIFF
--- a/src/Description.php
+++ b/src/Description.php
@@ -4,19 +4,37 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3;
 
+use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\Trims;
 use CultuurNet\UDB3\Model\ValueObject\Text\Description as Udb3ModelDescription;
 
 /**
  * @deprecated
  *   Use CultuurNet\UDB3\Model\ValueObject\Text\Description instead where possible.
  */
-class Description extends StringLiteral
+final class Description
 {
-    /**
-     * @return Description
-     */
-    public static function fromUdb3ModelDescription(Udb3ModelDescription $udb3ModelDescription)
+    use Trims;
+
+    private string $value;
+
+    public function __construct(string $value)
     {
-        return new Description($udb3ModelDescription->toString());
+        $value = $this->trim($value);
+        $this->value = $value;
+    }
+
+    public static function fromUdb3ModelDescription(Udb3ModelDescription $udb3ModelDescription): self
+    {
+        return new self($udb3ModelDescription->toString());
+    }
+
+    public function toNative(): string
+    {
+        return $this->value;
+    }
+
+    public function sameValueAs(self $description): bool
+    {
+        return $this->toNative() === $description->toNative();
     }
 }

--- a/tests/DescriptionTest.php
+++ b/tests/DescriptionTest.php
@@ -22,6 +22,9 @@ class DescriptionTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * @test
+     */
     public function it_should_return_value_with_to_string(): void
     {
         $udb3ModelDescription = new Udb3ModelDescription('test');
@@ -29,6 +32,9 @@ class DescriptionTest extends TestCase
         $this->assertEquals('test', $udb3ModelDescription->toString());
     }
 
+    /**
+     * @test
+     */
     public function it_should_compare_two_strings(): void
     {
         $descriptionA = new Udb3ModelDescription('test');

--- a/tests/DescriptionTest.php
+++ b/tests/DescriptionTest.php
@@ -21,4 +21,19 @@ class DescriptionTest extends TestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function it_should_return_value_with_to_string(): void
+    {
+        $udb3ModelDescription = new Udb3ModelDescription('test');
+
+        $this->assertEquals('test', $udb3ModelDescription->toString());
+    }
+
+    public function it_should_compare_two_strings(): void
+    {
+        $descriptionA = new Udb3ModelDescription('test');
+        $descriptionB = new Udb3ModelDescription('test');
+
+        $this->assertTrue($descriptionA->sameAs($descriptionB));
+    }
 }

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -199,7 +199,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
                 'nl' => 'Foo',
             ],
             'description' => (object) [
-                'nl' => $description,
+                'nl' => $description->toNative(),
             ],
             'languages' => ['nl'],
             'completedLanguages' => ['nl'],


### PR DESCRIPTION
### Added
Unit tests for the new legacy street class methods
### Changed
III-3853 Remove stringliteral from description


---
Ticket: https://jira.uitdatabank.be/browse/III-3853