### PR TITLE
III-5031 Use new fetch methods

### DIFF
--- a/app/Console/Command/ExcludeInvalidLabels.php
+++ b/app/Console/Command/ExcludeInvalidLabels.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Label\Commands\ExcludeLabel as ExcludeLabelCommand;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use Doctrine\DBAL\Connection;
-use PDO;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -77,7 +76,7 @@ final class ExcludeInvalidLabels extends AbstractCommand
                 ->where('excluded = :excluded')
                 ->setParameter(':excluded', 0)
                 ->execute()
-                ->fetchAll()
+                ->fetchAllAssociative()
         );
     }
 
@@ -91,6 +90,6 @@ final class ExcludeInvalidLabels extends AbstractCommand
             ->setFirstResult($firstResult)
             ->setMaxResults(self::MAX_RESULTS)
             ->execute()
-            ->fetchAll(PDO::FETCH_ASSOC);
+            ->fetchAllAssociative();
     }
 }

--- a/app/Console/Command/FindOutOfSyncProjections.php
+++ b/app/Console/Command/FindOutOfSyncProjections.php
@@ -79,7 +79,7 @@ final class FindOutOfSyncProjections extends Command
             ->setParameter(':last_id', $input->getArgument('last-id'))
             ->groupBy('uuid')
             ->execute()
-            ->fetchAll();
+            ->fetchAllAssociative();
 
         foreach ($results as $result) {
             $uuid = $result['uuid'];

--- a/app/Console/Command/FireProjectedToJSONLDForRelationsCommand.php
+++ b/app/Console/Command/FireProjectedToJSONLDForRelationsCommand.php
@@ -8,7 +8,6 @@ use Broadway\EventHandling\EventBus;
 use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
 use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
 use Doctrine\DBAL\Connection;
-use PDO;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -50,14 +49,14 @@ class FireProjectedToJSONLDForRelationsCommand extends AbstractFireProjectedToJS
                     ->from('event_relations')
                     ->where('organizer IS NOT NULL')
                     ->execute()
-                    ->fetchAll(PDO::FETCH_COLUMN);
+                    ->fetchFirstColumn();
 
                 $queryBuilder = $connection->createQueryBuilder();
                 $placeOrganizers = $queryBuilder->select('DISTINCT organizer')
                     ->from('place_relations')
                     ->where('organizer IS NOT NULL')
                     ->execute()
-                    ->fetchAll(PDO::FETCH_COLUMN);
+                    ->fetchFirstColumn();
 
                 $allOrganizers = array_merge($eventOrganizers, $placeOrganizers);
                 $allOrganizers = array_unique($allOrganizers);
@@ -81,7 +80,7 @@ class FireProjectedToJSONLDForRelationsCommand extends AbstractFireProjectedToJS
                     ->from('event_relations')
                     ->where('place IS NOT NULL')
                     ->execute()
-                    ->fetchAll(PDO::FETCH_COLUMN);
+                    ->fetchFirstColumn();
 
                 $this->fireEvents(
                     $eventLocations,

--- a/app/Console/Command/ProcessDuplicatePlaces.php
+++ b/app/Console/Command/ProcessDuplicatePlaces.php
@@ -16,7 +16,6 @@ use CultuurNet\UDB3\Place\Canonical\DuplicatePlaceRepository;
 use CultuurNet\UDB3\Place\Canonical\Exception\MuseumPassNotUniqueInCluster;
 use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
 use Doctrine\DBAL\Connection;
-use PDO;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -169,6 +168,6 @@ final class ProcessDuplicatePlaces extends AbstractCommand
             ->select('place_uuid')
             ->from('duplicate_places_removed_from_cluster')
             ->execute()
-            ->fetchAll(PDO::FETCH_COLUMN);
+            ->fetchFirstColumn();
     }
 }

--- a/app/Console/Command/ReindexEventsWithRecommendations.php
+++ b/app/Console/Command/ReindexEventsWithRecommendations.php
@@ -9,7 +9,6 @@ use Broadway\EventHandling\EventBus;
 use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
 use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -77,7 +76,7 @@ final class ReindexEventsWithRecommendations extends Command
             ->select('DISTINCT recommended_event_id')
             ->from('event_recommendations')
             ->execute()
