### PR TITLE
III-5820 Concluded Listener

### DIFF
--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Category;
 use CultuurNet\UDB3\CulturefeedSlugger;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\EntityServiceInterface;
+use CultuurNet\UDB3\Event\Events\Concluded;
 use CultuurNet\UDB3\Event\ReadModel\JSONLD\OrganizerServiceInterface;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Facility;
@@ -856,6 +857,11 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         if (isset($mainImage)) {
             $offerLd->image = $mainImage->getSourceLocation()->toString();
         }
+    }
+
+    protected function applyConcluded(Concluded $concluded): JsonDocument
+    {
+        return $this->loadDocumentFromRepository($concluded);
     }
 
     protected function newDocument(string $id): JsonDocument

--- a/tests/Offer/Item/ReadModel/JSONLD/ItemLDProjector.php
+++ b/tests/Offer/Item/ReadModel/JSONLD/ItemLDProjector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Item\ReadModel\JSONLD;
 
-use CultuurNet\UDB3\Event\Events\Concluded;
 use CultuurNet\UDB3\Offer\Item\Events\AvailableFromUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\CalendarUpdated;
@@ -205,10 +204,5 @@ class ItemLDProjector extends OfferLDProjector
     protected function getFacilitiesUpdatedClassName(): string
     {
         return FacilitiesUpdated::class;
-    }
-
-    protected function getConcludedClassName(): string
-    {
-        return Concluded::class;
     }
 }

--- a/tests/Offer/Item/ReadModel/JSONLD/ItemLDProjector.php
+++ b/tests/Offer/Item/ReadModel/JSONLD/ItemLDProjector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Item\ReadModel\JSONLD;
 
+use CultuurNet\UDB3\Event\Events\Concluded;
 use CultuurNet\UDB3\Offer\Item\Events\AvailableFromUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\CalendarUpdated;
@@ -204,5 +205,10 @@ class ItemLDProjector extends OfferLDProjector
     protected function getFacilitiesUpdatedClassName(): string
     {
         return FacilitiesUpdated::class;
+    }
+
+    protected function getConcludedClassName(): string
+    {
+        return Concluded::class;
     }
 }

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -9,6 +9,7 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Event\Events\Concluded;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
@@ -2425,5 +2426,31 @@ class OfferLDProjectorTest extends TestCase
 
         $body = $this->project($event, $id, null, $this->recordedOn->toBroadwayDateTime());
         $this->assertEquals($expectedBody, $body);
+    }
+
+    /**
+     * @test
+     */
+    public function it_updates_the_playhead_on_concluded(): void
+    {
+        $itemId = 'C50051D6-EEB1-E9F9-B07889755901D7156';
+        $initialDocument = new JsonDocument(
+            $itemId,
+            Json::encode([])
+        );
+
+        $this->documentRepository->save($initialDocument);
+
+        $concluded = new Concluded($itemId);
+
+        $body = $this->project($concluded, $itemId, null, $this->recordedOn->toBroadwayDateTime());
+
+        $this->assertEquals(
+            (object) [
+                'modified' => $this->recordedOn->toString(),
+                'playhead' => 1,
+            ],
+            $body
+        );
     }
 }


### PR DESCRIPTION
### Changed

- `OfferLDProjector`: Added a Listener for the event `Concluded`
- `testsItemLDProjector`: Added `getConcludedClassName()` for tests.
- `unit test` for updating `playhead` when Offers are `Concluded`

### Fixed

- The `playhead` is correctly updated if an `Offer` has Concluded in the `event_store`

---
Ticket: https://jira.uitdatabank.be/browse/III-5820
