### PR TITLE
III-5031 Upgrade composer for Docker

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -14,7 +14,7 @@ RUN docker-php-ext-configure gd && docker-php-ext-install gd
 
 RUN pecl install -o -f redis &&  rm -rf /tmp/pear &&  docker-php-ext-enable redis
 
-RUN curl https://getcomposer.org/download/2.1.3/composer.phar -o /usr/local/bin/composer && chmod +x /usr/local/bin/composer
+RUN curl https://getcomposer.org/download/2.6.6/composer.phar -o /usr/local/bin/composer && chmod +x /usr/local/bin/composer
 
 RUN echo "memory_limit=4096M" > $PHP_INI_DIR/conf.d/memory-limit.ini
 RUN echo "error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT" > $PHP_INI_DIR/conf.d/error_reporting.ini


### PR DESCRIPTION
### Changed
- Upgraded composer for Docker

### Note
- Use `docker-compose up php --build --detach` to get the latest composer

---
Ticket: https://jira.uitdatabank.be/browse/III-5031