-            ->fetchAll(FetchMode::COLUMN);
+            ->fetchFirstColumn();
     }
 
     private function askConfirmation(InputInterface $input, OutputInterface $output, int $count): bool

--- a/app/Console/Command/ReindexOffersWithPopularityScore.php
+++ b/app/Console/Command/ReindexOffersWithPopularityScore.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
 use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -98,7 +97,7 @@ class ReindexOffersWithPopularityScore extends Command
             ->where('offer_type = :type')
             ->setParameter(':type', $type)
             ->execute()
-            ->fetchAll(FetchMode::COLUMN);
+            ->fetchFirstColumn();
     }
 
     private function askConfirmation(InputInterface $input, OutputInterface $output, string $type, int $count): bool

--- a/app/Console/Command/ReplaceNewsArticlePublisher.php
+++ b/app/Console/Command/ReplaceNewsArticlePublisher.php
@@ -83,7 +83,7 @@ final class ReplaceNewsArticlePublisher extends Command
                 ->where('publisher = :publisher')
                 ->setParameter(':publisher', $publisher)
                 ->execute()
-                ->fetchAll()
+                ->fetchAllAssociative()
         );
     }
 

--- a/app/Console/Command/UpdateUniqueLabels.php
+++ b/app/Console/Command/UpdateUniqueLabels.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use PDO;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Console\Command\Command;
@@ -101,7 +100,7 @@ final class UpdateUniqueLabels extends Command
             ->setFirstResult($offset)
             ->setMaxResults(self::MAX_RESULTS)
             ->execute()
-            ->fetchAll(PDO::FETCH_ASSOC);
+            ->fetchAllAssociative();
     }
 
     private function getAllLabelAddedEventsCount(): int
@@ -113,7 +112,7 @@ final class UpdateUniqueLabels extends Command
                 ->where('type = "' . self::LABEL_CREATED . '"')
                 ->orderBy('id')
                 ->execute()
-                ->fetchAll()
+                ->fetchAllAssociative()
         );
     }
 

--- a/app/Console/Command/UpdateUniqueOrganizers.php
+++ b/app/Console/Command/UpdateUniqueOrganizers.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Organizer\WebsiteNormalizer;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use PDO;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -147,7 +146,7 @@ class UpdateUniqueOrganizers extends Command
             ->where('uuid_col = :uuid')
             ->setParameter('uuid', $organizerUuid)
             ->execute()
-            ->fetchAll(PDO::FETCH_COLUMN);
+            ->fetchFirstColumn();
 
         $existingOrganizerUrl = count($existingOrganizerUrls) === 1 ? $existingOrganizerUrls[0] : null;
 

--- a/app/Console/Command/UpdateUniqueOrganizers.php
+++ b/app/Console/Command/UpdateUniqueOrganizers.php
@@ -114,7 +114,7 @@ class UpdateUniqueOrganizers extends Command
             ->setFirstResult($offset)
             ->setMaxResults(self::MAX_RESULTS)
             ->execute()
-            ->fetchAll(PDO::FETCH_ASSOC);
+            ->fetchAllAssociative();
     }
 
     private function getAllOrganizerEventsCount(): int
@@ -127,7 +127,7 @@ class UpdateUniqueOrganizers extends Command
                 ->orWhere('type = "' . self::ORGANIZER_WEBSITE_UPDATED . '"')
                 ->orderBy('id')
                 ->execute()
-                ->fetchAll()
+                ->fetchAllAssociative()
         );
     }
 

--- a/src/Contributor/DbalContributorRepository.php
+++ b/src/Contributor/DbalContributorRepository.php
@@ -51,7 +51,7 @@ final class DbalContributorRepository implements ContributorRepository
             ->setParameter(':id', $id->toString())
             ->setParameter(':email', $emailAddress->toString())
             ->execute()
