### PR TITLE
III-5856 Add address name to geocoding api

### DIFF
--- a/app/Event/EventGeoCoordinatesServiceProvider.php
+++ b/app/Event/EventGeoCoordinatesServiceProvider.php
@@ -36,6 +36,8 @@ final class EventGeoCoordinatesServiceProvider extends AbstractServiceProvider
                     new FullAddressFormatter(),
                     new LocalityAddressFormatter(),
                     $container->get(GeocodingService::class),
+                    $container->get('event_jsonld_repository'),
+                    $container->get('config')['address_enrichment'] ?? false
                 );
                 $handler->setLogger(
                     LoggerFactory::create(

--- a/app/Geocoding/GeocodingServiceProvider.php
+++ b/app/Geocoding/GeocodingServiceProvider.php
@@ -40,10 +40,19 @@ final class GeocodingServiceProvider extends AbstractServiceProvider
                     LoggerFactory::create($container, LoggerName::forService('geo-coordinates', 'google'))
                 );
 
-                return new CachedGeocodingService(
+                $cachedGeocodingService = new CachedGeocodingService(
                     $geocodingService,
                     $container->get('cache')('geocoords')
                 );
+
+                if ($container->get('config')['address_enrichment']) {
+                    return new EnrichedCachedGeocodingService(
+                        $cachedGeocodingService,
+                        $container->get('cache')('geocoords_enriched')
+                    );
+                }
+
+                return $cachedGeocodingService;
             }
         );
     }

--- a/app/Place/PlaceGeoCoordinatesServiceProvider.php
+++ b/app/Place/PlaceGeoCoordinatesServiceProvider.php
@@ -34,7 +34,9 @@ final class PlaceGeoCoordinatesServiceProvider extends AbstractServiceProvider
                     $container->get('place_repository'),
                     new FullAddressFormatter(),
                     new LocalityAddressFormatter(),
-                    $container->get(GeocodingService::class)
+                    $container->get(GeocodingService::class),
+                    $container->get('place_jsonld_repository'),
+                    $container->get('config')['address_enrichment'] ?? false
                 );
 
                 $handler->setLogger(LoggerFactory::create($container, LoggerName::forService('geo-coordinates', 'place')));

--- a/src/Geocoding/CachedGeocodingService.php
+++ b/src/Geocoding/CachedGeocodingService.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Geocoding;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
+use CultuurNet\UDB3\Geocoding\Dto\EnrichedAddress;
 use CultuurNet\UDB3\Json;
 use Doctrine\Common\Cache\Cache;
 
@@ -24,7 +25,7 @@ class CachedGeocodingService implements GeocodingService
         $this->cache = $cache;
     }
 
-    public function getCoordinates(string $address): ?Coordinates
+    public function getCoordinates(string $address, ?string $locationName=null): ?Coordinates
     {
         $encodedCacheData = $this->cache->fetch($address);
 
@@ -39,13 +40,13 @@ class CachedGeocodingService implements GeocodingService
 
             if (isset($cacheData['lat'], $cacheData['long'])) {
                 return new Coordinates(
-                    new Latitude((float) $cacheData['lat']),
-                    new Longitude((float) $cacheData['long'])
+                    new Latitude((float)$cacheData['lat']),
+                    new Longitude((float)$cacheData['long'])
                 );
             }
         }
 
-        $coordinates = $this->geocodingService->getCoordinates($address);
+        $coordinates = $this->geocodingService->getCoordinates($address, $locationName);
 
         // Some addresses have no coordinates, to cache these addresses 'NO_COORDINATES_FOUND' is used as value.
         // When null is passed in as the coordinates, then 'NO_COORDINATES_FOUND' is stored as cache value.
@@ -60,5 +61,10 @@ class CachedGeocodingService implements GeocodingService
         $this->cache->save($address, Json::encode($cacheData));
 
         return $coordinates;
+    }
+
+    public function getEnrichedAddress(string $address, ?string $locationName): ?EnrichedAddress
+    {
+        return $this->geocodingService->getEnrichedAddress($address, $locationName);
     }
 }

