### PR TITLE
III-3853 Remove StringLiteral from Media/Path

### DIFF
--- a/src/Media/Commands/UploadImage.php
+++ b/src/Media/Commands/UploadImage.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
-use CultuurNet\UDB3\StringLiteral;
 
 final class UploadImage
 {
@@ -66,8 +65,8 @@ final class UploadImage
         return $this->mimeType;
     }
 
-    public function getFilePath(): StringLiteral
+    public function getFilePath(): string
     {
-        return new StringLiteral($this->filePath);
+        return $this->filePath;
     }
 }

--- a/src/Media/Commands/UploadImage.php
+++ b/src/Media/Commands/UploadImage.php
@@ -23,14 +23,14 @@ final class UploadImage
 
     private MIMEType $mimeType;
 
-    private StringLiteral $filePath;
+    private string $filePath;
 
     public function __construct(
         UUID $fileId,
         MIMEType $mimeType,
         Description $description,
         CopyrightHolder $copyrightHolder,
-        StringLiteral$filePath,
+        string $filePath,
         Language $language
     ) {
         $this->fileId = $fileId;
@@ -68,6 +68,6 @@ final class UploadImage
 
     public function getFilePath(): StringLiteral
     {
-        return $this->filePath;
+        return new StringLiteral($this->filePath);
     }
 }

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -14,7 +14,6 @@ use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
-use CultuurNet\UDB3\StringLiteral;
 use League\Flysystem\FilesystemOperator;
 use Psr\Http\Message\UploadedFileInterface;
 use RuntimeException;
@@ -87,7 +86,7 @@ final class ImageUploaderService implements ImageUploaderInterface
                 MIMEType::fromNative($mimeType),
                 $description,
                 $copyrightHolder,
-                new StringLiteral($destination),
+                $destination,
                 $language
             )
         );

