### PR TITLE
III-3853 StringLiteral Media/Description

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -101,7 +101,7 @@ use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
 
-class Event extends Offer
+final class Event extends Offer
 {
     protected string $eventId;
 

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -71,6 +71,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
+use CultuurNet\UDB3\Media\Properties\Description as ImageDescription;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEventUpdate;
@@ -547,7 +548,7 @@ class Event extends Offer
 
     protected function createImageUpdatedEvent(
         UUID $mediaObjectId,
-        StringLiteral $description,
+        ImageDescription $description,
         CopyrightHolder $copyrightHolder,
         ?string $language = null
     ): ImageUpdated {

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -94,7 +94,6 @@ use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\PriceInfo\Tariff;
-use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Timestamp;
 use CultuurNet\UDB3\Title;

--- a/src/Http/Media/UploadMediaRequestHandler.php
+++ b/src/Http/Media/UploadMediaRequestHandler.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\ImageUploaderInterface;
 use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
-use CultuurNet\UDB3\StringLiteral;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Http/Media/UploadMediaRequestHandler.php
+++ b/src/Http/Media/UploadMediaRequestHandler.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Http\Response\JsonResponse;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\ImageUploaderInterface;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\StringLiteral;
 use InvalidArgumentException;
@@ -71,7 +72,7 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
 
         $imageId = $this->imageUploader->upload(
             $uploadedFile,
-            new StringLiteral($description),
+            new Description($description),
             $copyrightHolder,
             $language
         );

--- a/src/Media/Commands/UploadImage.php
+++ b/src/Media/Commands/UploadImage.php
@@ -11,31 +11,19 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\StringLiteral;
 
-class UploadImage
+final class UploadImage
 {
-    protected UUID $fileId;
+    private UUID $fileId;
 
-    /**
-     * @var Language
-     */
-    protected $language;
+    private Language $language;
 
-    protected Description $description;
+    private Description $description;
 
-    /**
-     * @var CopyrightHolder
-     */
-    protected $copyrightHolder;
+    private CopyrightHolder $copyrightHolder;
 
-    /**
-     * @var MIMEType
-     */
-    protected $mimeType;
+    private MIMEType $mimeType;
 
-    /**
-     * @var StringLiteral
-     */
-    protected $filePath;
+    private StringLiteral $filePath;
 
     public function __construct(
         UUID $fileId,

--- a/src/Media/Commands/UploadImage.php
+++ b/src/Media/Commands/UploadImage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Media\Commands;
 
 use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -19,10 +20,7 @@ class UploadImage
      */
     protected $language;
 
-    /**
-     * @var StringLiteral
-     */
-    protected $description;
+    protected Description $description;
 
     /**
      * @var CopyrightHolder
@@ -42,7 +40,7 @@ class UploadImage
     public function __construct(
         UUID $fileId,
         MIMEType $mimeType,
-        StringLiteral $description,
+        Description $description,
         CopyrightHolder $copyrightHolder,
         StringLiteral$filePath,
         Language $language
@@ -65,7 +63,7 @@ class UploadImage
         return $this->fileId;
     }
 
-    public function getDescription(): StringLiteral
+    public function getDescription(): Description
     {
         return $this->description;
     }

--- a/src/Media/Events/MediaObjectCreated.php
+++ b/src/Media/Events/MediaObjectCreated.php
@@ -14,31 +14,16 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 
 final class MediaObjectCreated implements Serializable
 {
-    /**
-     * @var UUID
-     */
-    private $mediaObjectId;
+    private UUID $mediaObjectId;
 
-    /**
-     * @var MIMEType
-     */
-    private $mimeType;
+    private MIMEType $mimeType;
     private Description $description;
 
-    /**
-     * @var CopyrightHolder
-     */
-    private $copyrightHolder;
+    private CopyrightHolder $copyrightHolder;
 
-    /**
-     * @var Url
-     */
-    private $sourceLocation;
+    private Url $sourceLocation;
 
-    /**
-     * @var Language
-     */
-    private $language;
+    private Language $language;
 
     public function __construct(
         UUID $id,

--- a/src/Media/Events/MediaObjectCreated.php
+++ b/src/Media/Events/MediaObjectCreated.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use CultuurNet\UDB3\StringLiteral;
 
 final class MediaObjectCreated implements Serializable
 {

--- a/src/Media/Events/MediaObjectCreated.php
+++ b/src/Media/Events/MediaObjectCreated.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Media\Events;
 
 use Broadway\Serializer\Serializable;
 use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -23,11 +24,7 @@ final class MediaObjectCreated implements Serializable
      * @var MIMEType
      */
     private $mimeType;
-
-    /**
-     * @var StringLiteral
-     */
-    private $description;
+    private Description $description;
 
     /**
      * @var CopyrightHolder
@@ -47,7 +44,7 @@ final class MediaObjectCreated implements Serializable
     public function __construct(
         UUID $id,
         MIMEType $fileType,
-        StringLiteral $description,
+        Description $description,
         CopyrightHolder $copyrightHolder,
         Url $sourceLocation,
         Language $language
@@ -70,7 +67,7 @@ final class MediaObjectCreated implements Serializable
         return $this->mediaObjectId;
     }
 
-    public function getDescription(): StringLiteral
+    public function getDescription(): Description
     {
         return $this->description;
     }
@@ -114,7 +111,7 @@ final class MediaObjectCreated implements Serializable
         return new self(
             new UUID($data['media_object_id']),
             new MIMEType($data['mime_type']),
-            new StringLiteral($data['description']),
+            new Description($data['description']),
             new CopyrightHolder($copyrightHolderData),
             new Url($data['source_location']),
             array_key_exists('language', $data) ? new Language($data['language']) : new Language('nl')

--- a/src/Media/Image.php
+++ b/src/Media/Image.php
@@ -114,7 +114,7 @@ final class Image implements Serializable
         return [
             'media_object_id' => $this->getMediaObjectId()->toString(),
             'mime_type' => (string) $this->getMimeType(),
-            'description' => (string) $this->getDescription(),
+            'description' => $this->getDescription()->toNative(),
             'copyright_holder' => $this->getCopyrightHolder()->toString(),
             'source_location' => $this->getSourceLocation()->toString(),
             'language' => (string) $this->getLanguage(),

--- a/src/Media/Image.php
+++ b/src/Media/Image.php
@@ -14,35 +14,17 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 
 final class Image implements Serializable
 {
-    /**
-     * @var UUID
-     */
-    private $mediaObjectId;
+    private UUID $mediaObjectId;
 
-    /**
-     * @var MIMEType
-     */
-    private $mimeType;
+    private MIMEType $mimeType;
 
-    /**
-     * @var Description
-     */
-    private $description;
+    private Description $description;
 
-    /**
-     * @var CopyrightHolder
-     */
-    private $copyrightHolder;
+    private CopyrightHolder $copyrightHolder;
 
-    /**
-     * @var Url
-     */
-    private $sourceLocation;
+    private Url $sourceLocation;
 
-    /**
-     * @var Language
-     */
-    private $language;
+    private Language $language;
 
     public function __construct(
         UUID $id,

--- a/src/Media/ImageUploaderInterface.php
+++ b/src/Media/ImageUploaderInterface.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
-use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\UploadedFileInterface;
 
 interface ImageUploaderInterface

--- a/src/Media/ImageUploaderInterface.php
+++ b/src/Media/ImageUploaderInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Media;
 
 use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\StringLiteral;
@@ -14,7 +15,7 @@ interface ImageUploaderInterface
 {
     public function upload(
         UploadedFileInterface $file,
-        StringLiteral $description,
+        Description $description,
         CopyrightHolder $copyrightHolder,
         Language $language
     ): UUID;

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -19,7 +19,7 @@ use League\Flysystem\FilesystemOperator;
 use Psr\Http\Message\UploadedFileInterface;
 use RuntimeException;
 
-class ImageUploaderService implements ImageUploaderInterface
+final class ImageUploaderService implements ImageUploaderInterface
 {
     private UuidGeneratorInterface $uuidGenerator;
 

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Commands\UploadImage;
 use CultuurNet\UDB3\Media\Exceptions\InvalidFileSize;
 use CultuurNet\UDB3\Media\Exceptions\InvalidFileType;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -60,7 +61,7 @@ class ImageUploaderService implements ImageUploaderInterface
 
     public function upload(
         UploadedFileInterface $file,
-        StringLiteral $description,
+        Description $description,
         CopyrightHolder $copyrightHolder,
         Language $language
     ): UUID {

--- a/src/Media/MediaManager.php
+++ b/src/Media/MediaManager.php
@@ -50,7 +50,7 @@ class MediaManager extends Udb3CommandHandler implements LoggerAwareInterface, M
     public function create(
         UUID $id,
         MIMEType $fileType,
-        StringLiteral $description,
+        Description $description,
         CopyrightHolder $copyrightHolder,
         Url $sourceLocation,
         Language $language
@@ -130,7 +130,7 @@ class MediaManager extends Udb3CommandHandler implements LoggerAwareInterface, M
         return new Image(
             $mediaObject->getMediaObjectId(),
             $mediaObject->getMimeType(),
-            new Description((string) $mediaObject->getDescription()),
+            $mediaObject->getDescription(),
             $mediaObject->getCopyrightHolder(),
             $mediaObject->getSourceLocation(),
             $mediaObject->getLanguage()

--- a/src/Media/MediaManagerInterface.php
+++ b/src/Media/MediaManagerInterface.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Media;
 use Broadway\CommandHandling\CommandHandler;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Commands\UploadImage;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -24,7 +25,7 @@ interface MediaManagerInterface extends CommandHandler
     public function create(
         UUID $id,
         MIMEType $mimeType,
-        StringLiteral $description,
+        Description $description,
         CopyrightHolder $copyrightHolder,
         Url $sourceLocation,
         Language $language

--- a/src/Media/MediaManagerInterface.php
+++ b/src/Media/MediaManagerInterface.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use CultuurNet\UDB3\StringLiteral;
 
 interface MediaManagerInterface extends CommandHandler
 {

--- a/src/Media/MediaObject.php
+++ b/src/Media/MediaObject.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use CultuurNet\UDB3\StringLiteral;
 
 class MediaObject extends EventSourcedAggregateRoot
 {

--- a/src/Media/MediaObject.php
+++ b/src/Media/MediaObject.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Media;
 use Broadway\EventSourcing\EventSourcedAggregateRoot;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Events\MediaObjectCreated;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -19,7 +20,7 @@ class MediaObject extends EventSourcedAggregateRoot
 
     protected UUID $mediaObjectId;
 
-    protected StringLiteral $description;
+    protected Description $description;
 
     protected CopyrightHolder $copyrightHolder;
 
@@ -30,7 +31,7 @@ class MediaObject extends EventSourcedAggregateRoot
     public static function create(
         UUID $id,
         MIMEType $mimeType,
-        StringLiteral $description,
+        Description $description,
         CopyrightHolder $copyrightHolder,
         Url $sourceLocation,
         Language $language
@@ -65,7 +66,7 @@ class MediaObject extends EventSourcedAggregateRoot
         $this->language = $mediaObjectCreated->getLanguage();
     }
 
-    public function getDescription(): StringLiteral
+    public function getDescription(): Description
     {
         return $this->description;
     }

--- a/src/Media/Properties/Description.php
+++ b/src/Media/Properties/Description.php
@@ -4,8 +4,22 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Media\Properties;
 
-use CultuurNet\UDB3\StringLiteral;
-
-class Description extends StringLiteral
+final class Description
 {
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function toNative(): string
+    {
+        return $this->value;
+    }
+
+    public function sameValueAs(Description $description): bool
+    {
+        return $this->toNative() === $description->toNative();
+    }
 }

--- a/src/Media/Serialization/MediaObjectSerializer.php
+++ b/src/Media/Serialization/MediaObjectSerializer.php
@@ -39,7 +39,7 @@ class MediaObjectSerializer
             'id' => $mediaObject->getMediaObjectId()->toString(),
             'contentUrl' => $mediaObject->getSourceLocation()->toString(),
             'thumbnailUrl' => $mediaObject->getSourceLocation()->toString(),
-            'description' => (string) $mediaObject->getDescription(),
+            'description' => $mediaObject->getDescription()->toNative(),
             'copyrightHolder' => $mediaObject->getCopyrightHolder()->toString(),
             'inLanguage' => (string) $mediaObject->getLanguage(),
         ];

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -551,7 +551,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     public function updateImage(
         UUID $mediaObjectId,
-        StringLiteral $description,
+        ImageDescription $description,
         CopyrightHolder $copyrightHolder
     ): void {
         if ($this->updateImageAllowed($mediaObjectId, $description, $copyrightHolder)) {
@@ -567,7 +567,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     private function updateImageAllowed(
         UUID $mediaObjectId,
-        StringLiteral $description,
+        ImageDescription $description,
         CopyrightHolder $copyrightHolder
     ): bool {
         $image = $this->images->findImageByUUID($mediaObjectId);
@@ -1054,7 +1054,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     abstract protected function createImageUpdatedEvent(
         UUID $uuid,
-        StringLiteral $description,
+        ImageDescription $description,
         CopyrightHolder $copyrightHolder,
         ?string $language = null
     ): AbstractImageUpdated;

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -69,7 +69,6 @@ use CultuurNet\UDB3\Offer\Events\Moderation\AbstractPublished;
 use CultuurNet\UDB3\Offer\Events\Moderation\AbstractRejected;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
-use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;

--- a/src/Offer/OfferCommandHandler.php
+++ b/src/Offer/OfferCommandHandler.php
@@ -26,7 +26,6 @@ use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractFlagAsInappropriate;
 use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractPublish;
 use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractReject;
 use CultuurNet\UDB3\Organizer\Organizer;
-use CultuurNet\UDB3\StringLiteral;
 
 abstract class OfferCommandHandler extends Udb3CommandHandler
 {

--- a/src/Offer/OfferCommandHandler.php
+++ b/src/Offer/OfferCommandHandler.php
@@ -8,6 +8,7 @@ use Broadway\Repository\Repository;
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
 use CultuurNet\UDB3\Media\MediaManager;
 use CultuurNet\UDB3\Media\MediaManagerInterface;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Offer\Commands\AbstractDeleteCurrentOrganizer;
 use CultuurNet\UDB3\Offer\Commands\AbstractDeleteTypicalAgeRange;
 use CultuurNet\UDB3\Offer\Commands\AbstractUpdateBookingInfo;
@@ -142,7 +143,7 @@ abstract class OfferCommandHandler extends Udb3CommandHandler
         $offer = $this->load($updateImage->getItemId());
         $offer->updateImage(
             $updateImage->getMediaObjectId(),
-            new StringLiteral($updateImage->getDescription()),
+            new Description($updateImage->getDescription()),
             $updateImage->getCopyrightHolder()
         );
         $this->offerRepository->save($offer);

--- a/src/Offer/OfferCommandHandler.php
+++ b/src/Offer/OfferCommandHandler.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Offer;
 
 use Broadway\Repository\Repository;
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
-use CultuurNet\UDB3\Media\MediaManager;
 use CultuurNet\UDB3\Media\MediaManagerInterface;
 use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Offer\Commands\AbstractDeleteCurrentOrganizer;
@@ -33,10 +32,7 @@ abstract class OfferCommandHandler extends Udb3CommandHandler
 
     protected Repository $organizerRepository;
 
-    /**
-     * @var MediaManagerInterface|MediaManager
-     */
-    protected $mediaManager;
+    protected MediaManagerInterface $mediaManager;
 
     public function __construct(
         Repository $offerRepository,

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -73,7 +73,6 @@ use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
-use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language as Udb3Language;
 
 class Place extends Offer

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
+use CultuurNet\UDB3\Media\Properties\Description as ImageDescription;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -360,7 +361,7 @@ class Place extends Offer
 
     protected function createImageUpdatedEvent(
         UUID $mediaObjectId,
-        StringLiteral $description,
+        ImageDescription $description,
         CopyrightHolder $copyrightHolder,
         ?string $language = null
     ): ImageUpdated {

--- a/tests/Event/EventCommandHandlerTest.php
+++ b/tests/Event/EventCommandHandlerTest.php
@@ -26,7 +26,7 @@ use CultuurNet\UDB3\Event\Events\MajorInfoUpdated;
 use CultuurNet\UDB3\Event\ValueObjects\Audience;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
-use CultuurNet\UDB3\Media\MediaManager;
+use CultuurNet\UDB3\Media\MediaManagerInterface;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\OfferCommandHandlerTestTrait;
 use CultuurNet\UDB3\Theme;
@@ -47,7 +47,7 @@ class EventCommandHandlerTest extends CommandHandlerScenarioTestCase
 
         $this->organizerRepository = $this->createMock(Repository::class);
 
-        $this->mediaManager = $this->createMock(MediaManager::class);
+        $this->mediaManager = $this->createMock(MediaManagerInterface::class);
 
         return new EventCommandHandler(
             $repository,

--- a/tests/Http/Media/GetMediaRequestHandlerTest.php
+++ b/tests/Http/Media/GetMediaRequestHandlerTest.php
@@ -11,12 +11,12 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\MediaManager;
 use CultuurNet\UDB3\Media\MediaObject;
 use CultuurNet\UDB3\Media\MediaUrlMapping;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use CultuurNet\UDB3\StringLiteral;
 use PHPUnit\Framework\TestCase;
 
 final class GetMediaRequestHandlerTest extends TestCase
@@ -42,7 +42,7 @@ final class GetMediaRequestHandlerTest extends TestCase
                 MediaObject::create(
                     new UUID($id),
                     MIMEType::fromSubtype('jpeg'),
-                    new StringLiteral('UDB2 image'),
+                    new Description('UDB2 image'),
                     new CopyrightHolder('publiq'),
                     new Url('https://media.uitdatabank.be/123/5624b810-c340-40a4-8f38-0393eca59bfe.jpg'),
                     new Language('nl')

--- a/tests/Http/Offer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Offer/AddImageRequestHandlerTest.php
@@ -16,13 +16,13 @@ use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\MediaObject;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\Commands\Image\AbstractAddImage;
 use CultuurNet\UDB3\Place\Commands\AddImage as PlaceAddImage;
-use CultuurNet\UDB3\StringLiteral;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -81,7 +81,7 @@ final class AddImageRequestHandlerTest extends TestCase
                 MediaObject::create(
                     new UUID(self::MEDIA_ID),
                     MIMEType::fromSubtype('jpeg'),
-                    new StringLiteral('Uploaded image'),
+                    new Description('Uploaded image'),
                     new CopyrightHolder('madewithlove'),
                     new Url('https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg'),
                     new LegacyLanguage('nl')

--- a/tests/Http/Organizer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/AddImageRequestHandlerTest.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\MediaObject;
+use CultuurNet\UDB3\Media\Properties\Description as ImageDescription;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -23,7 +24,6 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Organizer\Commands\AddImage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 final class AddImageRequestHandlerTest extends TestCase
 {
@@ -64,7 +64,7 @@ final class AddImageRequestHandlerTest extends TestCase
                 MediaObject::create(
                     new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
                     MIMEType::fromSubtype('jpeg'),
-                    new StringLiteral('Uploaded image'),
+                    new ImageDescription('Uploaded image'),
                     new CopyrightHolder('madewithlove'),
                     new Url('https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg'),
                     new LegacyLanguage('nl')

--- a/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
+++ b/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
@@ -21,6 +21,7 @@ use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\MediaObject;
 use CultuurNet\UDB3\Media\MediaObjectRepository;
+use CultuurNet\UDB3\Media\Properties\Description as ImageDescription;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
@@ -56,7 +57,6 @@ use CultuurNet\UDB3\Organizer\Commands\UpdateTitle;
 use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 use CultuurNet\UDB3\Organizer\Organizer;
 use CultuurNet\UDB3\Organizer\Organizer as OrganizerAggregate;
-use CultuurNet\UDB3\StringLiteral;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -118,7 +118,7 @@ class ImportOrganizerRequestHandlerTest extends TestCase
 
         $mediaObject
             ->method('getDescription')
-            ->willReturn(new StringLiteral($description));
+            ->willReturn(new ImageDescription($description));
 
         $mediaObject
             ->method('getCopyrightHolder')

--- a/tests/Media/Commands/UploadImageTest.php
+++ b/tests/Media/Commands/UploadImageTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use PHPUnit\Framework\TestCase;
 use CultuurNet\UDB3\StringLiteral;
 
-class UploadImageTest extends TestCase
+final class UploadImageTest extends TestCase
 {
     /**
      * @var UploadImage

--- a/tests/Media/Commands/UploadImageTest.php
+++ b/tests/Media/Commands/UploadImageTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Media\Commands;
 
 use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -23,7 +24,7 @@ class UploadImageTest extends TestCase
         $this->uploadImage = new UploadImage(
             new UUID('de305d54-75b4-431b-adb2-eb6b9e546014'),
             new MIMEType('image/png'),
-            StringLiteral::fromNative('description'),
+            new Description('description'),
             new CopyrightHolder('copyright'),
             StringLiteral::fromNative('/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
             new Language('en')
@@ -58,7 +59,7 @@ class UploadImageTest extends TestCase
     public function it_stores_a_description(): void
     {
         $this->assertEquals(
-            StringLiteral::fromNative('description'),
+            new Description('description'),
             $this->uploadImage->getDescription()
         );
     }

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\UploadedFileInterface;
 use RuntimeException;
 use Zend\Diactoros\Stream;
 
-class ImageUploaderServiceTest extends TestCase
+final class ImageUploaderServiceTest extends TestCase
 {
     private UUID $fileId;
 

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -9,12 +9,12 @@ use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Exceptions\InvalidFileSize;
 use CultuurNet\UDB3\Media\Exceptions\InvalidFileType;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\UploadedFileInterface;
 use RuntimeException;
 use Zend\Diactoros\Stream;
@@ -63,7 +63,7 @@ class ImageUploaderServiceTest extends TestCase
      */
     public function it_should_throw_an_exception_if_the_uploaded_file_is_not_an_image(): void
     {
-        $description = new StringLiteral('file description');
+        $description = new Description('file description');
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
         $image = $this->createMock(UploadedFileInterface::class);
@@ -106,7 +106,7 @@ class ImageUploaderServiceTest extends TestCase
             ->method('getSize')
             ->willReturn(1000001);
 
-        $description = new StringLiteral('file description');
+        $description = new Description('file description');
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
@@ -144,7 +144,7 @@ class ImageUploaderServiceTest extends TestCase
             ->method('getError')
             ->willReturn(UPLOAD_ERR_CANT_WRITE);
 
-        $description = new StringLiteral('file description');
+        $description = new Description('file description');
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
@@ -184,7 +184,7 @@ class ImageUploaderServiceTest extends TestCase
             ->method('getStream')
             ->willReturn(new Stream(fopen(__DIR__ . '/files/my-image.png', 'rb')));
 
-        $description = new StringLiteral('file description');
+        $description = new Description('file description');
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
@@ -224,7 +224,7 @@ class ImageUploaderServiceTest extends TestCase
             ->method('getStream')
             ->willReturn(new Stream(fopen(__DIR__ . '/files/my-image.png', 'rb')));
 
-        $description = new StringLiteral('file description');
+        $description = new Description('file description');
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
@@ -264,7 +264,7 @@ class ImageUploaderServiceTest extends TestCase
             ->method('getStream')
             ->willReturn(new Stream(fopen(__DIR__ . '/files/my-image.png', 'rb')));
 
-        $description = new StringLiteral('file description');
+        $description = new Description('file description');
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
@@ -304,7 +304,7 @@ class ImageUploaderServiceTest extends TestCase
             1000000
         );
 
-        $description = new StringLiteral('file description');
+        $description = new Description('file description');
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 

--- a/tests/Media/MediaManagerTest.php
+++ b/tests/Media/MediaManagerTest.php
@@ -66,7 +66,7 @@ class MediaManagerTest extends TestCase
         $command = new UploadImage(
             new UUID('de305d54-75b4-431b-adb2-eb6b9e546014'),
             new MIMEType('image/png'),
-            StringLiteral::fromNative('description'),
+            new Description('description'),
             new CopyrightHolder('copyright'),
             StringLiteral::fromNative('/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
             new Language('en')
@@ -109,7 +109,7 @@ class MediaManagerTest extends TestCase
         $command = new UploadImage(
             new UUID('de305d54-75b4-431b-adb2-eb6b9e546014'),
             new MIMEType('image/png'),
-            StringLiteral::fromNative('description'),
+            new Description('description'),
             new CopyrightHolder('copyright'),
             StringLiteral::fromNative('/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
             new Language('en')

--- a/tests/Media/MediaManagerTest.php
+++ b/tests/Media/MediaManagerTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use CultuurNet\UDB3\StringLiteral;
 
-class MediaManagerTest extends TestCase
+final class MediaManagerTest extends TestCase
 {
     private MediaManager $mediaManager;
 

--- a/tests/Media/MediaObjectCreatedTest.php
+++ b/tests/Media/MediaObjectCreatedTest.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
 
-class MediaObjectCreatedTest extends TestCase
+final class MediaObjectCreatedTest extends TestCase
 {
     /**
      * @test

--- a/tests/Media/MediaObjectCreatedTest.php
+++ b/tests/Media/MediaObjectCreatedTest.php
@@ -6,12 +6,12 @@ namespace CultuurNet\UDB3\Media;
 
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Events\MediaObjectCreated;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class MediaObjectCreatedTest extends TestCase
 {
@@ -58,7 +58,7 @@ class MediaObjectCreatedTest extends TestCase
                 new MediaObjectCreated(
                     new UUID('de305d54-75b4-431b-adb2-eb6b9e546014'),
                     new MIMEType('image/png'),
-                    new StringLiteral('The Gleaners'),
+                    new Description('The Gleaners'),
                     new CopyrightHolder('Jean-François Millet'),
                     new Url('http://foo.be/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
                     new Language('en')
@@ -83,7 +83,7 @@ class MediaObjectCreatedTest extends TestCase
         $expectedEvent = new MediaObjectCreated(
             new UUID('de305d54-75b4-431b-adb2-eb6b9e546014'),
             new MIMEType('image/png'),
-            new StringLiteral('The Gleaners'),
+            new Description('The Gleaners'),
             new CopyrightHolder('Jean-François Millet'),
             new Url('http://foo.be/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
             new Language('nl')
@@ -108,7 +108,7 @@ class MediaObjectCreatedTest extends TestCase
         $expectedEvent = new MediaObjectCreated(
             new UUID('de305d54-75b4-431b-adb2-eb6b9e546014'),
             new MIMEType('image/png'),
-            new StringLiteral('The Gleaners'),
+            new Description('The Gleaners'),
             new CopyrightHolder('J_'),
             new Url('http://foo.be/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
             new Language('nl')

--- a/tests/Media/MediaObjectTest.php
+++ b/tests/Media/MediaObjectTest.php
@@ -7,11 +7,11 @@ namespace CultuurNet\UDB3\Media;
 use Broadway\EventSourcing\Testing\AggregateRootScenarioTestCase;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Events\MediaObjectCreated;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use CultuurNet\UDB3\StringLiteral;
 
 class MediaObjectTest extends AggregateRootScenarioTestCase
 {
@@ -27,7 +27,7 @@ class MediaObjectTest extends AggregateRootScenarioTestCase
     {
         $fileId = new UUID('de305d54-75b4-431b-adb2-eb6b9e546014');
         $fileType = new MIMEType('image/png');
-        $description = new StringLiteral('The Gleaners');
+        $description = new Description('The Gleaners');
         $copyrightHolder = new CopyrightHolder('Jean-François Millet');
         $location = new Url('http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png');
         $language = new Language('en');
@@ -68,7 +68,7 @@ class MediaObjectTest extends AggregateRootScenarioTestCase
         $mediaObject = MediaObject::create(
             new UUID('de305d54-75b4-431b-adb2-eb6b9e546014'),
             new MIMEType('image/png'),
-            new StringLiteral('The Gleaners'),
+            new Description('The Gleaners'),
             new CopyrightHolder('Jean-François Millet'),
             new Url('http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
             new Language('en')
@@ -85,7 +85,7 @@ class MediaObjectTest extends AggregateRootScenarioTestCase
         );
 
         $this->assertEquals(
-            new StringLiteral('The Gleaners'),
+            new Description('The Gleaners'),
             $mediaObject->getDescription()
         );
 

--- a/tests/Media/MediaObjectTest.php
+++ b/tests/Media/MediaObjectTest.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 
-class MediaObjectTest extends AggregateRootScenarioTestCase
+final class MediaObjectTest extends AggregateRootScenarioTestCase
 {
     protected function getAggregateRootClass(): string
     {

--- a/tests/Offer/Item/Item.php
+++ b/tests/Offer/Item/Item.php
@@ -71,7 +71,7 @@ use CultuurNet\UDB3\StringLiteral;
  * @deprecated
  *   Use a real Offer implementation in tests instead.
  */
-class Item extends Offer
+final class Item extends Offer
 {
     protected string $id;
 

--- a/tests/Offer/Item/Item.php
+++ b/tests/Offer/Item/Item.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Description;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
+use CultuurNet\UDB3\Media\Properties\Description as ImageDescription;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -123,7 +124,7 @@ class Item extends Offer
 
     protected function createImageUpdatedEvent(
         UUID $mediaObjectId,
-        StringLiteral $description,
+        ImageDescription $description,
         CopyrightHolder $copyrightHolder,
         ?string $language = null
     ): ImageUpdated {

--- a/tests/Offer/Item/Item.php
+++ b/tests/Offer/Item/Item.php
@@ -65,7 +65,6 @@ use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Title;
 use DateTimeInterface;
 use RuntimeException;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/tests/Offer/OfferCommandHandlerTest.php
+++ b/tests/Offer/OfferCommandHandlerTest.php
@@ -10,6 +10,7 @@ use Broadway\EventStore\EventStore;
 use Broadway\Repository\Repository;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\MediaManager;
+use CultuurNet\UDB3\Media\MediaManagerInterface;
 use CultuurNet\UDB3\Offer\Item\Commands\DeleteCurrentOrganizer;
 use CultuurNet\UDB3\Offer\Item\Commands\Moderation\Approve;
 use CultuurNet\UDB3\Offer\Item\Commands\Moderation\FlagAsDuplicate;
@@ -101,7 +102,7 @@ class OfferCommandHandlerTest extends CommandHandlerScenarioTestCase
         EventBus $eventBus
     ): ItemCommandHandler {
         $this->organizerRepository = $this->createMock(Repository::class);
-        $this->mediaManager = $this->createMock(MediaManager::class);
+        $this->mediaManager = $this->createMock(MediaManagerInterface::class);
 
         return new ItemCommandHandler(
             new ItemRepository($eventStore, $eventBus),

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -241,7 +241,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
                     'id' => 'de305d54-75b4-431b-adb2-eb6b9e546014',
                     'contentUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
                     'thumbnailUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
-                    'description' => (string) $description,
+                    'description' => $description->toNative(),
                     'copyrightHolder' => $copyrightHolder->toString(),
                     'inLanguage' => 'en',
                 ],

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -20,6 +20,7 @@ use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\MediaObject;
+use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\ImageNormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
@@ -61,7 +62,6 @@ use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
 use CultuurNet\UDB3\RecordedOn;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 final class OrganizerLDProjectorTest extends TestCase
 {
@@ -559,7 +559,7 @@ final class OrganizerLDProjectorTest extends TestCase
                 MediaObject::create(
                     new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
                     MIMEType::fromSubtype('jpeg'),
-                    new StringLiteral('Uploaded image'),
+                    new Description('Uploaded image'),
                     new CopyrightHolder('publiq'),
                     new Url('https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg'),
                     new Language('nl')
@@ -595,7 +595,7 @@ final class OrganizerLDProjectorTest extends TestCase
                 MediaObject::create(
                     new UUID('dd45e5a1-f70c-48d7-83e5-dde9226c1dd6'),
                     MIMEType::fromSubtype('png'),
-                    new StringLiteral('Extra image'),
+                    new Description('Extra image'),
                     new CopyrightHolder('madewithlove'),
                     new Url('https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png'),
                     new Language('en')
@@ -631,7 +631,7 @@ final class OrganizerLDProjectorTest extends TestCase
                 MediaObject::create(
                     new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
                     MIMEType::fromSubtype('jpeg'),
-                    new StringLiteral('Image Description'),
+                    new Description('Image Description'),
                     new CopyrightHolder('madewithlove'),
                     new Url('https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg'),
                     new Language('en')

--- a/tests/Place/CommandHandlerTest.php
+++ b/tests/Place/CommandHandlerTest.php
@@ -16,7 +16,7 @@ use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Language;
-use CultuurNet\UDB3\Media\MediaManager;
+use CultuurNet\UDB3\Media\MediaManagerInterface;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\OfferCommandHandlerTestTrait;
 use CultuurNet\UDB3\Place\Commands\UpdateAddress;
@@ -124,7 +124,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
 
         $this->organizerRepository = $this->createMock(Repository::class);
 
-        $this->mediaManager = $this->createMock(MediaManager::class);
+        $this->mediaManager = $this->createMock(MediaManagerInterface::class);
 
         return new CommandHandler(
             $repository,


### PR DESCRIPTION
### Changed

- Do not use `StringLiteral` in `Media\Description`
- Do not mix `StringLiteral` & `Media\Description`, use `Media\Description` consistently 

### Fixed

- Code Style update

---
Ticket: https://jira.uitdatabank.be/browse/III-3853
