### PR TITLE
III-3853 StringLiteral UiTPAS

### DIFF
--- a/src/UiTPAS/CardSystem/CardSystem.php
+++ b/src/UiTPAS/CardSystem/CardSystem.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\UiTPAS\CardSystem;
 
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
-use CultuurNet\UDB3\StringLiteral;
 
 class CardSystem
 {
@@ -33,11 +32,8 @@ class CardSystem
         return $this->id;
     }
 
-    /**
-     * @return StringLiteral
-     */
-    public function getName()
+    public function getName(): string
     {
-        return new StringLiteral($this->name);
+        return $this->name;
     }
 }

--- a/src/UiTPAS/CardSystem/CardSystem.php
+++ b/src/UiTPAS/CardSystem/CardSystem.php
@@ -6,12 +6,9 @@ namespace CultuurNet\UDB3\UiTPAS\CardSystem;
 
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
 
-class CardSystem
+final class CardSystem
 {
-    /**
-     * @var Id
-     */
-    private $id;
+    private Id $id;
 
     private string $name;
 
@@ -24,10 +21,7 @@ class CardSystem
         $this->name = $name;
     }
 
-    /**
-     * @return Id
-     */
-    public function getId()
+    public function getId(): Id
     {
         return $this->id;
     }

--- a/src/UiTPAS/CardSystem/CardSystem.php
+++ b/src/UiTPAS/CardSystem/CardSystem.php
@@ -14,15 +14,12 @@ class CardSystem
      */
     private $id;
 
-    /**
-     * @var StringLiteral
-     */
-    private $name;
+    private string $name;
 
 
     public function __construct(
         Id $id,
-        StringLiteral $name
+        string $name
     ) {
         $this->id = $id;
         $this->name = $name;
@@ -41,6 +38,6 @@ class CardSystem
      */
     public function getName()
     {
-        return $this->name;
+        return new StringLiteral($this->name);
     }
 }

--- a/src/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializer.php
+++ b/src/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializer.php
@@ -47,7 +47,7 @@ class EventCardSystemsUpdatedDeserializer extends JSONDeserializer
 
             $cardSystems[$cardSystemDTO->id] = new CardSystem(
                 new Id((string) $cardSystemDTO->id),
-                new StringLiteral($cardSystemDTO->name)
+                $cardSystemDTO->name
             );
         }
 

--- a/src/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializer.php
+++ b/src/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializer.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
  *
  * Make sure to extract this logic if more (similar) uitpas messages have to be deserialized in the future.
  */
