### PR TITLE
Add Uses comments so the dynamically called methods of applyX can be followed

### DIFF
--- a/src/EventHandling/DelegateEventHandlingToSpecificMethodTrait.php
+++ b/src/EventHandling/DelegateEventHandlingToSpecificMethodTrait.php
@@ -5,12 +5,31 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\EventHandling;
 
 use Broadway\Domain\DomainMessage;
+use CultuurNet\UDB3\Event\ReadModel\Relations\EventRelationsProjector;
 
 trait DelegateEventHandlingToSpecificMethodTrait
 {
+    /**
+     * @uses  Projector::applyEventImportedFromUDB2()
+     * @uses  Projector::applyEventCreated()
+     * @uses  Projector::applyEventCopied()
+     * @uses  Projector::applyOwnerChanged()
+     * @uses  EventRelationsProjector::applyEventImportedFromUDB2
+     * @uses  EventRelationsProjector::applyEventUpdatedFromUDB2
+     * @uses  EventRelationsProjector::applyEventCreated
+     * @uses  EventRelationsProjector::applyEventCopied
+     * @uses  EventRelationsProjector::applyMajorInfoUpdated
+     * @uses  EventRelationsProjector::applyLocationUpdated
+     * @uses  EventRelationsProjector::applyEventDeleted
+     * @uses  EventRelationsProjector::applyOrganizerUpdated
+     * @uses  EventRelationsProjector::applyOrganizerDeleted
+     * @uses  LabelRolesProjector::applyLabelAdded
+     * @uses  LabelRolesProjector::applyLabelRemoved
+     * @uses  LabelRolesProjector::applyRoleDeleted
+     */
     public function handle(DomainMessage $domainMessage): void
     {
-        $event  = $domainMessage->getPayload();
+        $event = $domainMessage->getPayload();
         $method = $this->getHandleMethodName($event);
 
         if ($method) {


### PR DESCRIPTION
### Added
Add Uses comments so the dynamically called methods of applyX can be followed.

There where a lot of methods that showed up as unused in the IDE because they where dynamically called from the handle() method. 
Adding this comment fixes this and allows you to directly click from both directions to the other method: handy for beginners in the codebase (like me)!

I have not done the comments for all 16 classes that use this trait, just for a couple, because I want the group opinion first.