-            ->fetchAll();
+            ->fetchAllAssociative();
 
         return count($results) > 0;
     }

--- a/src/Contributor/DbalContributorRepository.php
+++ b/src/Contributor/DbalContributorRepository.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 
 final class DbalContributorRepository implements ContributorRepository
 {
@@ -31,7 +30,7 @@ final class DbalContributorRepository implements ContributorRepository
             ->where('uuid = :id')
             ->setParameter(':id', $id->toString())
             ->execute()
-            ->fetchAll(FetchMode::COLUMN);
+            ->fetchFirstColumn();
 
         return EmailAddresses::fromArray(
             array_map(

--- a/src/Curators/DBALNewsArticleRepository.php
+++ b/src/Curators/DBALNewsArticleRepository.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 
 final class DBALNewsArticleRepository implements NewsArticleRepository
 {
@@ -30,7 +29,7 @@ final class DBALNewsArticleRepository implements NewsArticleRepository
             ->where('id = :id')
             ->setParameter(':id', $id->toString())
             ->execute()
-            ->fetchAll(FetchMode::ASSOCIATIVE);
+            ->fetchAllAssociative();
 
         if (count($newsArticleRows) !== 1) {
             throw new NewsArticleNotFound($id);
@@ -74,7 +73,7 @@ final class DBALNewsArticleRepository implements NewsArticleRepository
         $newsArticleRows = $query
             ->setMaxResults($newsArticleSearch->getItemsPerPage())
             ->execute()
-            ->fetchAll(FetchMode::ASSOCIATIVE);
+            ->fetchAllAssociative();
 
         return $this->createNewsArticles($newsArticleRows);
     }

--- a/src/Event/Productions/DBALProductionRepository.php
+++ b/src/Event/Productions/DBALProductionRepository.php
@@ -125,7 +125,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
             $query->setParameter(':keyword', $keyword);
         }
 
-        $results = $query->execute()->fetchAll();
+        $results = $query->execute()->fetchAllAssociative();
 
         if (empty($results)) {
             return [];
@@ -154,7 +154,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
     public function count(string $keyword): int
     {
         $keyword = $this->addWildcardToKeyword($keyword);
-        return count($this->createSearchQuery($keyword)->execute()->fetchAll());
+        return count($this->createSearchQuery($keyword)->execute()->fetchAllAssociative());
     }
 
     private function createSearchQuery(string $keyword): QueryBuilder

--- a/src/Event/Productions/DBALProductionRepository.php
+++ b/src/Event/Productions/DBALProductionRepository.php
@@ -28,7 +28,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
 
     public function find(ProductionId $productionId): Production
     {
-        $results = $this->getConnection()->fetchAll(
+        $results = $this->getConnection()->fetchAllAssociative(
             'SELECT * FROM productions WHERE production_id = :productionId',
             [
                 'productionId' => $productionId->toNative(),
@@ -187,7 +187,7 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
 
     public function findProductionForEventId(string $eventId): Production
     {
-        $results = $this->getConnection()->fetchAll(
+        $results = $this->getConnection()->fetchAllAssociative(
             'SELECT * FROM productions WHERE production_id = (SELECT production_id FROM productions WHERE event_id = :eventId)',
             [
                 'eventId' => $eventId,

--- a/src/Event/ReadModel/Relations/Doctrine/DBALEventRelationsRepository.php
+++ b/src/Event/ReadModel/Relations/Doctrine/DBALEventRelationsRepository.php
@@ -194,7 +194,7 @@ final class DBALEventRelationsRepository implements EventRelationsRepository
 
         $statement = $queryBuilder->execute();
 
-        $rows = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $statement->fetchAllAssociative();
 
         return isset($rows[0][$eventType]) ? $rows[0][$eventType] : null;
     }

--- a/src/Event/ReadModel/Relations/Doctrine/DBALEventRelationsRepository.php
+++ b/src/Event/ReadModel/Relations/Doctrine/DBALEventRelationsRepository.php
@@ -117,7 +117,7 @@ final class DBALEventRelationsRepository implements EventRelationsRepository
             ->setParameter('event_id', $id);
 
         $result = $q->execute();
-        $relations = $result->fetchAll();
+        $relations = $result->fetchAllAssociative();
 
         return count($relations) > 0;
     }

--- a/src/Event/Recommendations/DBALRecommendationsRepository.php
+++ b/src/Event/Recommendations/DBALRecommendationsRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Event\Recommendations;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 
 final class DBALRecommendationsRepository implements RecommendationsRepository
 {
@@ -26,7 +25,7 @@ final class DBALRecommendationsRepository implements RecommendationsRepository
             ->where('event_id = :event_id')
             ->setParameter(':event_id', $eventId)
             ->execute()
-            ->fetchAll(FetchMode::NUMERIC);
+            ->fetchAllNumeric();
 
         return $this->createRecommendations($recommendationRows);
     }
@@ -41,7 +40,7 @@ final class DBALRecommendationsRepository implements RecommendationsRepository
             ->where('recommended_event_id = :recommended_event_id')
             ->setParameter(':recommended_event_id', $recommendedEventId)
             ->execute()
-            ->fetchAll(FetchMode::NUMERIC);
+            ->fetchAllNumeric();
 
         return $this->createRecommendations($recommendationRows);
     }

--- a/src/EventSourcing/DBAL/UniqueDBALEventStoreDecorator.php
+++ b/src/EventSourcing/DBAL/UniqueDBALEventStoreDecorator.php
@@ -159,7 +159,7 @@ class UniqueDBALEventStoreDecorator extends AbstractEventStoreDecorator
             ->where($likeUniqueValue)
             ->setParameter('uniqueValue', $uniqueValue)
             ->execute()
-            ->fetchAll();
+            ->fetchAllAssociative();
 
         if (!empty($rows)) {
             throw new UniqueConstraintException(

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -237,7 +237,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
         $entities = [];
 
         $statement = $queryBuilder->execute();
-        $rows = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $statement->fetchAllAssociative();
         foreach ($rows as $row) {
             $entities[] = $this->rowToEntity($row);
         }

--- a/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
@@ -38,7 +38,8 @@ class DBALReadRepository extends AbstractDBALRepository implements ReadRepositor
             ->where($whereLabelName)
             ->andWhere(SchemaConfigurator::RELATION_TYPE . ' = ?')
             ->setParameters([$labelName, $relationType->toString()])
-        ->execute()->fetchAll(\PDO::FETCH_COLUMN);
+            ->execute()
+            ->fetchFirstColumn();
     }
 
     public function getLabelRelationsForItem(string $relationId): array

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Place\Canonical;
 
 use Doctrine\DBAL\Connection;
-use PDO;
 
 class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
 {
@@ -23,7 +22,7 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
             ->from('duplicate_places')
             ->orderBy('cluster_id')
             ->execute()
-            ->fetchAll(PDO::FETCH_COLUMN);
+            ->fetchFirstColumn();
 
         return array_map('intval', $result);
     }
@@ -36,7 +35,7 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
             ->where('cluster_id = :cluster_id')
             ->setParameter(':cluster_id', $clusterId)
             ->execute()
-            ->fetchAll(PDO::FETCH_COLUMN);
+            ->fetchFirstColumn();
     }
 
     public function setCanonicalOnCluster(int $clusterId, string $canonical): void
@@ -62,7 +61,7 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
             ->where('place_uuid = :place_uuid')
             ->setParameter(':place_uuid', $placeId)
             ->execute()
-            ->fetchAll(PDO::FETCH_COLUMN);
+            ->fetchFirstColumn();
 
         return count($rows) === 1 ? $rows[0] : null;
     }
@@ -75,7 +74,7 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
             ->where('canonical = :canonical')
             ->setParameter(':canonical', $placeId)
             ->execute()
-            ->fetchAll(PDO::FETCH_COLUMN);
+            ->fetchFirstColumn();
 
         return count($duplicates) > 0 ? $duplicates : null;
     }

--- a/src/Role/ReadModel/Constraints/Doctrine/UserConstraintsReadRepository.php
+++ b/src/Role/ReadModel/Constraints/Doctrine/UserConstraintsReadRepository.php
@@ -67,6 +67,6 @@ class UserConstraintsReadRepository implements UserConstraintsReadRepositoryInte
             ->setParameter('userId', $userId)
             ->setParameter('permission', $permission->toString());
 
-        return $userConstraintsQuery->execute()->fetchAll(\PDO::FETCH_COLUMN);
+        return $userConstraintsQuery->execute()->fetchFirstColumn();
     }
 }

--- a/src/Role/ReadModel/Permissions/Doctrine/UserPermissionsReadRepository.php
+++ b/src/Role/ReadModel/Permissions/Doctrine/UserPermissionsReadRepository.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use Doctrine\DBAL\Connection;
-use PDO;
 
 class UserPermissionsReadRepository implements UserPermissionsReadRepositoryInterface
 {
@@ -48,7 +47,7 @@ class UserPermissionsReadRepository implements UserPermissionsReadRepositoryInte
             )
             ->setParameter('userId', $userId);
 
-        $results = $userPermissionQuery->execute()->fetchAll(PDO::FETCH_COLUMN);
+        $results = $userPermissionQuery->execute()->fetchFirstColumn();
 
         return array_map(
             fn (string $permission) => new Permission($permission),
@@ -76,7 +75,7 @@ class UserPermissionsReadRepository implements UserPermissionsReadRepositoryInte
             ->setParameter('userId', $userId)
             ->setParameter('permission', $permission->toString());
 
-        $results = $userPermissionQuery->execute()->fetchAll(PDO::FETCH_COLUMN);
+        $results = $userPermissionQuery->execute()->fetchFirstColumn();
         return count($results) > 0;
     }
 }

--- a/src/Role/ReadModel/Search/Doctrine/DBALRepository.php
+++ b/src/Role/ReadModel/Search/Doctrine/DBALRepository.php
@@ -68,7 +68,7 @@ class DBALRepository implements RepositoryInterface
             $q->setParameter('role_name', '%' . $query . '%');
         }
 
-        $results = $q->execute()->fetchAll(\PDO::FETCH_ASSOC);
+        $results = $q->execute()->fetchAllAssociative();
 
         //Total.
         $q = $this->connection->createQueryBuilder();

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -88,6 +88,6 @@ final class DBALResourceOwnerRepository implements ResourceOwnerRepository, Reso
             ->where($this->idField . ' = :resource_id')
             ->setParameter(':resource_id', $resourceId)
             ->execute()
-            ->fetchAll());
+            ->fetchAllAssociative());
     }
 }

