### PR TITLE
III-5829 Fix missing created on organizer

### DIFF
--- a/src/Organizer/ReadModel/RDF/RdfProjector.php
+++ b/src/Organizer/ReadModel/RDF/RdfProjector.php
@@ -84,11 +84,13 @@ final class RdfProjector implements EventListener
             return;
         }
 
+        $modified = $domainMessage->getRecordedOn()->toNative()->format(DateTime::ATOM);
         GraphEditor::for($graph)->setGeneralProperties(
             $iri,
             self::TYPE_ORGANISATOR,
-            DateTimeFactory::fromISO8601($organizerData['created'])->format(DateTime::ATOM),
-            $domainMessage->getRecordedOn()->toNative()->format(DateTime::ATOM)
+            isset($organizerData['created']) ?
+                DateTimeFactory::fromISO8601($organizerData['created'])->format(DateTime::ATOM) : $modified,
+            $modified
         );
 
         $this->setName($resource, $organizer->getName());

--- a/tests/Organizer/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Organizer/ReadModel/RDF/RdfProjectorTest.php
@@ -71,6 +71,35 @@ class RdfProjectorTest extends RdfTestCase
     /**
      * @test
      */
+    public function it_converts_a_simple_organizer_without_created(): void
+    {
+        $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';
+
+        $organizer = [
+            '@id' => 'https://mock.io.uitdatabank.be/organizers/' . $organizerId,
+            'mainLanguage' => 'nl',
+            'url' => 'https://www.publiq.be',
+            'name' => [
+                'nl' => 'publiq VZW',
+                'en' => 'publiq NPO',
+            ],
+        ];
+
+        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+
+        $this->project(
+            $organizerId,
+            [
+                new OrganizerProjectedToJSONLD($organizerId, 'https://mock.io.uitdatabank.be/organizer/' . $organizerId),
+            ]
+        );
+
+        $this->assertTurtleData($organizerId, file_get_contents(__DIR__ . '/ttl/organizer.ttl'));
+    }
+
+    /**
+     * @test
+     */
     public function it_converts_an_organizer_with_address(): void
     {
         $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';


### PR DESCRIPTION
### Changed
- Used `modified` in case of missing `created` on organizer RDF projection

---
Ticket: https://jira.uitdatabank.be/browse/III-5829
