### PR TITLE
III-3853 StringLiteral in Http Domain

### DIFF
--- a/src/Http/Deserializer/TitleJSONDeserializer.php
+++ b/src/Http/Deserializer/TitleJSONDeserializer.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Deserializer;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Title;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -15,16 +14,16 @@ use CultuurNet\UDB3\StringLiteral;
  */
 class TitleJSONDeserializer extends JSONDeserializer
 {
-    private ?StringLiteral $propertyName;
+    private ?string $propertyName;
 
     public function __construct(
         bool $assoc = false,
-        StringLiteral $propertyName = null
+        string $propertyName = null
     ) {
         parent::__construct($assoc);
 
         if (is_null($propertyName)) {
-            $propertyName = new StringLiteral('title');
+            $propertyName = 'title';
         }
 
         $this->propertyName = $propertyName;
@@ -34,7 +33,7 @@ class TitleJSONDeserializer extends JSONDeserializer
     {
         $data = parent::deserialize($data);
 
-        $propertyName = $this->propertyName->toNative();
+        $propertyName = $this->propertyName;
 
         if (!isset($data->{$propertyName})) {
             throw new MissingValueException("Missing value for \"{$propertyName}\".");

--- a/src/Http/Deserializer/TitleJSONDeserializer.php
+++ b/src/Http/Deserializer/TitleJSONDeserializer.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Title;
  * @deprecated
  *   Refactor to implement RequestBodyParser and throw ApiProblemException
  */
-class TitleJSONDeserializer extends JSONDeserializer
+final class TitleJSONDeserializer extends JSONDeserializer
 {
     private ?string $propertyName;
 

--- a/src/Http/SavedSearches/CreateSavedSearchRequestHandler.php
+++ b/src/Http/SavedSearches/CreateSavedSearchRequestHandler.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\SavedSearches;
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
 use CultuurNet\UDB3\SavedSearches\Command\SubscribeToSavedSearchJSONDeserializer;
-use CultuurNet\UDB3\StringLiteral;
 use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -30,7 +29,7 @@ final class CreateSavedSearchRequestHandler implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $commandDeserializer = new SubscribeToSavedSearchJSONDeserializer(
-            new StringLiteral($this->userId)
+            $this->userId
         );
 
         $command = $commandDeserializer->deserialize($request->getBody()->getContents());

--- a/src/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializer.php
+++ b/src/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializer.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\SavedSearches\Command;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
-use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated
@@ -15,9 +14,9 @@ use CultuurNet\UDB3\StringLiteral;
  */
 class SubscribeToSavedSearchJSONDeserializer extends JSONDeserializer
 {
-    protected StringLiteral $userId;
+    private string $userId;
 
-    public function __construct(StringLiteral $userId)
+    public function __construct(string $userId)
     {
         parent::__construct();
         $this->userId = $userId;
@@ -36,7 +35,7 @@ class SubscribeToSavedSearchJSONDeserializer extends JSONDeserializer
         }
 
         return new SubscribeToSavedSearch(
-            $this->userId->toNative(),
+            $this->userId,
             $json->name,
             new QueryString($json->query)
         );

--- a/src/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializer.php
+++ b/src/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializer.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
  * @deprecated
  *   Refactor to implement RequestBodyParser and throw ApiProblemException
  */
-class SubscribeToSavedSearchJSONDeserializer extends JSONDeserializer
+final class SubscribeToSavedSearchJSONDeserializer extends JSONDeserializer
 {
     private string $userId;
 

--- a/tests/Http/Deserializer/TitleJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/TitleJSONDeserializerTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\TestCase;
 
-class TitleJSONDeserializerTest extends TestCase
+final class TitleJSONDeserializerTest extends TestCase
 {
     private TitleJSONDeserializer $deserializer;
 

--- a/tests/Http/Deserializer/TitleJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/TitleJSONDeserializerTest.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Deserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class TitleJSONDeserializerTest extends TestCase
 {
@@ -34,7 +33,7 @@ class TitleJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_with_optional_property_name(): void
     {
-        $deserializer = new TitleJSONDeserializer(false, new StringLiteral('name'));
+        $deserializer = new TitleJSONDeserializer(false, 'name');
 
         $json = '{"name": "Lorem ipsum"}';
         $expected = new Title('Lorem ipsum');

--- a/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
+++ b/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
@@ -8,11 +8,11 @@ use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use PHPUnit\Framework\TestCase;
 
-class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
+final class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
 {
-    protected string $userId;
+    private string $userId;
 
-    protected SubscribeToSavedSearchJSONDeserializer $deserializer;
+    private SubscribeToSavedSearchJSONDeserializer $deserializer;
 
     public function setUp(): void
     {

--- a/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
+++ b/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\SavedSearches\Command;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
 {
@@ -20,7 +19,7 @@ class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
         $this->userId ='xyx';
 
         $this->deserializer = new SubscribeToSavedSearchJSONDeserializer(
-            new StringLiteral($this->userId)
+            $this->userId
         );
     }
 


### PR DESCRIPTION
### Added

### Changed
- Removed `StringLiteral` from constructor of `SubscribeToSavedSearchJSONDeserializer`
- Removed `StringLiteral` from constructor of `TitleJSONDeserializer`

### Fixed

-  Code Style

---
Ticket: https://jira.uitdatabank.be/browse/III-3853
