### PR TITLE
WIP III-5875 Add config to manage if a route requires authentication

### DIFF
--- a/src/Http/Auth/PublicRouteWithAuthMatcher.php
+++ b/src/Http/Auth/PublicRouteWithAuthMatcher.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Auth;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class PublicRouteWithAuthMatcher
+{
+    private const ALWAYS = 'always';
+    private const PARAM = 'param';
+
+    /** @var PublicRouteRule[] */
+    private array $publicRoutes = [];
+
+    private array $publicRoutesWithAuth;
+
+    public function __construct(array $publicRoutesWithAuth)
+    {
+        $this->publicRoutesWithAuth = $publicRoutesWithAuth;
+    }
+
+    public function isAuthenticationRequired(ServerRequestInterface $request): bool
+    {
+        foreach ($this->publicRoutes as $publicRouteRule) {
+            if ($publicRouteRule->matchesRequest($request) && isset($this->publicRoutesWithAuth[$publicRouteRule->getPathPattern()])) {
+                $authConfig = $this->publicRoutesWithAuth[$publicRouteRule->getPathPattern()];
+
+                if (empty($authConfig['mode'])) {
+                    return false;
+                }
+
+                if (mb_strtolower($authConfig['mode']) === self::ALWAYS) {
+                    return true;
+                }
+
+                if (mb_strtolower($authConfig['mode']) === self::PARAM) {
+                    return isset($request->getQueryParams()[$authConfig['param']]) && $request->getQueryParams()[$authConfig['param']] !== false;
+                }
+
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    public function addPublicRoute(PublicRouteRule $publicRouteRule): void
+    {
+        $this->publicRoutes[] = $publicRouteRule;
+    }
+}

--- a/src/Http/Auth/RouteRule.php
+++ b/src/Http/Auth/RouteRule.php
@@ -23,4 +23,9 @@ abstract class RouteRule
         $path = $request->getUri()->getPath();
         return in_array($method, $this->methods, true) && preg_match($this->pathPattern, $path) === 1;
     }
+
+    public function getPathPattern(): string
+    {
+        return $this->pathPattern;
+    }
 }

--- a/tests/Http/Auth/PublicRouteWithAuthMatcherTest.php
+++ b/tests/Http/Auth/PublicRouteWithAuthMatcherTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Auth;
+
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class PublicRouteWithAuthMatcherTest extends TestCase
+{
+    private ServerRequestInterface $request;
+
+    public function setUp(): void
+    {
+        $this->request = (new Psr7RequestBuilder())
+            ->withRouteParameter('param', 'embedContributors')
+            ->withUriFromString('/places?embedContributors')
+            ->build('GET');
+    }
+
+    /**
+     * @dataProvider configProvider
+     */
+    public function testIsAuthenticationRequired(array $config, bool $expectedResult): void
+    {
+        $this->assertEquals(
+            $expectedResult,
+            $this->constructPublicRouteWithAuthMatcher($config)->isAuthenticationRequired($this->request)
+        );
+    }
+
+    public function configProvider(): array
+    {
+        return [
+            [
+                [
+                    '~^/places/?$~' => [
+                        'mode' => 'always',
+                    ],
+                ],
+                true,
+            ],
+            [
+                [
+                    '~^/places/?$~' => [
+                        'mode' => 'param',
+                        'param' => 'embedContributors',
+                    ],
+                ],
+                true,
+            ],
+            [
+                [
+                    '~^/places/?$~' => [
+                        'mode' => 'param',
+                        'param' => 'wrong',
+                    ],
+                ],
+                false,
+            ],
+            [
+                [
+                    '~^/places/?$~' => [],
+                ],
+                false,
+            ],
+            [
+                [],
+                false,
+            ],
+        ];
+    }
+
+    private function constructPublicRouteWithAuthMatcher(array $config): PublicRouteWithAuthMatcher
+    {
+        $publicRouteWithAuthMatcher = new PublicRouteWithAuthMatcher($config);
+        $publicRouteWithAuthMatcher->addPublicRoute(new PublicRouteRule('~^/places/?$~', ['GET']));
+
+        return $publicRouteWithAuthMatcher;
+    }
+}


### PR DESCRIPTION
### Changed
Added a configuration parameter to mark which routes are always requiring authentication, or make it toggleable dependent on a GET param.

Example in the config.php file:
```php
'public_routes_with_auth' => [
        '~^/events/[\w\-]+/?$~' => [
            'mode' => 'param',
            'param' => 'embedContributors',
        ],
        '~^/places/[\w\-]+/?$~' => [
            'mode' => 'always',
        ],
    ]
```

**Open questions:**
I am not sure about 2 details yet:

1. Should I remove all the calls to addPublicRoute() and move those to my config file? I am not sure the logic is now doubled.
2. When sending an authentication header the code will always try to authenticate you, even when not required. Is this oké? See RequestAuthenticatorMiddleware.php:88

---
Ticket: https://jira.uitdatabank.be/browse/III-5875