--- a/tests/Contributor/DbalContributorRepositoryTest.php
+++ b/tests/Contributor/DbalContributorRepositoryTest.php
@@ -157,7 +157,7 @@ final class DbalContributorRepositoryTest extends TestCase
             ->andWhere('type = :type')
             ->setParameter(':type', $itemType->toString())
             ->execute()
-            ->fetchAll();
+            ->fetchAllAssociative();
 
         $this->assertEquals(2, count($result));
     }

--- a/tests/Event/ReadModel/Relations/Doctrine/DBALRepositoryTest.php
+++ b/tests/Event/ReadModel/Relations/Doctrine/DBALRepositoryTest.php
@@ -5,22 +5,15 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Event\ReadModel\Relations\Doctrine;
 
 use CultuurNet\UDB3\DBALTestConnectionTrait;
-use PDO;
 use PHPUnit\Framework\TestCase;
 
 class DBALRepositoryTest extends TestCase
 {
     use DBALTestConnectionTrait;
 
-    /**
-     * @var DBALEventRelationsRepository
-     */
-    private $repository;
+    private DBALEventRelationsRepository $repository;
 
-    /**
-     * @var string
-     */
-    private $tableName;
+    private string $tableName;
 
     public function setUp(): void
     {
@@ -38,17 +31,13 @@ class DBALRepositoryTest extends TestCase
         $this->tableName = 'event_relations';
     }
 
-    /**
-     * @param array $expectedData
-     * @param string $tableName
-     */
-    private function assertTableData($expectedData, $tableName): void
+    private function assertTableData(array $expectedData, string $tableName): void
     {
         $expectedData = array_values($expectedData);
 
         $results = $this->getConnection()->executeQuery('SELECT * from ' . $tableName);
 
-        $actualData = $results->fetchAll(PDO::FETCH_OBJ);
+        $actualData = $results->fetchAllAssociative();
 
         $this->assertEquals(
             $expectedData,
@@ -56,11 +45,7 @@ class DBALRepositoryTest extends TestCase
         );
     }
 
-    /**
-     * @param string $tableName
-     * @param array $rows
-     */
-    private function insertTableData($tableName, $rows): void
+    private function insertTableData(string $tableName, array $rows): void
     {
         $q = $this->getConnection()->createQueryBuilder();
 
@@ -103,7 +88,7 @@ class DBALRepositoryTest extends TestCase
         $this->insertTableData($this->tableName, $existingData);
         $eventId = 'event-id';
         $organizerId = 'new-organizer-id';
-        $expectedData[] = (object)[
+        $expectedData[] = [
             'event' => 'event-id',
             'organizer' => 'new-organizer-id',
             'place' => 'some-place-id',
@@ -121,7 +106,7 @@ class DBALRepositoryTest extends TestCase
     {
         $eventId = 'event-id';
         $organizerId = 'organizer-id';
-        $expectedData[] = (object)[
+        $expectedData[] = [
             'event' => 'event-id',
             'organizer' => 'organizer-id',
             'place' => null,
@@ -144,7 +129,7 @@ class DBALRepositoryTest extends TestCase
         ];
         $this->insertTableData($this->tableName, $existingData);
         $eventId = 'event-id';
-        $expectedData[] = (object)[
+        $expectedData[] = [
             'event' => 'event-id',
             'organizer' => null,
             'place' => 'some-place-id',
@@ -174,7 +159,7 @@ class DBALRepositoryTest extends TestCase
         ];
         $this->insertTableData($this->tableName, $existingData);
         $eventId = 'e201cea1-4a79-4834-9501-b28a92900fa1';
-        $expectedData[] = (object)[
+        $expectedData[] = [
             'event' => 'cd996276-7aac-40b7-8bf4-e505dbbf11bf',
             'organizer' => '3a4abf90-1859-49de-a667-b713c81aad28',
             'place' => 'e64362f5-43e1-468b-97d6-8981fb0fe426',

--- a/tests/EventSourcing/DBAL/AggregateAwareDBALEventStoreTest.php
+++ b/tests/EventSourcing/DBAL/AggregateAwareDBALEventStoreTest.php
@@ -246,6 +246,6 @@ class AggregateAwareDBALEventStoreTest extends TestCase
             ->where('uuid = :uuid')
             ->setParameter(':uuid', $uuid->toString());
 
-        return $queryBuilder->execute()->fetchAll(\PDO::FETCH_ASSOC);
+        return $queryBuilder->execute()->fetchAllAssociative();
     }
 }

--- a/tests/EventSourcing/DBAL/UniqueDBALEventStoreDecoratorTest.php
+++ b/tests/EventSourcing/DBAL/UniqueDBALEventStoreDecoratorTest.php
@@ -271,7 +271,7 @@ class UniqueDBALEventStoreDecoratorTest extends TestCase
         $sql = 'SELECT * FROM ' . $tableName . $where;
 
         $statement = $this->connection->executeQuery($sql, [$uuid]);
-        $rows = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $statement->fetchAllAssociative();
 
         return $rows[0][UniqueDBALEventStoreDecorator::UNIQUE_COLUMN];
     }

--- a/tests/Label/ReadModels/Relations/Repository/Doctrine/BaseDBALRepositoryTest.php
+++ b/tests/Label/ReadModels/Relations/Repository/Doctrine/BaseDBALRepositoryTest.php
@@ -57,7 +57,7 @@ abstract class BaseDBALRepositoryTest extends TestCase
         $sql = 'SELECT * FROM ' . $this->tableName;
 
         $statement = $this->connection->executeQuery($sql);
-        $rows = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $statement->fetchAllAssociative();
 
         $labelRelations = [];
         foreach ($rows as $row) {

--- a/tests/Label/ReadModels/Roles/Doctrine/LabelRolesWriteRepositoryTest.php
+++ b/tests/Label/ReadModels/Roles/Doctrine/LabelRolesWriteRepositoryTest.php
@@ -131,6 +131,6 @@ class LabelRolesWriteRepositoryTest extends TestCase
         $sql = 'SELECT * FROM ' . $this->labelRolesTableName;
         $statement = $this->connection->executeQuery($sql);
 
-        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+        return $statement->fetchAllAssociative();
     }
 }

--- a/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
+++ b/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Place\Canonical;
 use CultuurNet\UDB3\DBALTestConnectionTrait;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
-use PDO;
 use PHPUnit\Framework\TestCase;
 
 class DBALDuplicatePlaceRepositoryTest extends TestCase
@@ -102,7 +101,7 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
             ->select('*')
             ->from('duplicate_places')
             ->execute()
-            ->fetchAll(PDO::FETCH_NUM);
+            ->fetchAllNumeric();
 
         $this->assertEquals(
             [

--- a/tests/Place/ReadModel/Relations/Doctrine/DBALRepositoryTest.php
+++ b/tests/Place/ReadModel/Relations/Doctrine/DBALRepositoryTest.php
@@ -104,10 +104,7 @@ class DBALRepositoryTest extends TestCase
         return $relations;
     }
 
-    /**
-     * @return array
-     */
-    private function getAll(Connection $connection)
+    private function getAll(Connection $connection): array
     {
         $queryBuilder = $connection->createQueryBuilder();
 
@@ -116,6 +113,6 @@ class DBALRepositoryTest extends TestCase
             ->from($this->tableName)
             ->getSQL();
 
-        return $connection->fetchAll($sql);
+        return $connection->fetchAllAssociative($sql);
     }
 }

--- a/tests/Role/ReadModel/Permissions/Doctrine/UserPermissionsWriteRepositoryTest.php
+++ b/tests/Role/ReadModel/Permissions/Doctrine/UserPermissionsWriteRepositoryTest.php
@@ -238,7 +238,7 @@ class UserPermissionsWriteRepositoryTest extends TestCase
         $sql = 'SELECT * FROM ' . $tableName;
 
         $statement = $this->getConnection()->executeQuery($sql);
-        $rows = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $statement->fetchAllAssociative();
 
         return $rows;
     }

--- a/tests/Role/ReadModel/Search/Doctrine/DBALRepositoryTest.php
+++ b/tests/Role/ReadModel/Search/Doctrine/DBALRepositoryTest.php
@@ -205,7 +205,7 @@ class DBALRepositoryTest extends TestCase
         $sql = 'SELECT * FROM ' . $this->tableName;
 
         $statement = $this->connection->executeQuery($sql);
-        $rows = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $statement->fetchAllAssociative();
 
         return $rows ? $rows[count($rows) - 1] : null;
     }

--- a/tests/SavedSearches/UDB3SavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/UDB3SavedSearchRepositoryTest.php
@@ -147,7 +147,7 @@ class UDB3SavedSearchRepositoryTest extends TestCase
         $statement = $this->connection->executeQuery(
             'SELECT * FROM ' . $this->tableName
         );
-        $rows = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $statement->fetchAllAssociative();
 
         $savedSearches = [];
         foreach ($rows as $row) {


### PR DESCRIPTION
### Changed
- Use `fetchAllAssociative` instead of `fetchAll(PDO::FETCH_ASSOC)`
- Use `fetchAllNumeric` instead of `fetchAll(PDO::FETCH_NUM)`
- Use `fetchFirstColumn` instead of `fetchAll(PDO::FETCH_COLUMN)`

---
Ticket: https://jira.uitdatabank.be/browse/III-5031