--- a/src/Geocoding/Dto/EnrichedAddress.php
+++ b/src/Geocoding/Dto/EnrichedAddress.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Geocoding\Dto;
+
+use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
+use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
+use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
+use Geocoder\Exception\CollectionIsEmpty;
+use Geocoder\Provider\GoogleMaps\Model\GoogleAddress;
+
+class EnrichedAddress implements \JsonSerializable
+{
+    private string $placeId;
+    private string $formattedAddress;
+    private string $locationType;
+    private array $resultType;
+    private bool $partialMatch;
+    private Coordinates $coordinates;
+
+    public function __construct(
+        string $placeId,
+        string $formattedAddress,
+        string $locationType,
+        array $resultType,
+        bool $partialMatch,
+        Coordinates $coordinates
+    ) {
+        $this->placeId = $placeId;
+        $this->formattedAddress = $formattedAddress;
+        $this->locationType = $locationType;
+        $this->resultType = $resultType;
+        $this->partialMatch = $partialMatch;
+        $this->coordinates = $coordinates;
+    }
+
+    public function getPlaceId(): string
+    {
+        return $this->placeId;
+    }
+
+    public function getFormattedAddress(): string
+    {
+        return $this->formattedAddress;
+    }
+
+    public function getLocationType(): string
+    {
+        return $this->locationType;
+    }
+
+    public function getResultType(): array
+    {
+        return $this->resultType;
+    }
+
+    public function getCoordinates(): Coordinates
+    {
+        return $this->coordinates;
+    }
+
+    public function isPartialMatch(): bool
+    {
+        return $this->partialMatch;
+    }
+
+    public function sameAs(self $comparedTo): bool
+    {
+        return ($this->jsonSerialize() === $comparedTo->jsonSerialize());
+    }
+
+    public static function constructFromGoogleAddress(GoogleAddress $googleAddress): self
+    {
+        $coordinates = $googleAddress->getCoordinates();
+        if ($coordinates === null) {
+            throw new CollectionIsEmpty('Coordinates from address are empty');
+        }
+
+        return new self(
+            $googleAddress->getId(),
+            $googleAddress->getFormattedAddress(),
+            $googleAddress->getLocationType(),
+            $googleAddress->getResultType(),
+            $googleAddress->isPartialMatch(),
+            new Coordinates(
+                new Latitude($coordinates->getLatitude()),
+                new Longitude($coordinates->getLongitude())
+            )
+        );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'placeId' => $this->placeId,
+            'formattedAddress' => $this->formattedAddress,
+            'locationType' => $this->locationType,
+            'resultType' => $this->resultType,
+            'partialMatch' => $this->partialMatch,
+            'coordinates' => [
+                'lat' => $this->coordinates->getLatitude()->toFloat(),
+                'long' => $this->coordinates->getLongitude()->toFloat(),
+            ],
+        ];
+    }
+}

--- a/src/Geocoding/EnrichedCachedGeocodingService.php
+++ b/src/Geocoding/EnrichedCachedGeocodingService.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Geocoding;
+
+use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
+use CultuurNet\UDB3\Geocoding\Dto\EnrichedAddress;
+use Doctrine\Common\Cache\Cache;
+
+class EnrichedCachedGeocodingService implements GeocodingService
+{
+    private GeocodingService $geocodingService;
+
+    private Cache $cache;
+
+    public function __construct(GeocodingService $geocodingService, Cache $cache)
+    {
+        $this->geocodingService = $geocodingService;
+        $this->cache = $cache;
+    }
+
+    public function getCoordinates(string $address, ?string $locationName=null): ?Coordinates
+    {
+        $key = $address . $locationName;
+
+        if (!$this->cache->contains($key)) {
+            try {
+                $this->cache->save($key, $this->geocodingService->getEnrichedAddress($address, $locationName));
+            } catch (NoGoogleAddressToEnrichReceived $e) {
+                // No google address to save
+            }
+        }
+
+        return $this->geocodingService->getCoordinates($address, $locationName);
+    }
+
+    public function getEnrichedAddress(string $address, ?string $locationName): EnrichedAddress
+    {
+        return $this->geocodingService->getEnrichedAddress($address, $locationName);
+    }
+}