-class EventCardSystemsUpdatedDeserializer extends JSONDeserializer
+final class EventCardSystemsUpdatedDeserializer extends JSONDeserializer
 {
     public function deserialize(string $data): EventCardSystemsUpdated
     {

--- a/src/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializer.php
+++ b/src/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializer.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\UiTPAS\Event\Event;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Deserializes `application/vnd.cultuurnet.uitpas-events.event-card-systems-updated+json` messages

--- a/src/UiTPAS/ValueObject/Id.php
+++ b/src/UiTPAS/ValueObject/Id.php
@@ -4,18 +4,25 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPAS\ValueObject;
 
-use CultuurNet\UDB3\StringLiteral;
+use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\IsNotEmpty;
+use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\Trims;
 
-class Id extends StringLiteral
+final class Id
 {
+    use IsNotEmpty;
+    use Trims;
+
+    private string $value;
+
     public function __construct(string $value)
     {
-        parent::__construct($value);
+        $value = $this->trim($value);
+        $this->guardNotEmpty($value);
+        $this->value = $value;
+    }
 
-        $value = trim($value);
-
-        if (strlen($value) === 0) {
-            throw new \InvalidArgumentException('ID should not be an empty string.');
-        }
+    public function toNative(): string
+    {
+        return $this->value;
     }
 }

--- a/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
+++ b/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\UiTPAS\Event\Event;
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
 use PHPUnit\Framework\TestCase;
 
-class EventCardSystemsUpdatedDeserializerTest extends TestCase
+final class EventCardSystemsUpdatedDeserializerTest extends TestCase
 {
     private EventCardSystemsUpdatedDeserializer $deserializer;
 

--- a/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
+++ b/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\UiTPAS\Event\Event;
 
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class EventCardSystemsUpdatedDeserializerTest extends TestCase
 {
@@ -43,9 +42,9 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
 
         $this->assertEquals(new Id('48ef34b0-e34a-4a15-9ae2-a5a01f189f90'), $event->getId());
         $this->assertEquals(new Id('7'), $cardSystems[7]->getId());
-        $this->assertEquals(new StringLiteral('UiTPAS Oostende'), $cardSystems[7]->getName());
+        $this->assertEquals('UiTPAS Oostende', $cardSystems[7]->getName());
         $this->assertEquals(new Id('25'), $cardSystems[25]->getId());
-        $this->assertEquals(new StringLiteral('UiTPAS Dender'), $cardSystems[25]->getName());
+        $this->assertEquals('UiTPAS Dender', $cardSystems[25]->getName());
         $this->assertCount(2, $cardSystems);
     }
 
@@ -71,7 +70,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
 
         $this->assertEquals(new Id('48ef34b0-e34a-4a15-9ae2-a5a01f189f90'), $event->getId());
         $this->assertEquals(new Id('7'), $cardSystems[7]->getId());
-        $this->assertEquals(new StringLiteral('UiTPAS Oostende'), $cardSystems[7]->getName());
+        $this->assertEquals('UiTPAS Oostende', $cardSystems[7]->getName());
         $this->assertCount(1, $cardSystems);
     }
 

--- a/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
+++ b/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
@@ -41,7 +41,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
         $event = $this->deserializer->deserialize($json);
         $cardSystems = $event->getCardSystems();
 
-        $this->assertEquals('48ef34b0-e34a-4a15-9ae2-a5a01f189f90', $event->getId());
+        $this->assertEquals(new Id('48ef34b0-e34a-4a15-9ae2-a5a01f189f90'), $event->getId());
         $this->assertEquals(new Id('7'), $cardSystems[7]->getId());
         $this->assertEquals(new StringLiteral('UiTPAS Oostende'), $cardSystems[7]->getName());
         $this->assertEquals(new Id('25'), $cardSystems[25]->getId());
@@ -69,7 +69,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
         $event = $this->deserializer->deserialize($json);
         $cardSystems = $event->getCardSystems();
 
-        $this->assertEquals('48ef34b0-e34a-4a15-9ae2-a5a01f189f90', $event->getId());
+        $this->assertEquals(new Id('48ef34b0-e34a-4a15-9ae2-a5a01f189f90'), $event->getId());
         $this->assertEquals(new Id('7'), $cardSystems[7]->getId());
         $this->assertEquals(new StringLiteral('UiTPAS Oostende'), $cardSystems[7]->getName());
         $this->assertCount(1, $cardSystems);
@@ -90,7 +90,7 @@ class EventCardSystemsUpdatedDeserializerTest extends TestCase
         $event = $this->deserializer->deserialize($json);
         $cardSystems = $event->getCardSystems();
 
-        $this->assertEquals('48ef34b0-e34a-4a15-9ae2-a5a01f189f90', $event->getId());
+        $this->assertEquals(new Id('48ef34b0-e34a-4a15-9ae2-a5a01f189f90'), $event->getId());
         $this->assertCount(0, $cardSystems);
     }
 

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -26,7 +26,6 @@ use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use CultuurNet\UDB3\StringLiteral;
 
 class EventProcessManagerTest extends TestCase
 {

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -140,15 +140,15 @@ class EventProcessManagerTest extends TestCase
         $cardSystems = [
             'c73d78b7-95a7-45b3-bde5-5b2ec7b13afa' => new CardSystem(
                 new Id('c73d78b7-95a7-45b3-bde5-5b2ec7b13afa'),
-                new StringLiteral('Mock CS Paspartoe')
+                'Mock CS Paspartoe'
             ),
             'f23ccb75-190a-4814-945e-c95e83101cc5' => new CardSystem(
                 new Id('f23ccb75-190a-4814-945e-c95e83101cc5'),
-                new StringLiteral('Mock CS UiTPAS Gent')
+                'Mock CS UiTPAS Gent'
             ),
             '98ce6fbc-fb68-4efc-b8c7-95763cb967dd' => new CardSystem(
                 new Id('98ce6fbc-fb68-4efc-b8c7-95763cb967dd'),
-                new StringLiteral('Mock CS UiTPAS Oostende')
+                'Mock CS UiTPAS Oostende'
             ),
         ];
 
@@ -185,7 +185,7 @@ class EventProcessManagerTest extends TestCase
     public function it_should_log_a_warning_if_no_label_can_be_found_for_an_active_card_system(): void
     {
         $eventId = new Id('cbee7413-ac1e-4dfb-8004-34767eafb8b7');
-        $cardSystems = [7 => new CardSystem(new Id('7'), new StringLiteral('Mock CS'))];
+        $cardSystems = [7 => new CardSystem(new Id('7'), 'Mock CS')];
 
         $cardSystemsUpdated = new EventCardSystemsUpdated($eventId, $cardSystems);
 

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -27,7 +27,7 @@ use Money\Money;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class EventProcessManagerTest extends TestCase
+final class EventProcessManagerTest extends TestCase
 {
     private EventProcessManager $eventProcessManager;
 


### PR DESCRIPTION
### Changed

- Removed `StringLiteral` from `UiTPAS\Id`
- Change type of property of `CardSystem->name` from `StringLiteral` to `string` 

### Removed

- Removed `StringLiteral` from Domain `UiTPAS`

### Fixed

- Code Style update

---
Ticket: https://jira.uitdatabank.be/browse/III-3853
