### PR TITLE
III-5853 Handle organizers without url

### DIFF
--- a/src/Organizer/ReadModel/RDF/RdfProjector.php
+++ b/src/Organizer/ReadModel/RDF/RdfProjector.php
@@ -95,7 +95,9 @@ final class RdfProjector implements EventListener
 
         $this->setName($resource, $organizer->getName());
 
-        $this->setHomepage($resource, $organizer->getUrl());
+        if ($organizer->getUrl()) {
+            $this->setHomepage($resource, $organizer->getUrl());
+        }
 
         if ($organizer->getAddress()) {
             (new AddressEditor($this->addressParser))

--- a/tests/Organizer/ReadModel/RDF/RdfProjectorTest.php
+++ b/tests/Organizer/ReadModel/RDF/RdfProjectorTest.php
@@ -71,6 +71,35 @@ class RdfProjectorTest extends RdfTestCase
     /**
      * @test
      */
+    public function it_converts_a_simple_organizer_without_url(): void
+    {
+        $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';
+
+        $organizer = [
+            '@id' => 'https://mock.io.uitdatabank.be/organizers/' . $organizerId,
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'publiq VZW',
+                'en' => 'publiq NPO',
+            ],
+            'created' => '2023-01-01T12:30:15+01:00',
+        ];
+
+        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+
+        $this->project(
+            $organizerId,
+            [
+                new OrganizerProjectedToJSONLD($organizerId, 'https://mock.io.uitdatabank.be/organizer/' . $organizerId),
+            ]
+        );
+
+        $this->assertTurtleData($organizerId, file_get_contents(__DIR__ . '/ttl/organizer-without-homepage.ttl'));
+    }
+
+    /**
+     * @test
+     */
     public function it_converts_a_simple_organizer_without_created(): void
     {
         $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';

--- a/tests/Organizer/ReadModel/RDF/ttl/organizer-without-homepage.ttl
+++ b/tests/Organizer/ReadModel/RDF/ttl/organizer-without-homepage.ttl
@@ -1,0 +1,22 @@
+@prefix cp: <https://data.vlaanderen.be/ns/cultuurparticipatie#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix cpr: <https://data.vlaanderen.be/ns/cultuurparticipatie#Realisator.> .
+
+<https://mock.data.publiq.be/organizers/56f1efdb-fe25-44f6-b9d7-4a6a836799d7>
+  a cp:Organisator ;
+  dcterms:created "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  dcterms:modified "2023-01-01T12:30:15+01:00"^^xsd:dateTime ;
+  adms:identifier [
+    a adms:Identifier ;
+    skos:notation "https://mock.data.publiq.be/organizers/56f1efdb-fe25-44f6-b9d7-4a6a836799d7"^^xsd:anyURI ;
+    generiek:gestructureerdeIdentificator [
+      a generiek:GestructureerdeIdentificator ;
+      generiek:naamruimte "https://mock.data.publiq.be/organizers/" ;
+      generiek:lokaleIdentificator "56f1efdb-fe25-44f6-b9d7-4a6a836799d7"
+    ]
+  ] ;
+  cpr:naam "publiq VZW"@nl, "publiq NPO"@en .


### PR DESCRIPTION
### Fixed
- Handled organizers without URL (homepage in RDF)

---
Ticket: https://jira.uitdatabank.be/browse/III-5853