--- a/src/Geocoding/GeocodingResponse.php
+++ b/src/Geocoding/GeocodingResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Geocoding;
+
+use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
+use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
+use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
+use CultuurNet\UDB3\Geocoding\Dto\EnrichedAddress;
+use Geocoder\Exception\CollectionIsEmpty;
+use Geocoder\Exception\Exception;
+use Geocoder\Geocoder;
+use Geocoder\Location;
+use Geocoder\Provider\GoogleMaps\Model\GoogleAddress;
+
+class GeocodingResponse
+{
+    private Location $location;
+
+    /**
+     * @throws Exception
+     */
+    public function __construct(
+        Geocoder $geocoder,
+        string $address,
+        string $locationName=null
+    ) {
+        $response = $geocoder->geocode($locationName ? $address . ' ' . $locationName : $address);
+
+        $this->location = $response->first();
+    }
+
+    public function getCoordinates(): Coordinates
+    {
+        $coordinates = $this->location->getCoordinates();
+
+        if ($coordinates === null) {
+            throw new CollectionIsEmpty('Coordinates from address are empty');
+        }
+
+        return new Coordinates(
+            new Latitude($coordinates->getLatitude()),
+            new Longitude($coordinates->getLongitude())
+        );
+    }
+
+    public function getEnrichedAddress(): EnrichedAddress
+    {
+        if (! $this->location instanceof GoogleAddress) {
+            throw new NoGoogleAddressToEnrichReceived();
+        }
+
+        return EnrichedAddress::constructFromGoogleAddress($this->location);
+    }
+}

--- a/src/Geocoding/GeocodingService.php
+++ b/src/Geocoding/GeocodingService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Geocoding;
 
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
+use CultuurNet\UDB3\Geocoding\Dto\EnrichedAddress;
 
 interface GeocodingService
 {
@@ -13,5 +14,7 @@ interface GeocodingService
      * Returns null when no coordinates are found for the given address.
      * This can happen in case of a wrong/unknown address.
      */
-    public function getCoordinates(string $address): ?Coordinates;
+    public function getCoordinates(string $address, ?string $locationName=null): ?Coordinates;
+
+    public function getEnrichedAddress(string $address, ?string $locationName): ?EnrichedAddress;
 }

--- a/src/Geocoding/NoGoogleAddressToEnrichReceived.php
+++ b/src/Geocoding/NoGoogleAddressToEnrichReceived.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Geocoding;
+
+use RuntimeException;
+
+class NoGoogleAddressToEnrichReceived extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Did not receive a google address to enrich');
+    }
+}

--- a/src/Offer/AbstractGeoCoordinatesCommandHandler.php
+++ b/src/Offer/AbstractGeoCoordinatesCommandHandler.php
@@ -9,6 +9,9 @@ use CultuurNet\UDB3\Geocoding\GeocodingService;
 use CultuurNet\UDB3\Address\AddressFormatter;
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
 use CultuurNet\UDB3\Offer\Commands\AbstractUpdateGeoCoordinatesFromAddress;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use JsonException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
@@ -24,18 +27,24 @@ abstract class AbstractGeoCoordinatesCommandHandler extends Udb3CommandHandler i
     private AddressFormatter $fallbackAddressFormatter;
 
     private GeocodingService $geocodingService;
+    private DocumentRepository $documentRepository;
+    private bool $addressEnrichment;
 
     public function __construct(
         Repository $placeRepository,
         AddressFormatter $defaultAddressFormatter,
         AddressFormatter $fallbackAddressFormatter,
-        GeocodingService $geocodingService
+        GeocodingService $geocodingService,
+        DocumentRepository $documentRepository,
+        bool $addressEnrichment
     ) {
         $this->offerRepository = $placeRepository;
         $this->defaultAddressFormatter = $defaultAddressFormatter;
         $this->fallbackAddressFormatter = $fallbackAddressFormatter;
         $this->geocodingService = $geocodingService;
         $this->logger = new NullLogger();
+        $this->documentRepository = $documentRepository;
+        $this->addressEnrichment = $addressEnrichment;
     }
 
     protected function updateGeoCoordinatesFromAddress(
@@ -47,7 +56,9 @@ abstract class AbstractGeoCoordinatesCommandHandler extends Udb3CommandHandler i
             $updateGeoCoordinates->getAddress()
         );
 
