### PR TITLE
III-5031 Replace assert object methods

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9054,20 +9054,20 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.25",
+            "version": "9.6.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
+                "reference": "810500e92855eba8a7a5319ae913be2da6f957b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/810500e92855eba8a7a5319ae913be2da6f957b0",
+                "reference": "810500e92855eba8a7a5319ae913be2da6f957b0",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1",
+                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -9096,8 +9096,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -9105,7 +9105,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -9136,7 +9136,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.11"
             },
             "funding": [
                 {
@@ -9152,7 +9153,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-25T03:44:45+00:00"
+            "time": "2023-08-19T07:10:56+00:00"
         },
         {
             "name": "publiq/php-cs-fixer-config",

--- a/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -551,7 +551,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_negative_base_price.cdbxml.xml');
 
-        $this->assertObjectNotHasAttribute('priceInfo', $jsonEvent);
+        $this->assertObjectNotHasProperty('priceInfo', $jsonEvent);
     }
 
     /**
@@ -561,7 +561,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_invalid_base_price.cdbxml.xml');
 
-        $this->assertObjectNotHasAttribute('priceInfo', $jsonEvent);
+        $this->assertObjectNotHasProperty('priceInfo', $jsonEvent);
     }
 
     /**

--- a/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -222,7 +222,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_non_cdb_externalid.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('sameAs', $jsonEvent);
+        $this->assertObjectHasProperty('sameAs', $jsonEvent);
         $this->assertContains('CC_De_Grote_Post:degrotepost_Evenement_453', $jsonEvent->sameAs);
     }
 
@@ -233,7 +233,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_cdb_externalid.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('sameAs', $jsonEvent);
+        $this->assertObjectHasProperty('sameAs', $jsonEvent);
         $this->assertNotContains('CDB:95b30501-6a70-4cb3-a5c9-4a2eb7003214', $jsonEvent->sameAs);
     }
 
@@ -254,7 +254,7 @@ class CdbXMLImporterTest extends TestCase
 
         $originalReference = 'http://www.uitinvlaanderen.be/agenda/e/' . $slug . '/' . $eventId;
 
-        $this->assertObjectHasAttribute('sameAs', $jsonEvent);
+        $this->assertObjectHasProperty('sameAs', $jsonEvent);
         $this->assertContains($originalReference, $jsonEvent->sameAs);
     }
 
@@ -265,18 +265,18 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_non_cdb_externalid.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('availableFrom', $jsonEvent);
+        $this->assertObjectHasProperty('availableFrom', $jsonEvent);
         $this->assertEquals('2014-07-25T05:18:22+02:00', $jsonEvent->availableFrom);
 
-        $this->assertObjectHasAttribute('availableTo', $jsonEvent);
+        $this->assertObjectHasProperty('availableTo', $jsonEvent);
         $this->assertEquals('2015-03-29T00:00:00+01:00', $jsonEvent->availableTo);
 
         $anotherJsonEvent = $this->createJsonEventFromCdbXml('event_with_cdb_externalid.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('availableFrom', $anotherJsonEvent);
+        $this->assertObjectHasProperty('availableFrom', $anotherJsonEvent);
         $this->assertEquals('2014-10-22T00:00:00+02:00', $anotherJsonEvent->availableFrom);
 
-        $this->assertObjectHasAttribute('availableTo', $anotherJsonEvent);
+        $this->assertObjectHasProperty('availableTo', $anotherJsonEvent);
         $this->assertEquals('2015-03-19T00:00:00+01:00', $anotherJsonEvent->availableTo);
     }
 
@@ -287,7 +287,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_email_and_phone_number.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('contactPoint', $jsonEvent);
+        $this->assertObjectHasProperty('contactPoint', $jsonEvent);
         $this->assertEquals(['0475 82 21 36'], $jsonEvent->contactPoint['phone']);
     }
 
@@ -298,7 +298,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_just_an_email.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('contactPoint', $jsonEvent);
+        $this->assertObjectHasProperty('contactPoint', $jsonEvent);
         $this->assertArrayNotHasKey('phone', $jsonEvent->contactPoint);
     }
 
@@ -309,7 +309,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_just_an_email.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('contactPoint', $jsonEvent);
+        $this->assertObjectHasProperty('contactPoint', $jsonEvent);
         $this->assertEquals(
             ['kgielens@stichtingtegenkanker.be'],
             $jsonEvent->contactPoint['email']
@@ -323,7 +323,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_just_a_phone_number.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('contactPoint', $jsonEvent);
+        $this->assertObjectHasProperty('contactPoint', $jsonEvent);
         $this->assertArrayNotHasKey('mail', $jsonEvent->contactPoint);
     }
 
@@ -334,7 +334,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_email_and_phone_number.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('seeAlso', $jsonEvent);
+        $this->assertObjectHasProperty('seeAlso', $jsonEvent);
         $this->assertContains('http://www.rekanto.be', $jsonEvent->seeAlso);
     }
 
@@ -345,11 +345,11 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_reservation_url.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('bookingInfo', $jsonEvent);
+        $this->assertObjectHasProperty('bookingInfo', $jsonEvent);
         $this->assertEquals('http://brugge.iticketsro.com/ccmechelen/', $jsonEvent->bookingInfo['url']);
 
         // Reservation url should not have been added to seeAlso.
-        $this->assertObjectHasAttribute('seeAlso', $jsonEvent);
+        $this->assertObjectHasProperty('seeAlso', $jsonEvent);
         $this->assertNotContains('http://brugge.iticketsro.com/ccmechelen/', $jsonEvent->seeAlso);
     }
 
@@ -360,7 +360,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_email_and_phone_number.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('bookingInfo', $jsonEvent);
+        $this->assertObjectHasProperty('bookingInfo', $jsonEvent);
         $this->assertArrayNotHasKey('url', $jsonEvent->bookingInfo);
     }
 
@@ -376,7 +376,7 @@ class CdbXMLImporterTest extends TestCase
             'url' => ['http://www.rekanto.be'],
         ];
 
-        $this->assertObjectHasAttribute('contactPoint', $jsonEvent);
+        $this->assertObjectHasProperty('contactPoint', $jsonEvent);
         $this->assertEquals($expectedContactPoint, $jsonEvent->contactPoint);
     }
 
@@ -387,7 +387,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_negative_timestamp.cdbxml.xml');
 
-        $this->assertObjectHasAttribute('bookingInfo', $jsonEvent);
+        $this->assertObjectHasProperty('bookingInfo', $jsonEvent);
         $this->assertEquals('1968-12-31T23:00:00+00:00', $jsonEvent->bookingInfo['availabilityStarts']);
         $this->assertEquals('1968-12-31T23:00:00+00:00', $jsonEvent->bookingInfo['availabilityEnds']);
     }
@@ -1062,7 +1062,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXmlWithAgeRange(null, null);
 
-        $this->assertObjectHasAttribute('typicalAgeRange', $jsonEvent, '-');
+        $this->assertObjectHasProperty('typicalAgeRange', $jsonEvent, '-');
     }
 
     /**

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -811,7 +811,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $body = $this->project($event, $event->getEventId());
 
-        $this->assertObjectNotHasAttribute('image', $body);
+        $this->assertObjectNotHasProperty('image', $body);
     }
 
     /**
@@ -889,7 +889,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $body = $this->project($event, $event->getEventId());
 
-        $this->assertObjectNotHasAttribute('bookingInfo', $body);
+        $this->assertObjectNotHasProperty('bookingInfo', $body);
     }
 
     /**

--- a/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
+++ b/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -102,8 +103,14 @@ class EventJsonToTurtleConverterTest extends TestCase
             ->method('warning')
             ->with('Unable to project event d4b46fba-6433-4f86-bcb5-edeef6689fea with invalid JSON to RDF.');
 
-        $this->expectError();
-        $this->expectErrorMessage('Undefined index: name');
+        set_error_handler(
+            static function ($errorNumber, $errorString) {
+                restore_error_handler();
+                throw new Exception($errorString, $errorNumber);
+            },
+            E_ALL
+        );
+        $this->expectExceptionMessage('Undefined index: name');
 
         $this->eventJsonToTurtleConverter->convert($eventId);
     }

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -1002,7 +1002,7 @@ class OfferLDProjectorTest extends TestCase
         $imageRemovedEvent = new ImageRemoved($eventId, $image);
         $eventBody = $this->project($imageRemovedEvent, $eventId);
 
-        $this->assertObjectNotHasAttribute('mediaObject', $eventBody);
+        $this->assertObjectNotHasProperty('mediaObject', $eventBody);
     }
 
     /**
@@ -1041,8 +1041,8 @@ class OfferLDProjectorTest extends TestCase
         $imageRemovedEvent = new ImageRemoved($eventId, $image);
         $eventBody = $this->project($imageRemovedEvent, $eventId);
 
-        $this->assertObjectNotHasAttribute('mediaObject', $eventBody);
-        $this->assertObjectNotHasAttribute('image', $eventBody);
+        $this->assertObjectNotHasProperty('mediaObject', $eventBody);
+        $this->assertObjectNotHasProperty('image', $eventBody);
     }
 
     /**
@@ -1132,7 +1132,7 @@ class OfferLDProjectorTest extends TestCase
         $imageRemovedEvent = new ImageRemoved($eventId, $image);
         $eventBody = $this->project($imageRemovedEvent, $eventId);
 
-        $this->assertObjectNotHasAttribute('image', $eventBody);
+        $this->assertObjectNotHasProperty('image', $eventBody);
     }
 
     /**

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -497,7 +497,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
 
         $body = $this->project($event, $event->getActorId());
 
-        $this->assertObjectNotHasAttribute('image', $body);
+        $this->assertObjectNotHasProperty('image', $body);
     }
 
 

--- a/tests/Place/ReadModel/RDF/PlaceJsonToTurtleConverterTest.php
+++ b/tests/Place/ReadModel/RDF/PlaceJsonToTurtleConverterTest.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -115,8 +116,14 @@ class PlaceJsonToTurtleConverterTest extends TestCase
             ->method('warning')
             ->with('Unable to project place d4b46fba-6433-4f86-bcb5-edeef6689fea with invalid JSON to RDF.');
 
-        $this->expectError();
-        $this->expectErrorMessage('Undefined index: name');
+        set_error_handler(
+            static function ($errorNumber, $errorString) {
+                restore_error_handler();
+                throw new Exception($errorString, $errorNumber);
+            },
+            E_ALL
+        );
+        $this->expectExceptionMessage('Undefined index: name');
 
         $this->placeJsonToTurtleConverter->convert($placeId);
     }


### PR DESCRIPTION
### Changed
- Replaced the PHPUnit assert object methods
- Replaced `exceptError` with `set_error_handler`
- Upgraded PHPUnit to 9.6.11

### Note
- These changes are done as preparation for the switch to PHP 8.x

---
Ticket: https://jira.uitdatabank.be/browse/III-5031
