### PR TITLE
III-3853 StringLiteral categoryResolver

### DIFF
--- a/src/Event/EventThemeResolver.php
+++ b/src/Event/EventThemeResolver.php
@@ -7,12 +7,12 @@ namespace CultuurNet\UDB3\Event;
 use CultuurNet\UDB3\Offer\ThemeResolverInterface;
 use CultuurNet\UDB3\Theme;
 
-class EventThemeResolver implements ThemeResolverInterface
+final class EventThemeResolver implements ThemeResolverInterface
 {
     /**
      * @var Theme[]
      */
-    private $themes;
+    private array $themes;
 
     public function __construct()
     {
@@ -713,10 +713,7 @@ class EventThemeResolver implements ThemeResolverInterface
         );
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function byId(string $themeId)
+    public function byId(string $themeId): Theme
     {
         if (!array_key_exists($themeId, $this->themes)) {
             throw new \Exception('Unknown event theme id: ' . $themeId);

--- a/src/Event/EventThemeResolver.php
+++ b/src/Event/EventThemeResolver.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Offer\ThemeResolverInterface;
 use CultuurNet\UDB3\Theme;
-use CultuurNet\UDB3\StringLiteral;
 
 class EventThemeResolver implements ThemeResolverInterface
 {
@@ -717,11 +716,11 @@ class EventThemeResolver implements ThemeResolverInterface
     /**
      * @inheritdoc
      */
-    public function byId(StringLiteral $themeId)
+    public function byId(string $themeId)
     {
-        if (!array_key_exists((string) $themeId, $this->themes)) {
+        if (!array_key_exists($themeId, $this->themes)) {
             throw new \Exception('Unknown event theme id: ' . $themeId);
         }
-        return $this->themes[(string) $themeId];
+        return $this->themes[$themeId];
     }
 }

--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -43,7 +43,7 @@ class EventTypeResolver implements TypeResolverInterface
         ];
     }
 
-    public function byId(StringLiteral $typeId): EventType
+    public function byId(string $typeId): EventType
     {
         if (!array_key_exists((string) $typeId, $this->types)) {
             throw new Exception('Unknown event type id: ' . $typeId);

--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -7,12 +7,12 @@ namespace CultuurNet\UDB3\Event;
 use CultuurNet\UDB3\Offer\TypeResolverInterface;
 use Exception;
 
-class EventTypeResolver implements TypeResolverInterface
+final class EventTypeResolver implements TypeResolverInterface
 {
     /**
      * @var EventType[]
      */
-    private $types;
+    private array $types;
 
     public function __construct()
     {
@@ -44,10 +44,10 @@ class EventTypeResolver implements TypeResolverInterface
 
     public function byId(string $typeId): EventType
     {
-        if (!array_key_exists((string) $typeId, $this->types)) {
+        if (!array_key_exists($typeId, $this->types)) {
             throw new Exception('Unknown event type id: ' . $typeId);
         }
-        return $this->types[(string) $typeId];
+        return $this->types[$typeId];
     }
 
     public static function isOnlyAvailableUntilStartDate(EventType $eventType): bool

--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Offer\TypeResolverInterface;
 use Exception;
-use CultuurNet\UDB3\StringLiteral;
 
 class EventTypeResolver implements TypeResolverInterface
 {

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -386,7 +386,7 @@ final class EventLDProjector extends OfferLDProjector implements
         $eventType = null;
         foreach ($eventJsonLD->terms as $term) {
             if ($term->domain === 'eventtype') {
-                $typeId = new StringLiteral($term->id);
+                $typeId = $term->id;
                 // This is a workaround to allow copies of events that
                 // have a placeType instead of an eventType.
                 // These events could also be cleaned up in the future

--- a/src/Http/Deserializer/Place/FacilitiesJSONDeserializer.php
+++ b/src/Http/Deserializer/Place/FacilitiesJSONDeserializer.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Offer\OfferFacilityResolverInterface;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\RequiredPropertiesDataValidator;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Place/FacilitiesJSONDeserializer.php
+++ b/src/Http/Deserializer/Place/FacilitiesJSONDeserializer.php
@@ -15,7 +15,7 @@ use CultuurNet\UDB3\Http\Deserializer\DataValidator\RequiredPropertiesDataValida
  * @deprecated
  *   Refactor to implement RequestBodyParser and throw ApiProblemException
  */
-class FacilitiesJSONDeserializer extends JSONDeserializer
+final class FacilitiesJSONDeserializer extends JSONDeserializer
 {
     private OfferFacilityResolverInterface $facilityResolver;
 

--- a/src/Http/Deserializer/Place/FacilitiesJSONDeserializer.php
+++ b/src/Http/Deserializer/Place/FacilitiesJSONDeserializer.php
@@ -46,7 +46,7 @@ class FacilitiesJSONDeserializer extends JSONDeserializer
 
         return array_map(
             function ($facilityId) {
-                return $this->facilityResolver->byId(new StringLiteral($facilityId));
+                return $this->facilityResolver->byId($facilityId);
             },
             array_unique($data['facilities'])
         );

--- a/src/Model/Import/Taxonomy/Category/LegacyBridgeCategoryResolver.php
+++ b/src/Model/Import/Taxonomy/Category/LegacyBridgeCategoryResolver.php
@@ -82,7 +82,7 @@ class LegacyBridgeCategoryResolver implements CategoryResolverInterface
 
         try {
             /** @var LegacyCategory $legacyCategory */
-            $legacyCategory = $resolver->byId(new StringLiteral($categoryID->toString()));
+            $legacyCategory = $resolver->byId($categoryID->toString());
             return $this->convertLegacyCategory($legacyCategory);
         } catch (\Exception $e) {
             return null;

--- a/src/Model/Import/Taxonomy/Category/LegacyBridgeCategoryResolver.php
+++ b/src/Model/Import/Taxonomy/Category/LegacyBridgeCategoryResolver.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryLabel;
 use CultuurNet\UDB3\Offer\OfferFacilityResolverInterface;
 use CultuurNet\UDB3\Offer\ThemeResolverInterface;
 use CultuurNet\UDB3\Offer\TypeResolverInterface;
-use CultuurNet\UDB3\StringLiteral;
 
 class LegacyBridgeCategoryResolver implements CategoryResolverInterface
 {

--- a/src/Model/Import/Taxonomy/Category/LegacyBridgeCategoryResolver.php
+++ b/src/Model/Import/Taxonomy/Category/LegacyBridgeCategoryResolver.php
@@ -15,21 +15,11 @@ use CultuurNet\UDB3\Offer\TypeResolverInterface;
 
 class LegacyBridgeCategoryResolver implements CategoryResolverInterface
 {
-    /**
-     * @var TypeResolverInterface
-     */
-    private $typeResolver;
+    private TypeResolverInterface $typeResolver;
 
-    /**
-     * @var ThemeResolverInterface|null
-     */
-    private $themeResolver;
+    private ?ThemeResolverInterface $themeResolver;
 
-    /**
-     * @var OfferFacilityResolverInterface
-     */
-    private $facilityResolver;
-
+    private OfferFacilityResolverInterface $facilityResolver;
 
     public function __construct(
         TypeResolverInterface $typeResolver,

--- a/src/Offer/OfferFacilityResolver.php
+++ b/src/Offer/OfferFacilityResolver.php
@@ -13,9 +13,6 @@ abstract class OfferFacilityResolver implements OfferFacilityResolverInterface
      */
     private array $facilities;
 
-    /**
-     * PlaceTypeResolver constructor.
-     */
     public function __construct()
     {
         $this->facilities = $this->getFacilities();
@@ -23,11 +20,11 @@ abstract class OfferFacilityResolver implements OfferFacilityResolverInterface
 
     public function byId(string $facilityId): Facility
     {
-        if (!array_key_exists((string) $facilityId, $this->facilities)) {
+        if (!array_key_exists($facilityId, $this->facilities)) {
             throw new \Exception("Unknown facility id '{$facilityId}'");
         }
 
-        return $this->facilities[(string) $facilityId];
+        return $this->facilities[$facilityId];
     }
 
     /**

--- a/src/Offer/OfferFacilityResolver.php
+++ b/src/Offer/OfferFacilityResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Facility;
-use CultuurNet\UDB3\StringLiteral;
 
 abstract class OfferFacilityResolver implements OfferFacilityResolverInterface
 {

--- a/src/Offer/OfferFacilityResolver.php
+++ b/src/Offer/OfferFacilityResolver.php
@@ -12,7 +12,7 @@ abstract class OfferFacilityResolver implements OfferFacilityResolverInterface
     /**
      * @var Facility[]
      */
-    private $facilities;
+    private array $facilities;
 
     /**
      * PlaceTypeResolver constructor.
@@ -22,7 +22,7 @@ abstract class OfferFacilityResolver implements OfferFacilityResolverInterface
         $this->facilities = $this->getFacilities();
     }
 
-    public function byId(StringLiteral $facilityId): Facility
+    public function byId(string $facilityId): Facility
     {
         if (!array_key_exists((string) $facilityId, $this->facilities)) {
             throw new \Exception("Unknown facility id '{$facilityId}'");

--- a/src/Offer/OfferFacilityResolverInterface.php
+++ b/src/Offer/OfferFacilityResolverInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Facility;
-use CultuurNet\UDB3\StringLiteral;
 
 interface OfferFacilityResolverInterface
 {

--- a/src/Offer/OfferFacilityResolverInterface.php
+++ b/src/Offer/OfferFacilityResolverInterface.php
@@ -9,5 +9,5 @@ use CultuurNet\UDB3\StringLiteral;
 
 interface OfferFacilityResolverInterface
 {
-    public function byId(StringLiteral $facilityId): Facility;
+    public function byId(string $facilityId): Facility;
 }

--- a/src/Offer/ThemeResolverInterface.php
+++ b/src/Offer/ThemeResolverInterface.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Theme;
-use CultuurNet\UDB3\StringLiteral;
 
 interface ThemeResolverInterface
 {
     /**
      * @return Theme
      */
-    public function byId(StringLiteral $themeId);
+    public function byId(string $themeId);
 }

--- a/src/Offer/ThemeResolverInterface.php
+++ b/src/Offer/ThemeResolverInterface.php
@@ -8,8 +8,5 @@ use CultuurNet\UDB3\Theme;
 
 interface ThemeResolverInterface
 {
-    /**
-     * @return Theme
-     */
-    public function byId(string $themeId);
+    public function byId(string $themeId): Theme;
 }

--- a/src/Offer/TypeResolverInterface.php
+++ b/src/Offer/TypeResolverInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Event\EventType;
-use CultuurNet\UDB3\StringLiteral;
 
 interface TypeResolverInterface
 {

--- a/src/Offer/TypeResolverInterface.php
+++ b/src/Offer/TypeResolverInterface.php
@@ -9,5 +9,5 @@ use CultuurNet\UDB3\StringLiteral;
 
 interface TypeResolverInterface
 {
-    public function byId(StringLiteral $typeId): EventType;
+    public function byId(string $typeId): EventType;
 }

--- a/src/Place/PlaceTypeResolver.php
+++ b/src/Place/PlaceTypeResolver.php
@@ -41,7 +41,7 @@ class PlaceTypeResolver implements TypeResolverInterface
         ];
     }
 
-    public function byId(StringLiteral $typeId): EventType
+    public function byId(string $typeId): EventType
     {
         if (!array_key_exists((string) $typeId, $this->types)) {
             throw new Exception('Unknown place type id: ' . $typeId);

--- a/src/Place/PlaceTypeResolver.php
+++ b/src/Place/PlaceTypeResolver.php
@@ -8,12 +8,12 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Offer\TypeResolverInterface;
 use Exception;
 
-class PlaceTypeResolver implements TypeResolverInterface
+final class PlaceTypeResolver implements TypeResolverInterface
 {
     /**
      * @var EventType[]
      */
-    private $types;
+    private array $types;
 
     public function __construct()
     {

--- a/src/Place/PlaceTypeResolver.php
+++ b/src/Place/PlaceTypeResolver.php
@@ -42,7 +42,7 @@ final class PlaceTypeResolver implements TypeResolverInterface
 
     public function byId(string $typeId): EventType
     {
-        if (!array_key_exists((string) $typeId, $this->types)) {
+        if (!array_key_exists($typeId, $this->types)) {
             throw new Exception('Unknown place type id: ' . $typeId);
         }
         return $this->types[(string) $typeId];

--- a/src/Place/PlaceTypeResolver.php
+++ b/src/Place/PlaceTypeResolver.php
@@ -45,6 +45,6 @@ final class PlaceTypeResolver implements TypeResolverInterface
         if (!array_key_exists($typeId, $this->types)) {
             throw new Exception('Unknown place type id: ' . $typeId);
         }
-        return $this->types[(string) $typeId];
+        return $this->types[$typeId];
     }
 }

--- a/src/Place/PlaceTypeResolver.php
+++ b/src/Place/PlaceTypeResolver.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Place;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Offer\TypeResolverInterface;
 use Exception;
-use CultuurNet\UDB3\StringLiteral;
 
 class PlaceTypeResolver implements TypeResolverInterface
 {

--- a/tests/Event/EventFacilityResolverTest.php
+++ b/tests/Event/EventFacilityResolverTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Facility;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class EventFacilityResolverTest extends TestCase
 {

--- a/tests/Event/EventFacilityResolverTest.php
+++ b/tests/Event/EventFacilityResolverTest.php
@@ -21,7 +21,7 @@ class EventFacilityResolverTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Unknown facility id '1.8.2'");
 
-        $resolver->byId(new StringLiteral('1.8.2'));
+        $resolver->byId('1.8.2');
     }
 
     /**
@@ -32,7 +32,7 @@ class EventFacilityResolverTest extends TestCase
     {
         $resolver = new EventFacilityResolver();
 
-        $facility = $resolver->byId(new StringLiteral('3.13.2.0.0'));
+        $facility = $resolver->byId('3.13.2.0.0');
         $expectedFacility = new Facility('3.13.2.0.0', 'Audiodescriptie');
 
         $this->assertEquals($expectedFacility, $facility);

--- a/tests/Event/EventFacilityResolverTest.php
+++ b/tests/Event/EventFacilityResolverTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Event;
 use CultuurNet\UDB3\Facility;
 use PHPUnit\Framework\TestCase;
 
-class EventFacilityResolverTest extends TestCase
+final class EventFacilityResolverTest extends TestCase
 {
     /**
      * @test

--- a/tests/Event/EventThemeResolverTest.php
+++ b/tests/Event/EventThemeResolverTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Theme;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class EventThemeResolverTest extends TestCase
 {
@@ -25,7 +24,7 @@ class EventThemeResolverTest extends TestCase
      */
     public function it_should_resolve_themes_by_matching_id(): void
     {
-        $resolvedTheme = $this->themeResolver->byId(new StringLiteral('0.52.0.0.0'));
+        $resolvedTheme = $this->themeResolver->byId('0.52.0.0.0');
         $expectedTheme = new Theme('0.52.0.0.0', 'Circus');
 
         $this->assertEquals($expectedTheme, $resolvedTheme);
@@ -37,6 +36,6 @@ class EventThemeResolverTest extends TestCase
     public function it_should_not_resolve_a_theme_when_id_is_unknown(): void
     {
         $this->expectExceptionMessage('Unknown event theme id: 182.0.0.1');
-        $this->themeResolver->byId(new StringLiteral('182.0.0.1'));
+        $this->themeResolver->byId('182.0.0.1');
     }
 }

--- a/tests/Event/EventThemeResolverTest.php
+++ b/tests/Event/EventThemeResolverTest.php
@@ -7,12 +7,9 @@ namespace CultuurNet\UDB3\Event;
 use CultuurNet\UDB3\Theme;
 use PHPUnit\Framework\TestCase;
 
-class EventThemeResolverTest extends TestCase
+final class EventThemeResolverTest extends TestCase
 {
-    /**
-     * @var EventThemeResolver
-     */
-    private $themeResolver;
+    private EventThemeResolver $themeResolver;
 
     public function setUp(): void
     {

--- a/tests/Offer/AvailableToTest.php
+++ b/tests/Offer/AvailableToTest.php
@@ -39,10 +39,10 @@ class AvailableToTest extends TestCase
         $calendar = new Calendar(CalendarType::MULTIPLE(), null, null, [new Timestamp($startDate, $endDate)]);
         $eventTypeResolver = new EventTypeResolver();
 
-        $availableTo = AvailableTo::createFromCalendar($calendar, $eventTypeResolver->byId(new StringLiteral('0.7.0.0.0')));
+        $availableTo = AvailableTo::createFromCalendar($calendar, $eventTypeResolver->byId('0.7.0.0.0'));
         $this->assertEquals($endDate, $availableTo->getAvailableTo());
 
-        $availableTo = AvailableTo::createFromCalendar($calendar, $eventTypeResolver->byId(new StringLiteral('0.3.1.0.0')));
+        $availableTo = AvailableTo::createFromCalendar($calendar, $eventTypeResolver->byId('0.3.1.0.0'));
         $this->assertEquals($startDate, $availableTo->getAvailableTo());
     }
 

--- a/tests/Offer/AvailableToTest.php
+++ b/tests/Offer/AvailableToTest.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventTypeResolver;
 use CultuurNet\UDB3\Timestamp;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class AvailableToTest extends TestCase
 {

--- a/tests/Offer/AvailableToTest.php
+++ b/tests/Offer/AvailableToTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Event\EventTypeResolver;
 use CultuurNet\UDB3\Timestamp;
 use PHPUnit\Framework\TestCase;
 
-class AvailableToTest extends TestCase
+final class AvailableToTest extends TestCase
 {
     /**
      * @test

--- a/tests/Place/PlaceFacilityResolverTest.php
+++ b/tests/Place/PlaceFacilityResolverTest.php
@@ -21,7 +21,7 @@ class PlaceFacilityResolverTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Unknown facility id '1.8.2'");
 
-        $resolver->byId(new StringLiteral('1.8.2'));
+        $resolver->byId('1.8.2');
     }
 
     /**
@@ -32,7 +32,7 @@ class PlaceFacilityResolverTest extends TestCase
     {
         $resolver = new PlaceFacilityResolver();
 
-        $facility = $resolver->byId(new StringLiteral('3.23.3.0.0'));
+        $facility = $resolver->byId('3.23.3.0.0');
         $expectedFacility = new Facility('3.23.3.0.0', 'Rolstoel ter beschikking');
 
         $this->assertEquals($expectedFacility, $facility);

--- a/tests/Place/PlaceFacilityResolverTest.php
+++ b/tests/Place/PlaceFacilityResolverTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Place;
 
 use CultuurNet\UDB3\Facility;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class PlaceFacilityResolverTest extends TestCase
 {

--- a/tests/Place/PlaceFacilityResolverTest.php
+++ b/tests/Place/PlaceFacilityResolverTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Place;
 use CultuurNet\UDB3\Facility;
 use PHPUnit\Framework\TestCase;
 
-class PlaceFacilityResolverTest extends TestCase
+final class PlaceFacilityResolverTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
### Changed

- Removed `StringLiteral` from the `FacilityResolver`, `ThemeResolver` & `TypeResolver`

### Fixed

- Updated CodeStyle

---
Ticket: https://jira.uitdatabank.be/browse/III-3853