-        $coordinates = $this->geocodingService->getCoordinates($exactAddress);
+        $locationName = $this->fetchOfferName($offerId);
+
+        $coordinates = $this->geocodingService->getCoordinates($exactAddress, $locationName);
 
         if ($coordinates === null) {
             $fallbackAddress = $this->fallbackAddressFormatter->format(
@@ -63,7 +74,7 @@ abstract class AbstractGeoCoordinatesCommandHandler extends Udb3CommandHandler i
                 )
             );
 
-            $coordinates = $this->geocodingService->getCoordinates($fallbackAddress);
+            $coordinates = $this->geocodingService->getCoordinates($fallbackAddress, $locationName);
 
             if (!is_null($coordinates)) {
                 $this->logger->debug(
@@ -81,5 +92,20 @@ abstract class AbstractGeoCoordinatesCommandHandler extends Udb3CommandHandler i
         $offer = $this->offerRepository->load($offerId);
         $offer->updateGeoCoordinates($coordinates);
         $this->offerRepository->save($offer);
+    }
+
+    private function fetchOfferName(string $offerId): ?string
+    {
+        if (! $this->addressEnrichment) {
+            return null;
+        }
+
+        try {
+            $offer = $this->documentRepository->fetch($offerId)->getAssocBody();
+
+            return $offer['name']['nl'] ?? $offer['name']['fr'];
+        } catch (DocumentDoesNotExist|JsonException $e) {
+            return null;
+        }
     }
 }

--- a/src/Offer/Commands/AbstractUpdateGeoCoordinatesFromAddress.php
+++ b/src/Offer/Commands/AbstractUpdateGeoCoordinatesFromAddress.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Address\Address;
+use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 
 abstract class AbstractUpdateGeoCoordinatesFromAddress extends AbstractCommand
 {
-    /**
-     * @var Address
-     */
-    private $address;
+    private Address $address;
 
     /**
      * @param string $itemId
@@ -22,10 +20,7 @@ abstract class AbstractUpdateGeoCoordinatesFromAddress extends AbstractCommand
         $this->address = $address;
     }
 
-    /**
-     * @return Address
-     */
-    public function getAddress()
+    public function getAddress() : Address
     {
         return $this->address;
     }

--- a/src/Offer/Commands/AbstractUpdateGeoCoordinatesFromAddress.php
+++ b/src/Offer/Commands/AbstractUpdateGeoCoordinatesFromAddress.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Address\Address;
-use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 
 abstract class AbstractUpdateGeoCoordinatesFromAddress extends AbstractCommand
 {
@@ -20,7 +19,7 @@ abstract class AbstractUpdateGeoCoordinatesFromAddress extends AbstractCommand
         $this->address = $address;
     }
 
-    public function getAddress() : Address
+    public function getAddress(): Address
     {
         return $this->address;
     }

--- a/src/ReadModel/JsonDocument.php
+++ b/src/ReadModel/JsonDocument.php
@@ -29,6 +29,9 @@ final class JsonDocument implements Identifiable
         return (object) Json::decode($this->body);
     }
 
