### PR TITLE
III-5901 Store RDF projections inside Redis

### DIFF
--- a/app/Event/EventRdfServiceProvider.php
+++ b/app/Event/EventRdfServiceProvider.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
 use CultuurNet\UDB3\Event\ReadModel\RDF\RdfProjector;
 use CultuurNet\UDB3\Model\Serializer\Event\EventDenormalizer;
+use CultuurNet\UDB3\RDF\CacheGraphRepository;
 use CultuurNet\UDB3\RDF\RdfServiceProvider;
 
 final class EventRdfServiceProvider extends AbstractServiceProvider
@@ -27,6 +28,10 @@ final class EventRdfServiceProvider extends AbstractServiceProvider
             $this->container->get('config')['rdf']['eventsGraphStoreUrl'],
             $this->container->get('config')['rdf']['useDeleteAndInsert'] ?? false
         );
+
+        if ($this->container->get('config')['rdf']['useCache']) {
+            $graphStoreRepository = new CacheGraphRepository($this->container->get('cache')('rdf_event'));
+        }
 
         $this->container->addShared(
             RdfProjector::class,

--- a/app/Organizer/OrganizerRdfServiceProvider.php
+++ b/app/Organizer/OrganizerRdfServiceProvider.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
 use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
 use CultuurNet\UDB3\Organizer\ReadModel\RDF\RdfProjector;
+use CultuurNet\UDB3\RDF\CacheGraphRepository;
 use CultuurNet\UDB3\RDF\RdfServiceProvider;
 
 final class OrganizerRdfServiceProvider extends AbstractServiceProvider
@@ -27,6 +28,10 @@ final class OrganizerRdfServiceProvider extends AbstractServiceProvider
             $this->container->get('config')['rdf']['organizersGraphStoreUrl'],
             $this->container->get('config')['rdf']['useDeleteAndInsert'] ?? false
         );
+
+        if ($this->container->get('config')['rdf']['useCache']) {
+            $graphStoreRepository = new CacheGraphRepository($this->container->get('cache')('rdf_organizer'));
+        }
 
         $this->container->addShared(
             RdfProjector::class,

--- a/app/Place/PlaceRdfServiceProvider.php
+++ b/app/Place/PlaceRdfServiceProvider.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
 use CultuurNet\UDB3\Model\Serializer\Place\PlaceDenormalizer;
 use CultuurNet\UDB3\Place\ReadModel\RDF\RdfProjector;
+use CultuurNet\UDB3\RDF\CacheGraphRepository;
 use CultuurNet\UDB3\RDF\RdfServiceProvider;
 
 final class PlaceRdfServiceProvider extends AbstractServiceProvider
@@ -27,6 +28,10 @@ final class PlaceRdfServiceProvider extends AbstractServiceProvider
             $this->container->get('config')['rdf']['placesGraphStoreUrl'],
             $this->container->get('config')['rdf']['useDeleteAndInsert'] ?? false
         );
+
+        if ($this->container->get('config')['rdf']['useCache']) {
+            $graphStoreRepository = new CacheGraphRepository($this->container->get('cache')('rdf_place'));
+        }
 
         $this->container->addShared(
             RdfProjector::class,

--- a/src/RDF/CacheGraphRepository.php
+++ b/src/RDF/CacheGraphRepository.php
@@ -18,7 +18,7 @@ final class CacheGraphRepository implements GraphRepository
 
     public function save(string $uri, Graph $graph): void
     {
-        $this->cache->save($uri, $graph->serialise('turtle'));
+        $this->cache->save($uri, trim($graph->serialise('turtle')));
     }
 
     public function get(string $uri): Graph

--- a/src/RDF/CacheGraphRepository.php
+++ b/src/RDF/CacheGraphRepository.php
@@ -24,12 +24,11 @@ final class CacheGraphRepository implements GraphRepository
     public function get(string $uri): Graph
     {
         $value = $this->cache->fetch($uri);
-
-        $graph = new Graph($uri);
         if ($value === false) {
-            return $graph;
+            throw new GraphNotFound($uri);
         }
 
+        $graph = new Graph($uri);
         $graph->parse($value, 'turtle');
         return $graph;
     }

--- a/src/RDF/CacheGraphRepository.php
+++ b/src/RDF/CacheGraphRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\RDF;
+
+use Doctrine\Common\Cache\Cache;
+use EasyRdf\Graph;
+
+final class CacheGraphRepository implements GraphRepository
+{
+    private Cache $cache;
+
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function save(string $uri, Graph $graph): void
+    {
+        $this->cache->save($uri, $graph->serialise('turtle'));
+    }
+
+    public function get(string $uri): Graph
+    {
+        $value = $this->cache->fetch($uri);
+
+        $graph = new Graph($uri);
+        if ($value === false) {
+            return $graph;
+        }
+
+        $graph->parse($value, 'turtle');
+        return $graph;
+    }
+}

--- a/src/RDF/GraphNotFound.php
+++ b/src/RDF/GraphNotFound.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\RDF;
+
+final class GraphNotFound extends \Exception
+{
+    public function __construct(string $uri)
+    {
+        parent::__construct(sprintf('Graph not found for uri: %s', $uri));
+    }
+}

--- a/src/RDF/GraphRepository.php
+++ b/src/RDF/GraphRepository.php
@@ -9,5 +9,9 @@ use EasyRdf\Graph;
 interface GraphRepository
 {
     public function save(string $uri, Graph $graph): void;
+
+    /**
+     * @throws GraphNotFound
+     */
     public function get(string $uri): Graph;
 }

--- a/src/RDF/GraphStoreRepository.php
+++ b/src/RDF/GraphStoreRepository.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\RDF;
 
 use EasyRdf\Graph;
 use EasyRdf\GraphStore;
-use EasyRdf\Http\Exception;
 
 final class GraphStoreRepository implements GraphRepository
 {
@@ -38,11 +37,11 @@ final class GraphStoreRepository implements GraphRepository
     {
         try {
             return $this->graphStore->get($this->appendSuffix($uri));
-        } catch (Exception $e) {
-            if ($e->getCode() !== 404) {
-                throw $e;
+        } catch (\Exception $e) {
+            if ($e->getCode() === 404) {
+                throw new GraphNotFound($uri);
             }
-            return new Graph($uri);
+            throw $e;
         }
     }
 

--- a/src/RDF/InMemoryGraphRepository.php
+++ b/src/RDF/InMemoryGraphRepository.php
@@ -24,6 +24,7 @@ final class InMemoryGraphRepository implements GraphRepository
             // are also cloned.
             return unserialize(serialize($this->graphs[$uri]));
         }
-        return new Graph($uri);
+
+        throw new GraphNotFound($uri);
     }
 }

