### PR TITLE
III-5818 event_permission_readmodel check for UPDATE/INSERT

### DIFF
--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -63,22 +63,15 @@ final class DBALResourceOwnerRepository implements ResourceOwnerRepository, Reso
 
     public function markResourceEditableByNewUser(string $resourceId, string $userId): void
     {
-        /*$rowCount = $this->connection->createQueryBuilder()
+        $rowCount = count($this->connection->createQueryBuilder()
             ->select($this->idField)
             ->from($this->tableName)
-            ->where($this->idField . ' = :offerId')
-            ->setParameter(':offerId', $resourceId)
-            ->execute()->rowCount();*/
+            ->where($this->idField . ' = :resource_id')
+            ->setParameter(':resource_id', $resourceId)
+            ->execute()
+            ->fetchAll());
 
-        $results = $this->connection->fetchAll(
-            'SELECT * FROM ' . $this->tableName . ' WHERE ' . $this->idField . ' = :offerId',
-            [
-                'offerId' => $resourceId,
-            ]
-        );
-
-        //if ($rowCount === 0) {
-        if (!$results) {
+        if ($rowCount === 0) {
             $this->connection->insert(
                 $this->tableName,
                 [

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -63,10 +63,27 @@ final class DBALResourceOwnerRepository implements ResourceOwnerRepository, Reso
 
     public function markResourceEditableByNewUser(string $resourceId, string $userId): void
     {
-        $this->connection->update(
-            $this->tableName,
-            ['user_id' => $userId],
-            [$this->idField => $resourceId]
+        $results = $this->connection->fetchAll(
+            'SELECT * FROM ' . $this->tableName . ' WHERE event_id = :eventId',
+            [
+                'eventId' => $resourceId,
+            ]
         );
+
+        if (!$results) {
+            $this->connection->insert(
+                $this->tableName,
+                [
+                    $this->idField => $resourceId,
+                    'user_id' => $userId,
+                ]
+            );
+        } else {
+            $this->connection->update(
+                $this->tableName,
+                ['user_id' => $userId],
+                [$this->idField => $resourceId]
+            );
+        }
     }
 }

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -63,15 +63,7 @@ final class DBALResourceOwnerRepository implements ResourceOwnerRepository, Reso
 
     public function markResourceEditableByNewUser(string $resourceId, string $userId): void
     {
-        $rowCount = count($this->connection->createQueryBuilder()
-            ->select($this->idField)
-            ->from($this->tableName)
-            ->where($this->idField . ' = :resource_id')
-            ->setParameter(':resource_id', $resourceId)
-            ->execute()
-            ->fetchAll());
-
-        if ($rowCount === 0) {
+        if ($this->getResourceCount($resourceId) === 0) {
             $this->connection->insert(
                 $this->tableName,
                 [
@@ -86,5 +78,16 @@ final class DBALResourceOwnerRepository implements ResourceOwnerRepository, Reso
                 [$this->idField => $resourceId]
             );
         }
+    }
+
+    private function getResourceCount(string $resourceId): int
+    {
+        return count($this->connection->createQueryBuilder()
+            ->select($this->idField)
+            ->from($this->tableName)
+            ->where($this->idField . ' = :resource_id')
+            ->setParameter(':resource_id', $resourceId)
+            ->execute()
+            ->fetchAll());
     }
 }

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -63,13 +63,21 @@ final class DBALResourceOwnerRepository implements ResourceOwnerRepository, Reso
 
     public function markResourceEditableByNewUser(string $resourceId, string $userId): void
     {
+        /*$rowCount = $this->connection->createQueryBuilder()
+            ->select($this->idField)
+            ->from($this->tableName)
+            ->where($this->idField . ' = :offerId')
+            ->setParameter(':offerId', $resourceId)
+            ->execute()->rowCount();*/
+
         $results = $this->connection->fetchAll(
-            'SELECT * FROM ' . $this->tableName . ' WHERE event_id = :eventId',
+            'SELECT * FROM ' . $this->tableName . ' WHERE ' . $this->idField . ' = :offerId',
             [
-                'eventId' => $resourceId,
+                'offerId' => $resourceId,
             ]
         );
 
+        //if ($rowCount === 0) {
         if (!$results) {
             $this->connection->insert(
                 $this->tableName,

--- a/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
+++ b/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
@@ -129,4 +129,21 @@ final class DBALResourceOwnerRepositoryTest extends TestCase
             $this->repository->getEditableResourceIds($johnDoe)
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_updates_the_user_id_if_previous_user_was_not_known(): void
+    {
+        $janeDoe = 'def';
+
+        $this->repository->markResourceEditableByNewUser('C50051D6-EEB1-E9F9-B07889755901D716', $janeDoe);
+
+        $this->assertEquals(
+            [
+                'C50051D6-EEB1-E9F9-B07889755901D716',
+            ],
+            $this->repository->getEditableResourceIds($janeDoe)
+        );
+    }
 }


### PR DESCRIPTION
### Changed
- `DBALResourceOwnerRepository`: Add check to see if the `resourceId` is present in `event_permission_readmodel`, if it is not present preform an `INSERT` instead of an `UPDATE`. If it already exists, the code remains an `UPDATE`

### Fixed

- When changing the `owner` of an `Offer` with an unknown `creator`(e.g., legacy Offers, with creators who could not be mapped to an `UiTID`), the new `owner` will have edit rights.

---
Ticket: https://jira.uitdatabank.be/browse/III-5818