+    /**
+     * @throws \JsonException
+     */
     public function getAssocBody(): array
     {
         return (array) Json::decodeAssociatively($this->body);

--- a/tests/Event/GeoCoordinatesCommandHandlerTest.php
+++ b/tests/Event/GeoCoordinatesCommandHandlerTest.php
@@ -27,21 +27,16 @@ use CultuurNet\UDB3\Event\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
 {
-    /**
-     * @var AddressFormatter
-     */
-    private $defaultAddressFormatter;
+    private AddressFormatter $defaultAddressFormatter;
 
-    /**
-     * @var AddressFormatter
-     */
-    private $localityAddressFormatter;
+    private AddressFormatter $localityAddressFormatter;
 
     /**
      * @var GeocodingService|MockObject
@@ -59,12 +54,15 @@ class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
         $this->localityAddressFormatter = new LocalityAddressFormatter();
 
         $this->geocodingService = $this->createMock(GeocodingService::class);
+        $documentRepository = $this->createMock(DocumentRepository::class);
 
         return new GeoCoordinatesCommandHandler(
             $eventRepository,
             $this->defaultAddressFormatter,
             $this->localityAddressFormatter,
-            $this->geocodingService
+            $this->geocodingService,
+            $documentRepository,
+            false
         );
     }
 

--- a/tests/Geocoding/Dto/EnrichedAddressTest.php
+++ b/tests/Geocoding/Dto/EnrichedAddressTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Geocoding\Dto;
+
+use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
+use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
+use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
+use Geocoder\Model\AdminLevelCollection;
+use Geocoder\Model\Coordinates as CoordinatesGeocoder;
+use Geocoder\Provider\GoogleMaps\Model\GoogleAddress;
+use PHPUnit\Framework\TestCase;
+
+class EnrichedAddressTest extends TestCase
+{
+    private const PLACE_ID = 'place123';
+    private const ADDRESS = 'Some Street, City, Country';
+    private const LOCATION_TYPE = 'ROOFTOP';
+    private const RESULT_TYPE = ['street_address'];
+    private const LATITUDE = 40.7128;
+    private const LONGITUDE = -74.0060;
+
+    public function testJsonSerialize(): void
+    {
+        $enrichedAddress = new EnrichedAddress(
+            self::PLACE_ID,
+            self::ADDRESS,
+            self::LOCATION_TYPE,
+            self::RESULT_TYPE,
+            true,
+            new Coordinates(new Latitude(self::LATITUDE), new Longitude(self::LONGITUDE))
+        );
+
+        $expectedJson = json_encode([
+            'placeId' => self::PLACE_ID,
+            'formattedAddress' => self::ADDRESS,
+            'locationType' => self::LOCATION_TYPE,
+            'resultType' => self::RESULT_TYPE,
+            'partialMatch' => true,
+            'coordinates' => [
+                'lat' => self::LATITUDE,
+                'long' => self::LONGITUDE,
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $this->assertEquals($expectedJson, json_encode($enrichedAddress, JSON_THROW_ON_ERROR));
+    }
+
+    public function testConstructFromGoogleAddress(): void
+    {
+        $googleAddress = new GoogleAddress(
+            'phpunit',
+            new AdminLevelCollection(),
+            new CoordinatesGeocoder(self::LATITUDE, self::LONGITUDE)
+        );
+        $googleAddress = $googleAddress
+            ->withId(self::PLACE_ID)
+            ->withFormattedAddress(self::ADDRESS)
+            ->withLocationType(self::LOCATION_TYPE)
+            ->withResultType(self::RESULT_TYPE)
+            ->withPartialMatch(true);
+
+        $enrichedAddress = EnrichedAddress::constructFromGoogleAddress($googleAddress);
+
+        $this->assertEquals(self::PLACE_ID, $enrichedAddress->getPlaceId());
+        $this->assertEquals(self::ADDRESS, $enrichedAddress->getFormattedAddress());
+        $this->assertEquals(self::LOCATION_TYPE, $enrichedAddress->getLocationType());
+        $this->assertEquals(self::RESULT_TYPE, $enrichedAddress->getResultType());
+        $this->assertTrue($enrichedAddress->isPartialMatch());
+        $this->assertEquals(self::LATITUDE, $enrichedAddress->getCoordinates()->getLatitude()->toFloat());
+        $this->assertEquals(self::LONGITUDE, $enrichedAddress->getCoordinates()->getLongitude()->toFloat());
+    }
+
+    public function testSameAs(): void
+    {
+        $enrichedAddress = new EnrichedAddress(
+            self::PLACE_ID,
+            self::ADDRESS,
+            self::LOCATION_TYPE,
+            self::RESULT_TYPE,
+            true,
+            new Coordinates(new Latitude(self::LATITUDE), new Longitude(self::LONGITUDE))
+        );
+
+        $differentAddress = new EnrichedAddress(
+            self::PLACE_ID,
+            self::ADDRESS,
+            self::LOCATION_TYPE,
+            self::RESULT_TYPE,
+            false,
+            new Coordinates(new Latitude(self::LATITUDE), new Longitude(self::LONGITUDE))
+        );
+
+        $this->assertTrue($enrichedAddress->sameAs(clone $enrichedAddress));
+        $this->assertFalse($enrichedAddress->sameAs($differentAddress));
+    }
+}

--- a/tests/Geocoding/EnrichedCachedGeocodingServiceTest.php
+++ b/tests/Geocoding/EnrichedCachedGeocodingServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Geocoding;
+
+use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
+use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
+use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
+use CultuurNet\UDB3\Geocoding\Dto\EnrichedAddress;
+use Doctrine\Common\Cache\Cache;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class EnrichedCachedGeocodingServiceTest extends TestCase
+{
+    private const ADDRESS = 'Some Street, City, Country';
+    private const LOCATION_NAME = 'Some Location';
+    /**
+     * @var GeocodingService|MockObject
+     */
+    private $geocodingServiceMock;
+
+    /**
+     * @var Cache|MockObject
+     */
+    private $cacheMock;
+
+    private EnrichedCachedGeocodingService $enrichedCachedGeocodingService;
+    private Coordinates $coordinates;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->geocodingServiceMock = $this->createMock(GeocodingService::class);
+        $this->cacheMock = $this->createMock(Cache::class);
+
+        $this->enrichedCachedGeocodingService = new EnrichedCachedGeocodingService(
+            $this->geocodingServiceMock,
+            $this->cacheMock
+        );
+
+        $this->coordinates = new Coordinates(new Latitude(40.7128), new Longitude(-74.0060));
+
+        $this->geocodingServiceMock->expects($this->once())
+            ->method('getCoordinates')
+            ->with(self::ADDRESS, self::LOCATION_NAME)
+            ->willReturn($this->coordinates);
+    }
+
+    public function testGetCoordinatesWithCache(): void
+    {
+        $this->cacheMock->expects($this->once())
+            ->method('contains')
+            ->with(self::ADDRESS . self::LOCATION_NAME)
+            ->willReturn(true);
+
+        $this->assertSame(
+            $this->coordinates,
+            $this->enrichedCachedGeocodingService->getCoordinates(self::ADDRESS, self::LOCATION_NAME)
+        );
+    }
+
+    public function testGetCoordinatesWithoutCache(): void
+    {
+        $this->cacheMock->expects($this->once())
+            ->method('contains')
+            ->with(self::ADDRESS . self::LOCATION_NAME)
+            ->willReturn(false);
+
+        $this->geocodingServiceMock->expects($this->once())
+            ->method('getEnrichedAddress')
+            ->with(self::ADDRESS, self::LOCATION_NAME)
+            ->willReturn(new EnrichedAddress(
+                'place123',
+                self::ADDRESS,
+                'ROOFTOP',
+                ['street_address'],
+                true,
+                $this->coordinates
+            ));
+
+        $this->assertSame(
+            $this->coordinates,
+            $this->enrichedCachedGeocodingService->getCoordinates(self::ADDRESS, self::LOCATION_NAME)
+        );
+    }
+}