--- a/tests/RDF/CacheGraphRepositoryTest.php
+++ b/tests/RDF/CacheGraphRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace RDF;
 
 use CultuurNet\UDB3\RDF\CacheGraphRepository;
+use CultuurNet\UDB3\RDF\GraphNotFound;
 use Doctrine\Common\Cache\Cache;
 use EasyRdf\Graph;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -83,16 +84,16 @@ class CacheGraphRepositoryTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_an_empty_graph_when_key_is_not_found(): void
+    public function it_throws_graph_not_found_when_key_is_not_found(): void
     {
         $this->cache->expects($this->once())
             ->method('fetch')
             ->with($this->uri)
             ->willReturn(false);
 
-        $this->assertEquals(
-            new Graph($this->uri),
-            $this->cacheGraphRepository->get($this->uri)
-        );
+        $this->expectException(GraphNotFound::class);
+        $this->expectExceptionMessage('Graph not found for uri: ' . $this->uri);
+
+        $this->cacheGraphRepository->get($this->uri);
     }
 }

--- a/tests/RDF/CacheGraphRepositoryTest.php
+++ b/tests/RDF/CacheGraphRepositoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RDF;
+
+use CultuurNet\UDB3\RDF\CacheGraphRepository;
+use Doctrine\Common\Cache\Cache;
+use EasyRdf\Graph;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CacheGraphRepositoryTest extends TestCase
+{
+    /** @var Cache&MockObject  */
+    private Cache $cache;
+
+    private CacheGraphRepository $cacheGraphRepository;
+
+    private string $uri;
+    private Graph $graph;
+
+    public function setUp(): void
+    {
+        $this->cache = $this->createMock(Cache::class);
+        $this->cacheGraphRepository = new CacheGraphRepository($this->cache);
+
+        $this->uri = 'https://mock.data.publiq.be/events/612e0661-4bb3-42d4-a392-aa5825ca5427';
+
+        $this->graph = new Graph($this->uri);
+        $resource = $this->graph->resource($this->uri);
+        $resource->setType('cidoc:E7_Activity');
+        $resource->addLiteral('dcterms:title', ['My beautiful event']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_save_a_graph(): void
+    {
+        $this->cache->expects($this->once())
+            ->method('save')
+            ->with($this->uri, file_get_contents(__DIR__ . '/event.ttl'));
+
+        $this->cacheGraphRepository->save($this->uri, $this->graph);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_a_graph(): void
+    {
+        $this->cache->expects($this->once())
+            ->method('fetch')
+            ->with($this->uri)
+            ->willReturn(file_get_contents(__DIR__ . '/event.ttl'));
+
+        $graph = $this->cacheGraphRepository->get($this->uri);
+
+        $resource = $graph->resource($this->uri);
+        $this->assertEquals(
+            'cidoc:E7_Activity',
+            $resource->type()
+        );
+
+        $this->assertEquals(
+            'My beautiful event',
+            $resource->get('dcterms:title')
+        );
+
+        $this->assertEquals(
+            $this->graph->resources(),
+            $graph->resources()
+        );
+
+        // Comparing the full Graph objects only works because `resources()` was first called on both graphs.
+        $this->assertEquals(
+            $this->graph,
+            $graph
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_empty_graph_when_key_is_not_found(): void
+    {
+        $this->cache->expects($this->once())
+            ->method('fetch')
+            ->with($this->uri)
+            ->willReturn(false);
+
+        $this->assertEquals(
+            new Graph($this->uri),
+            $this->cacheGraphRepository->get($this->uri)
+        );
+    }
+}

--- a/tests/RDF/event.ttl
+++ b/tests/RDF/event.ttl
@@ -1,0 +1,7 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+<https://mock.data.publiq.be/events/612e0661-4bb3-42d4-a392-aa5825ca5427>
+  a cidoc:E7_Activity ;
+  dcterms:title "My beautiful event" .
+

--- a/tests/RDF/event.ttl
+++ b/tests/RDF/event.ttl
@@ -4,4 +4,3 @@
 <https://mock.data.publiq.be/events/612e0661-4bb3-42d4-a392-aa5825ca5427>
   a cidoc:E7_Activity ;
   dcterms:title "My beautiful event" .
-


### PR DESCRIPTION
### Added
- Implemented `CacheGraphRepository` to store RDF projection inside Redis

### Note
- In a follow-up pull requests the RDF will be served from Redis

---
Ticket: https://jira.uitdatabank.be/browse/III-5901
