### PR TITLE
III-5031 Use `AbstractMigration` from `Doctrine\Migrations` namespace

### DIFF
--- a/app/Migrations/Version19700101000000.php
+++ b/app/Migrations/Version19700101000000.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Creates the event store.
- */
 class Version19700101000000 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version19700101000001.php
+++ b/app/Migrations/Version19700101000001.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Creates the organizer store.
- */
 class Version19700101000001 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version19700101000002.php
+++ b/app/Migrations/Version19700101000002.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Creates the places store.
- */
 class Version19700101000002 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version19700101000003.php
+++ b/app/Migrations/Version19700101000003.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Creates the event_relations table.
- */
 class Version19700101000003 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20150403111222.php
+++ b/app/Migrations/Version20150403111222.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Increases the length of columns in the event_relations table.
- */
 class Version20150403111222 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20150612151318.php
+++ b/app/Migrations/Version20150612151318.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Creates the event store for variations.
- */
 class Version20150612151318 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20150615114627.php
+++ b/app/Migrations/Version20150615114627.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Creates the search index table for variations.
- */
 class Version20150615114627 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20150817113039.php
+++ b/app/Migrations/Version20150817113039.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Creates the multi-purpose index read model.
- */
 class Version20150817113039 extends AbstractMigration
 {
     /**

--- a/app/Migrations/Version20151029184516.php
+++ b/app/Migrations/Version20151029184516.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20151029184516 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20151214154130.php
+++ b/app/Migrations/Version20151214154130.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20151214154130 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20160125121509.php
+++ b/app/Migrations/Version20160125121509.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160125121509 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20160224144108.php
+++ b/app/Migrations/Version20160224144108.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160224144108 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20160224221541.php
+++ b/app/Migrations/Version20160224221541.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160224221541 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20160322095452.php
+++ b/app/Migrations/Version20160322095452.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Add a created column to the index read-model.
- */
 class Version20160322095452 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20160506142905.php
+++ b/app/Migrations/Version20160506142905.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160506142905 extends AbstractMigration
 {
     public const PLACE_RELATIONS = 'place_relations';

--- a/app/Migrations/Version20160607132920.php
+++ b/app/Migrations/Version20160607132920.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160607132920 extends AbstractMigration
 {
     public const LABELS_TABLE = 'labels';

--- a/app/Migrations/Version20160607134416.php
+++ b/app/Migrations/Version20160607134416.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160607134416 extends AbstractMigration
 {
     public const LABELS_JSON_TABLE = 'labels_json';

--- a/app/Migrations/Version20160621151445.php
+++ b/app/Migrations/Version20160621151445.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160621151445 extends AbstractMigration
 {
     public const ROLES = 'roles';

--- a/app/Migrations/Version20160718210058.php
+++ b/app/Migrations/Version20160718210058.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160718210058 extends AbstractMigration
 {
     public const ROLES_SEARCH = 'roles_search';

--- a/app/Migrations/Version20160728102259.php
+++ b/app/Migrations/Version20160728102259.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160728102259 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20160808143623.php
+++ b/app/Migrations/Version20160808143623.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Migrations;
 
 use CultuurNet\UDB3\Role\UserPermissionsServiceProvider;
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20160808143623 extends AbstractMigration
 {

--- a/app/Migrations/Version20160817112023.php
+++ b/app/Migrations/Version20160817112023.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Migrations;
 
 use CultuurNet\UDB3\Labels\LabelServiceProvider;
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160817112023 extends AbstractMigration
 {
     public const LABEL_ID_COLUMN = 'label_id';

--- a/app/Migrations/Version20160830161312.php
+++ b/app/Migrations/Version20160830161312.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Migrations;
 
 use CultuurNet\UDB3\Role\ReadModel\Search\Doctrine\SchemaConfigurator;
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160830161312 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20160930161518.php
+++ b/app/Migrations/Version20160930161518.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20160930161518 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20161117141025.php
+++ b/app/Migrations/Version20161117141025.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20161117141025 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20161220092125.php
+++ b/app/Migrations/Version20161220092125.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\Migrations\AbstractMigration;
 
 final class Version20161220092125 extends AbstractMigration
 {

--- a/app/Migrations/Version20170109103905.php
+++ b/app/Migrations/Version20170109103905.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Creates a new event store table for all aggregates.
- */
 class Version20170109103905 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20170413075617.php
+++ b/app/Migrations/Version20170413075617.php
@@ -5,14 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Migrations;
 
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\Doctrine\SchemaConfigurator;
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20170413075617 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20170731151814.php
+++ b/app/Migrations/Version20170731151814.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20170731151814 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20180108080352.php
+++ b/app/Migrations/Version20180108080352.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20180108080352 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20180711095920.php
+++ b/app/Migrations/Version20180711095920.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20180711095920 extends AbstractMigration
 {

--- a/app/Migrations/Version20180802121423.php
+++ b/app/Migrations/Version20180802121423.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20180802121423 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20180823080123.php
+++ b/app/Migrations/Version20180823080123.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20180823080123 extends AbstractMigration
 {

--- a/app/Migrations/Version20180914083853.php
+++ b/app/Migrations/Version20180914083853.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20180914083853 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20181023121440.php
+++ b/app/Migrations/Version20181023121440.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Migrations;
 
 use CultuurNet\UDB3\SavedSearches\Doctrine\SchemaConfigurator;
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20181023121440 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20181106123049.php
+++ b/app/Migrations/Version20181106123049.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Migrations;
 
 use CultuurNet\UDB3\Role\ReadModel\Search\Doctrine\SchemaConfigurator;
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Add roles_search_v3 table.
- */
 class Version20181106123049 extends AbstractMigration
 {
     private const ROLES_SEARCH_V3 = 'roles_search_v3';

--- a/app/Migrations/Version20181107142155.php
+++ b/app/Migrations/Version20181107142155.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Migrations;
 
 use CultuurNet\UDB3\SavedSearches\Doctrine\SchemaConfigurator;
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Add the table for SAPI3 saved searches.
- */
 class Version20181107142155 extends AbstractMigration
 {
     private const SAVED_SEARCHES_SAPI3 = 'saved_searches_sapi3';

--- a/app/Migrations/Version20181217144324.php
+++ b/app/Migrations/Version20181217144324.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 final class Version20181217144324 extends AbstractMigration
 {

--- a/app/Migrations/Version20190509112328.php
+++ b/app/Migrations/Version20190509112328.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20190509112328 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20190606172743.php
+++ b/app/Migrations/Version20190606172743.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20190606172743 extends AbstractMigration
 {
     public function up(Schema $schema): void

--- a/app/Migrations/Version20200122131812.php
+++ b/app/Migrations/Version20200122131812.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20200122131812 extends AbstractMigration
 {
     /**

--- a/app/Migrations/Version20200526130622.php
+++ b/app/Migrations/Version20200526130622.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 class Version20200526130622 extends AbstractMigration
 {
     /**

--- a/app/Migrations/Version20200602134547.php
+++ b/app/Migrations/Version20200602134547.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20200602134547 extends AbstractMigration
 {

--- a/app/Migrations/Version20200804090405.php
+++ b/app/Migrations/Version20200804090405.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20200804090405 extends AbstractMigration
 {

--- a/app/Migrations/Version20200909121744.php
+++ b/app/Migrations/Version20200909121744.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20200909121744 extends AbstractMigration
 {

--- a/app/Migrations/Version20200909165220.php
+++ b/app/Migrations/Version20200909165220.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20200909165220 extends AbstractMigration
 {

--- a/app/Migrations/Version20200910055353.php
+++ b/app/Migrations/Version20200910055353.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20200910055353 extends AbstractMigration
 {

--- a/app/Migrations/Version20201015095142.php
+++ b/app/Migrations/Version20201015095142.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20201015095142 extends AbstractMigration
 {

--- a/app/Migrations/Version20201015123012.php
+++ b/app/Migrations/Version20201015123012.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20201015123012 extends AbstractMigration
 {

--- a/app/Migrations/Version20201019121035.php
+++ b/app/Migrations/Version20201019121035.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20201019121035 extends AbstractMigration
 {

--- a/app/Migrations/Version20201022154706.php
+++ b/app/Migrations/Version20201022154706.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20201022154706 extends AbstractMigration
 {

--- a/app/Migrations/Version20210222150300.php
+++ b/app/Migrations/Version20210222150300.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20210222150300 extends AbstractMigration
 {

--- a/app/Migrations/Version20220308071939.php
+++ b/app/Migrations/Version20220308071939.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 class Version20220308071939 extends AbstractMigration
 {


### PR DESCRIPTION
### Changed
- Used `AbstractMigration` from `Doctrine\Migrations` namespace

---
Ticket: https://jira.uitdatabank.be/browse/III-5031