--- a/tests/Place/GeoCoordinatesCommandHandlerTest.php
+++ b/tests/Place/GeoCoordinatesCommandHandlerTest.php
@@ -26,25 +26,25 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Place\Commands\UpdateGeoCoordinatesFromAddress;
 use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
 {
-    /**
-     * @var AddressFormatter
-     */
-    private $defaultAddressFormatter;
+    private AddressFormatter $defaultAddressFormatter;
 
-    /**
-     * @var AddressFormatter
-     */
-    private $localityAddressFormatter;
+    private AddressFormatter $localityAddressFormatter;
 
     /**
      * @var GeocodingService|MockObject
      */
     private $geocodingService;
+
+    /**
+     * @var DocumentRepository|MockObject
+     */
+    private $documentRepository;
 
     protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): GeoCoordinatesCommandHandler
     {
@@ -57,12 +57,15 @@ class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
         $this->localityAddressFormatter = new LocalityAddressFormatter();
 
         $this->geocodingService = $this->createMock(GeocodingService::class);
+        $this->documentRepository = $this->createMock(DocumentRepository::class);
 
         return new GeoCoordinatesCommandHandler(
             $repository,
             $this->defaultAddressFormatter,
             $this->localityAddressFormatter,
-            $this->geocodingService
+            $this->geocodingService,
+            $this->documentRepository,
+            false
         );
     }
 


### PR DESCRIPTION
### Changed
I added the location name to the google map api call for more accurate results (requested by Frederick from Data Minded).
I also added an extra layer of cache that can be enable with a flag "address_enrichment", that stores this enriched address in Redis for Data Minded.

---
Ticket: https://jira.uitdatabank.be/browse/III-5856
