### PR TITLE
III-3583 Remove unused function getLabelNames() from ImportLabels

### DIFF
--- a/src/Organizer/Commands/ImportLabels.php
+++ b/src/Organizer/Commands/ImportLabels.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\Commands;
 
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Security\AuthorizableCommand;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use CultuurNet\UDB3\StringLiteral;
 
 final class ImportLabels implements AuthorizableCommand
 {
@@ -37,15 +35,5 @@ final class ImportLabels implements AuthorizableCommand
     public function getPermission(): Permission
     {
         return Permission::organisatiesBewerken();
-    }
-
-    public function getLabelNames(): array
-    {
-        return array_map(
-            function (Label $label) {
-                return new StringLiteral($label->getName()->toString());
-            },
-            $this->getLabels()->toArray()
-        );
     }
 }

--- a/tests/Organizer/Commands/ImportLabelsTest.php
+++ b/tests/Organizer/Commands/ImportLabelsTest.php
@@ -9,9 +9,8 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
-class ImportLabelsTest extends TestCase
+final class ImportLabelsTest extends TestCase
 {
     private string $organizerId;
 
@@ -53,20 +52,6 @@ class ImportLabelsTest extends TestCase
         $this->assertEquals(
             $this->labels,
             $this->importLabels->getLabels()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_convert_a_labels_collection_to_label_names(): void
-    {
-        $this->assertEquals(
-            [
-                new StringLiteral('foo'),
-                new StringLiteral('bar'),
-            ],
-            $this->importLabels->getLabelNames()
         );
     }
 


### PR DESCRIPTION
### Removed

- Unused `getLabelNames()` from `Organizer\ImportLabels` thereby removing `StringLiteral` from Domain `Organizer`

---
Ticket: https://jira.uitdatabank.be/browse/III-3853
