### PR TITLE
III-5916 Create organizer turtle on the fly

### DIFF
--- a/app/Organizer/OrganizerRdfServiceProvider.php
+++ b/app/Organizer/OrganizerRdfServiceProvider.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
 use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
+use CultuurNet\UDB3\Organizer\ReadModel\RDF\OrganizerJsonToTurtleConverter;
 use CultuurNet\UDB3\Organizer\ReadModel\RDF\RdfProjector;
 use CultuurNet\UDB3\RDF\CacheGraphRepository;
 use CultuurNet\UDB3\RDF\RdfServiceProvider;
@@ -18,8 +19,8 @@ final class OrganizerRdfServiceProvider extends AbstractServiceProvider
     protected function getProvidedServiceNames(): array
     {
         return [
-            'organizer_graph_store_repository',
             RdfProjector::class,
+            OrganizerJsonToTurtleConverter::class,
         ];
     }
 
@@ -35,14 +36,20 @@ final class OrganizerRdfServiceProvider extends AbstractServiceProvider
         }
 
         $this->container->addShared(
-            'organizer_graph_store_repository',
-            $graphStoreRepository
-        );
-
-        $this->container->addShared(
             RdfProjector::class,
             fn (): RdfProjector => new RdfProjector(
                 $graphStoreRepository,
+                RdfServiceProvider::createIriGenerator($this->container->get('config')['rdf']['organizersRdfBaseUri']),
+                $this->container->get('organizer_jsonld_repository'),
+                new OrganizerDenormalizer(),
+                $this->container->get(AddressParser::class),
+                LoggerFactory::create($this->getContainer(), LoggerName::forService('rdf'))
+            )
+        );
+
+        $this->container->addShared(
+            OrganizerJsonToTurtleConverter::class,
+            fn (): OrganizerJsonToTurtleConverter => new OrganizerJsonToTurtleConverter(
                 RdfServiceProvider::createIriGenerator($this->container->get('config')['rdf']['organizersRdfBaseUri']),
                 $this->container->get('organizer_jsonld_repository'),
                 new OrganizerDenormalizer(),

--- a/app/Organizer/OrganizerRequestHandlerServiceProvider.php
+++ b/app/Organizer/OrganizerRequestHandlerServiceProvider.php
@@ -31,10 +31,10 @@ use CultuurNet\UDB3\Http\Organizer\UpdateImagesRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\UpdateMainImageRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\UpdateTitleRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\UpdateUrlRequestHandler;
-use CultuurNet\UDB3\Http\RDF\RDFResponseFactory;
+use CultuurNet\UDB3\Http\RDF\TurtleResponseFactory;
 use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\ImagesPropertyPolyfillRequestBodyParser;
-use CultuurNet\UDB3\RDF\RdfServiceProvider;
+use CultuurNet\UDB3\Organizer\ReadModel\RDF\OrganizerJsonToTurtleConverter;
 use CultuurNet\UDB3\User\CurrentUser;
 
 final class OrganizerRequestHandlerServiceProvider extends AbstractServiceProvider
@@ -96,9 +96,8 @@ final class OrganizerRequestHandlerServiceProvider extends AbstractServiceProvid
             function () use ($container) {
                 return new GetOrganizerRequestHandler(
                     $container->get('organizer_service'),
-                    new RDFResponseFactory(
-                        $container->get('organizer_graph_store_repository'),
-                        RdfServiceProvider::createIriGenerator($this->container->get('config')['rdf']['organizersRdfBaseUri'])
+                    new TurtleResponseFactory(
+                        $container->get(OrganizerJsonToTurtleConverter::class)
                     )
                 );
             }

--- a/app/RDF/RdfServiceProvider.php
+++ b/app/RDF/RdfServiceProvider.php
@@ -18,7 +18,6 @@ use CultuurNet\UDB3\Event\ReadModel\RDF\RdfProjector as EventRdfProjector;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Organizer\OrganizerProjectedToJSONLD;
-use CultuurNet\UDB3\Organizer\ReadModel\RDF\RdfProjector as OrganizerRdfProjector;
 use CultuurNet\UDB3\Place\Events\PlaceProjectedToJSONLD;
 use CultuurNet\UDB3\Place\ReadModel\RDF\RdfProjector as PlaceRdfProjector;
 use EasyRdf\GraphStore;
@@ -58,7 +57,6 @@ final class RdfServiceProvider extends AbstractServiceProvider
                 if (($this->container->get('config')['rdf']['enabled'] ?? false) === true) {
                     $eventBus->subscribe($this->container->get(PlaceRdfProjector::class));
                     $eventBus->subscribe($this->container->get(EventRdfProjector::class));
-                    $eventBus->subscribe($this->container->get(OrganizerRdfProjector::class));
                 }
 
                 $deserializerLocator = new SimpleDeserializerLocator();

--- a/src/Http/Organizer/GetOrganizerRequestHandler.php
+++ b/src/Http/Organizer/GetOrganizerRequestHandler.php
@@ -7,10 +7,9 @@ namespace CultuurNet\UDB3\Http\Organizer;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\EntityServiceInterface;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
-use CultuurNet\UDB3\Http\RDF\RDFResponseFactory;
+use CultuurNet\UDB3\Http\RDF\TurtleResponseFactory;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\JsonLdResponse;
-use CultuurNet\UDB3\RDF\GraphNotFound;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -18,14 +17,14 @@ use Psr\Http\Server\RequestHandlerInterface;
 class GetOrganizerRequestHandler implements RequestHandlerInterface
 {
     private EntityServiceInterface $organizerService;
-    private RDFResponseFactory $rdfResponseFactory;
+    private TurtleResponseFactory $turtleResponseFactory;
 
     public function __construct(
         EntityServiceInterface $organizerService,
-        RDFResponseFactory $rdfResponseFactory
+        TurtleResponseFactory $turtleResponseFactory
     ) {
         $this->organizerService = $organizerService;
-        $this->rdfResponseFactory = $rdfResponseFactory;
+        $this->turtleResponseFactory = $turtleResponseFactory;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -35,11 +34,7 @@ class GetOrganizerRequestHandler implements RequestHandlerInterface
         $acceptHeader = $request->getHeaderLine('Accept');
 
         if ($acceptHeader === 'text/turtle') {
-            try {
-                return $this->rdfResponseFactory->turtle($organizerId);
-            } catch (GraphNotFound $exception) {
-                throw ApiProblem::organizerNotFound($organizerId);
-            }
+            return $this->turtleResponseFactory->turtle($organizerId);
         }
 
         try {

--- a/src/Http/RDF/JsonToTurtleConverter.php
+++ b/src/Http/RDF/JsonToTurtleConverter.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\RDF;
+
+interface JsonToTurtleConverter
+{
+    public function convert(string $id): string;
+}

--- a/src/Http/RDF/TurtleResponseFactory.php
+++ b/src/Http/RDF/TurtleResponseFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\RDF;
+
+final class TurtleResponseFactory
+{
+    private JsonToTurtleConverter $jsonToTurtleConverter;
+
+    public function __construct(JsonToTurtleConverter $jsonToTurtleConverter)
+    {
+        $this->jsonToTurtleConverter = $jsonToTurtleConverter;
+    }
+
+    public function turtle(string $id): TurtleResponse
+    {
+        $turtle = $this->jsonToTurtleConverter->convert($id);
+        return new TurtleResponse($turtle);
+    }
+}

--- a/src/Organizer/ReadModel/RDF/OrganizerJsonToTurtleConverter.php
+++ b/src/Organizer/ReadModel/RDF/OrganizerJsonToTurtleConverter.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\ReadModel\RDF;
+
+use CultuurNet\UDB3\Address\AddressParser;
+use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Http\RDF\JsonToTurtleConverter;
+use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Model\Organizer\ImmutableOrganizer;
+use CultuurNet\UDB3\Model\Organizer\Organizer;
+use CultuurNet\UDB3\Model\ValueObject\Moderation\Organizer\WorkflowStatus;
+use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\RDF\Editor\AddressEditor;
+use CultuurNet\UDB3\RDF\Editor\ContactPointEditor;
+use CultuurNet\UDB3\RDF\Editor\GeometryEditor;
+use CultuurNet\UDB3\RDF\Editor\GraphEditor;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use DateTime;
+use EasyRdf\Graph;
+use EasyRdf\Literal;
+use EasyRdf\Resource;
+use EasyRdf\Serialiser\Turtle;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class OrganizerJsonToTurtleConverter implements JsonToTurtleConverter
+{
+    private IriGeneratorInterface $iriGenerator;
+    private DocumentRepository $documentRepository;
+    private DenormalizerInterface $denormalizer;
+    private AddressParser $addressParser;
+    private LoggerInterface $logger;
+
+    private const TYPE_ORGANISATOR = 'cp:Organisator';
+
+    private const PROPERTY_REALISATOR_NAAM = 'cpr:naam';
+    private const PROPERTY_HOMEPAGE = 'foaf:homepage';
+    private const PROPERTY_LOCATIE_ADRES = 'locn:address';
+    private const PROPERTY_WORKFLOW_STATUS = 'udb:workflowStatus';
+
+    public function __construct(
+        IriGeneratorInterface $iriGenerator,
+        DocumentRepository $documentRepository,
+        DenormalizerInterface $denormalizer,
+        AddressParser $addressParser,
+        LoggerInterface $logger
+    ) {
+        $this->iriGenerator = $iriGenerator;
+        $this->documentRepository = $documentRepository;
+        $this->denormalizer = $denormalizer;
+        $this->addressParser = $addressParser;
+        $this->logger = $logger;
+    }
+
+    public function convert(string $id): string
+    {
+        $iri = $this->iriGenerator->iri($id);
+
+        $graph = new Graph($iri);
+        $resource = $graph->resource($iri);
+
+        $organizerData = $this->fetchOrganizerData($id);
+        try {
+            $organizer = $this->getOrganizer($organizerData);
+        } catch (\Throwable $throwable) {
+            $this->logger->warning(
+                'Unable to project organizer ' . $id . ' with invalid JSON to RDF.',
+                [
+                    'id' => $id,
+                    'type' => 'organizer',
+                    'exception' => $throwable,
+                ]
+            );
+
+            throw $throwable;
+        }
+
+        $modified = DateTimeFactory::fromISO8601($organizerData['modified'])->format(DateTime::ATOM);
+        GraphEditor::for($graph)->setGeneralProperties(
+            $iri,
+            self::TYPE_ORGANISATOR,
+            isset($organizerData['created']) ?
+                DateTimeFactory::fromISO8601($organizerData['created'])->format(DateTime::ATOM) : $modified,
+            $modified
+        );
+
+        $this->setWorkflowStatus($resource, $organizer->getWorkflowStatus());
+
+        $this->setName($resource, $organizer->getName());
+
+        if ($organizer->getUrl()) {
+            $this->setHomepage($resource, $organizer->getUrl());
+        }
+
+        if ($organizer->getAddress()) {
+            (new AddressEditor($this->addressParser))
+                ->setAddress($resource, self::PROPERTY_LOCATIE_ADRES, $organizer->getAddress());
+        }
+
+        if ($organizer->getGeoCoordinates()) {
+            (new GeometryEditor())
+                ->setCoordinates($resource, $organizer->getGeoCoordinates());
+        }
+
+        if (!$organizer->getContactPoint()->isEmpty()) {
+            (new ContactPointEditor())->setContactPoint($resource, $organizer->getContactPoint());
+        }
+
+        return trim((new Turtle())->serialise($graph, 'turtle'));
+    }
+
+    private function fetchOrganizerData(string $organizerId): array
+    {
+        $organizerDocument = $this->documentRepository->fetch($organizerId);
+        return $organizerDocument->getAssocBody();
+    }
+
+    private function getOrganizer(array $organizerData): Organizer
+    {
+        /** @var ImmutableOrganizer $organizer */
+        $organizer = $this->denormalizer->denormalize($organizerData, Organizer::class);
+        return $organizer;
+    }
+
+    private function setWorkflowStatus(Resource $resource, WorkflowStatus $workflowStatus): void
+    {
+        $statusTemplate = 'https://data.publiq.be/concepts/workflowStatus/%s';
+        $status = sprintf($statusTemplate, 'active');
+
+        if ($workflowStatus->sameAs(WorkflowStatus::DELETED())) {
+            $status = sprintf($statusTemplate, 'deleted');
+        }
+
+        $resource->set(self::PROPERTY_WORKFLOW_STATUS, new Resource($status));
+    }
+
+    private function setName(Resource $resource, TranslatedTitle $translatedTitle): void
+    {
+        foreach ($translatedTitle->getLanguages() as $language) {
+            $resource->addLiteral(
+                self::PROPERTY_REALISATOR_NAAM,
+                new Literal($translatedTitle->getTranslation($language)->toString(), $language->toString())
+            );
+        }
+    }
+
+    private function setHomepage(Resource $resource, Url $url): void
+    {
+        $resource->addLiteral(self::PROPERTY_HOMEPAGE, new Literal($url->toString()));
+    }
+}

--- a/tests/Organizer/ReadModel/RDF/OrganizerJsonToTurtleConverterTest.php
+++ b/tests/Organizer/ReadModel/RDF/OrganizerJsonToTurtleConverterTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\ReadModel\RDF;
+
+use CultuurNet\UDB3\Address\AddressParser;
+use CultuurNet\UDB3\Address\ParsedAddress;
+use CultuurNet\UDB3\Iri\CallableIriGenerator;
+use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class OrganizerJsonToTurtleConverterTest extends TestCase
+{
+    private DocumentRepository $documentRepository;
+
+    private OrganizerJsonToTurtleConverter $organizerJsonToTurtleConverter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->documentRepository = new InMemoryDocumentRepository();
+
+        $addressParser = $this->createMock(AddressParser::class);
+        $addressParser->expects($this->any())
+            ->method('parse')
+            ->willReturn(
+                new ParsedAddress(
+                    'Kerkstraat',
+                    '1',
+                    '3271',
+                    'Zichem (Scherpenheuvel-Zichem)'
+                )
+            );
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $this->organizerJsonToTurtleConverter = new OrganizerJsonToTurtleConverter(
+            new CallableIriGenerator(fn (string $item): string => 'https://mock.data.publiq.be/organizers/' . $item),
+            $this->documentRepository,
+            new OrganizerDenormalizer(),
+            $addressParser,
+            $logger
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_a_simple_organizer(): void
+    {
+        $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';
+
+        $organizer = [
+            '@id' => 'https://mock.io.uitdatabank.be/organizers/' . $organizerId,
+            'mainLanguage' => 'nl',
+            'url' => 'https://www.publiq.be',
+            'name' => [
+                'nl' => 'publiq VZW',
+                'en' => 'publiq NPO',
+            ],
+            'created' => '2023-01-01T12:30:15+01:00',
+            'modified' => '2023-01-01T12:30:15+01:00',
+        ];
+
+        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+
+        $turtle = $this->organizerJsonToTurtleConverter->convert($organizerId);
+
+        $this->assertEquals($turtle, file_get_contents(__DIR__ . '/ttl/organizer.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_a_simple_deleted_organizer(): void
+    {
+        $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';
+
+        $organizer = [
+            '@id' => 'https://mock.io.uitdatabank.be/organizers/' . $organizerId,
+            'mainLanguage' => 'nl',
+            'url' => 'https://www.publiq.be',
+            'name' => [
+                'nl' => 'publiq VZW',
+                'en' => 'publiq NPO',
+            ],
+            'created' => '2023-01-01T12:30:15+01:00',
+            'modified' => '2023-01-01T12:30:15+01:00',
+            'workflowStatus' => 'DELETED',
+        ];
+
+        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+
+        $turtle = $this->organizerJsonToTurtleConverter->convert($organizerId);
+
+        $this->assertEquals($turtle, file_get_contents(__DIR__ . '/ttl/organizer-deleted.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_a_simple_organizer_without_url(): void
+    {
+        $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';
+
+        $organizer = [
+            '@id' => 'https://mock.io.uitdatabank.be/organizers/' . $organizerId,
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'publiq VZW',
+                'en' => 'publiq NPO',
+            ],
+            'created' => '2023-01-01T12:30:15+01:00',
+            'modified' => '2023-01-01T12:30:15+01:00',
+        ];
+
+        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+
+        $turtle = $this->organizerJsonToTurtleConverter->convert($organizerId);
+
+        $this->assertEquals($turtle, file_get_contents(__DIR__ . '/ttl/organizer-without-homepage.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_a_simple_organizer_without_created(): void
+    {
+        $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';
+
+        $organizer = [
+            '@id' => 'https://mock.io.uitdatabank.be/organizers/' . $organizerId,
+            'mainLanguage' => 'nl',
+            'url' => 'https://www.publiq.be',
+            'name' => [
+                'nl' => 'publiq VZW',
+                'en' => 'publiq NPO',
+            ],
+            'modified' => '2023-01-01T12:30:15+01:00',
+        ];
+
+        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+
+        $turtle = $this->organizerJsonToTurtleConverter->convert($organizerId);
+
+        $this->assertEquals($turtle, file_get_contents(__DIR__ . '/ttl/organizer.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_an_organizer_with_address(): void
+    {
+        $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';
+
+        $organizer = [
+            '@id' => 'https://mock.io.uitdatabank.be/organizers/' . $organizerId,
+            'mainLanguage' => 'nl',
+            'url' => 'https://www.publiq.be',
+            'name' => [
+                'nl' => 'publiq VZW',
+                'en' => 'publiq NPO',
+            ],
+            'address' => [
+                'nl' => [
+                    'addressCountry' => 'BE',
+                    'addressLocality' => 'Zichem (Scherpenheuvel-Zichem)',
+                    'postalCode' => '3271',
+                    'streetAddress' => 'Kerkstraat 1',
+                ],
+            ],
+            'geo' => [
+                'latitude' => 50.9656077,
+                'longitude' => 4.9502035,
+            ],
+            'created' => '2023-01-01T12:30:15+01:00',
+            'modified' => '2023-01-01T12:30:15+01:00',
+        ];
+
+        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+
+        $turtle = $this->organizerJsonToTurtleConverter->convert($organizerId);
+
+        $this->assertEquals($turtle, file_get_contents(__DIR__ . '/ttl/organizer-with-address.ttl'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_an_organizer_with_contact_point(): void
+    {
+        $organizerId = '56f1efdb-fe25-44f6-b9d7-4a6a836799d7';
+
+        $organizer = [
+            '@id' => 'https://mock.io.uitdatabank.be/organizers/' . $organizerId,
+            'mainLanguage' => 'nl',
+            'url' => 'https://www.publiq.be',
+            'name' => [
+                'nl' => 'publiq VZW',
+                'en' => 'publiq NPO',
+            ],
+            'contactPoint' => [
+                'url' => [
+                    'https://www.publiq.be',
+                    'https://www.cultuurnet.be',
+                ],
+                'email' => [
+                    'info@publiq.be',
+                    'info@cultuurnet.be',
+                ],
+                'phone' => [
+                    '016 10 20 30',
+                    '016 10 20 40',
+                    '016 99 99 99',
+                ],
+            ],
+            'created' => '2023-01-01T12:30:15+01:00',
+            'modified' => '2023-01-01T12:30:15+01:00',
+        ];
+
+        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+
+        $turtle = $this->organizerJsonToTurtleConverter->convert($organizerId);
+
+        $this->assertEquals($turtle, file_get_contents(__DIR__ . '/ttl/organizer-with-contact-point.ttl'));
+    }
+
+    public function getRdfDataSetName(): string
+    {
+        return 'organizers';
+    }
+}


### PR DESCRIPTION
### Added
- Create `OrganizerJsonToTurtleConverter` to replace `RdfProjector`
- Create `TurtleResponseFactory`

### Changed
- Use `TurtleResponseFactory` inside `GetOrganizerRequestHandler`

### Removed
- Removed `OrganizerRdfProjector` as a subscriber

### Note
- Removing the old Fuseki and AMQP code will be done in the context of https://jira.publiq.be/browse/III-5909 and once a full reload has been done

---
Ticket: https://jira.uitdatabank.be/browse/III-5916