--- a/src/Media/MediaManager.php
+++ b/src/Media/MediaManager.php
@@ -80,7 +80,7 @@ class MediaManager extends Udb3CommandHandler implements LoggerAwareInterface, M
 
     public function handleUploadImage(UploadImage $uploadImage): void
     {
-        $pathParts = explode('/', $uploadImage->getFilePath()->toNative());
+        $pathParts = explode('/', $uploadImage->getFilePath());
         $fileName = array_pop($pathParts);
         $fileNameParts = explode('.', $fileName);
         $extension = array_pop($fileNameParts);
@@ -91,7 +91,7 @@ class MediaManager extends Udb3CommandHandler implements LoggerAwareInterface, M
 
         $destinationIri = $this->iriGenerator->iri($destinationPath);
 
-        $this->imageStorage->store($uploadImage->getFilePath()->toNative(), $destinationPath);
+        $this->imageStorage->store($uploadImage->getFilePath(), $destinationPath);
 
         $this->create(
             $uploadImage->getFileId(),

--- a/src/Media/MediaManager.php
+++ b/src/Media/MediaManager.php
@@ -18,7 +18,6 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
-use CultuurNet\UDB3\StringLiteral;
 
 class MediaManager extends Udb3CommandHandler implements LoggerAwareInterface, MediaManagerInterface
 {
@@ -84,7 +83,7 @@ class MediaManager extends Udb3CommandHandler implements LoggerAwareInterface, M
         $pathParts = explode('/', $uploadImage->getFilePath()->toNative());
         $fileName = array_pop($pathParts);
         $fileNameParts = explode('.', $fileName);
-        $extension = StringLiteral::fromNative(array_pop($fileNameParts));
+        $extension = array_pop($fileNameParts);
         $destinationPath = $this->pathGenerator->path(
             $uploadImage->getFileId(),
             $extension

--- a/src/Media/PathGeneratorInterface.php
+++ b/src/Media/PathGeneratorInterface.php
@@ -5,15 +5,8 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Media;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use CultuurNet\UDB3\StringLiteral;
 
 interface PathGeneratorInterface
 {
-    /**
-     * Returns the path where a file is stored
-     *
-     *
-     * @return string
-     */
-    public function path(UUID $fileId, StringLiteral $extension);
+    public function path(UUID $fileId, string $extension): string;
 }

--- a/src/Media/SimplePathGenerator.php
+++ b/src/Media/SimplePathGenerator.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Media;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 
-class SimplePathGenerator implements PathGeneratorInterface
+final class SimplePathGenerator implements PathGeneratorInterface
 {
     public function path(UUID $fileId, string $extension): string
     {

--- a/src/Media/SimplePathGenerator.php
+++ b/src/Media/SimplePathGenerator.php
@@ -5,15 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Media;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use CultuurNet\UDB3\StringLiteral;
 
 class SimplePathGenerator implements PathGeneratorInterface
 {
-    /**
-     * @{inheritdoc}
-     */
-    public function path(UUID $fileId, StringLiteral $extension)
+    public function path(UUID $fileId, string $extension): string
     {
-        return $fileId->toString() . '.' . (string)$extension;
+        return $fileId->toString() . '.' . $extension;
     }
 }

--- a/tests/Media/Commands/UploadImageTest.php
+++ b/tests/Media/Commands/UploadImageTest.php
@@ -26,7 +26,7 @@ final class UploadImageTest extends TestCase
             new MIMEType('image/png'),
             new Description('description'),
             new CopyrightHolder('copyright'),
-            StringLiteral::fromNative('/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
+            '/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png',
             new Language('en')
         );
     }

--- a/tests/Media/Commands/UploadImageTest.php
+++ b/tests/Media/Commands/UploadImageTest.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 final class UploadImageTest extends TestCase
 {
@@ -81,7 +80,7 @@ final class UploadImageTest extends TestCase
     public function it_stores_a_file_path(): void
     {
         $this->assertEquals(
-            StringLiteral::fromNative('/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
+            '/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png',
             $this->uploadImage->getFilePath()
         );
     }

--- a/tests/Media/MediaManagerTest.php
+++ b/tests/Media/MediaManagerTest.php
@@ -17,7 +17,6 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use CultuurNet\UDB3\StringLiteral;
 
 final class MediaManagerTest extends TestCase
 {
@@ -68,7 +67,7 @@ final class MediaManagerTest extends TestCase
             new MIMEType('image/png'),
             new Description('description'),
             new CopyrightHolder('copyright'),
-            StringLiteral::fromNative('/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
+            '/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png',
             new Language('en')
         );
 
@@ -111,7 +110,7 @@ final class MediaManagerTest extends TestCase
             new MIMEType('image/png'),
             new Description('description'),
             new CopyrightHolder('copyright'),
-            StringLiteral::fromNative('/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png'),
+            '/uploads/de305d54-75b4-431b-adb2-eb6b9e546014.png',
             new Language('en')
         );
 

--- a/tests/Media/SimplePathGeneratorTest.php
+++ b/tests/Media/SimplePathGeneratorTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Media;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class SimplePathGeneratorTest extends TestCase
 {
@@ -17,7 +16,7 @@ class SimplePathGeneratorTest extends TestCase
     {
         $generator = new SimplePathGenerator();
         $fileId = new UUID('de305d54-75b4-431b-adb2-eb6b9e546014');
-        $extension = new StringLiteral('png');
+        $extension = 'png';
         $expectedPath = 'de305d54-75b4-431b-adb2-eb6b9e546014.png';
 
         $path = $generator->path($fileId, $extension);

--- a/tests/Media/SimplePathGeneratorTest.php
+++ b/tests/Media/SimplePathGeneratorTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Media;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
 
-class SimplePathGeneratorTest extends TestCase
+final class SimplePathGeneratorTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
### Added

### Changed

- `PathGenerator` use `string` instead of `StringLiteral` as parameter in `path()`
- `UploadImage` use `string` instead of `StringLiteral` for `$filePath`

### Fixed

- Updated code style

---
Ticket: https://jira.uitdatabank.be/browse/III-3853
