### PR TITLE
III-5031 Run CI also on PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.4', '8.0', '8.1']
+                php-versions: ['7.4', '8.0']
         name: PHP ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
@@ -47,7 +47,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            php-versions: ['7.4', '8.0', '8.1']
+            php-versions: [ '7.4', '8.0' ]
         name: Code style ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
@@ -80,7 +80,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            php-versions: ['7.4', '8.0', '8.1']
+            php-versions: [ '7.4', '8.0' ]
         name: Static analysis ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
@@ -113,7 +113,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            php-versions: ['7.4', '8.0', '8.1']
+            php-versions: [ '7.4', '8.0' ]
         name: Unused composer dependencies ${{ matrix.php-versions }}
         steps:
             -   name: 📤 Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.4']
+                php-versions: ['7.4', '8.0']
         name: PHP ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
@@ -45,7 +45,10 @@ jobs:
 
     cs:
         runs-on: ubuntu-latest
-        name: Code style
+        strategy:
+          matrix:
+            php-versions: [ '7.4', '8.0' ]
+        name: Code style ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
               uses: actions/checkout@v2
@@ -53,7 +56,7 @@ jobs:
             - name: 🐘 Install PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: ${{ matrix.php-versions }}
                   extensions: tidy, zip
                   tools: composer
 
@@ -75,7 +78,10 @@ jobs:
 
     phpstan:
         runs-on: ubuntu-latest
-        name: Static analysis
+        strategy:
+          matrix:
+            php-versions: [ '7.4', '8.0' ]
+        name: Static analysis ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
               uses: actions/checkout@v2
@@ -83,7 +89,7 @@ jobs:
             - name: 🐘 Install PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: ${{ matrix.php-versions }}
                   extensions: tidy, zip
                   tools: composer
 
@@ -105,7 +111,10 @@ jobs:
 
     unused:
         runs-on: ubuntu-latest
-        name: Unused composer dependencies
+        strategy:
+          matrix:
+            php-versions: [ '7.4', '8.0' ]
+        name: Unused composer dependencies ${{ matrix.php-versions }}
         steps:
             -   name: 📤 Checkout project
                 uses: actions/checkout@v2
@@ -113,7 +122,7 @@ jobs:
             -   name: 🐘 Install PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 7.4
+                    php-version: ${{ matrix.php-versions }}
                     extensions: tidy, zip
                     tools: composer
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.4', '8.0']
+                php-versions: ['7.4', '8.0', '8.1']
         name: PHP ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
@@ -47,7 +47,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            php-versions: [ '7.4', '8.0' ]
+            php-versions: ['7.4', '8.0', '8.1']
         name: Code style ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
@@ -80,7 +80,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            php-versions: [ '7.4', '8.0' ]
+            php-versions: ['7.4', '8.0', '8.1']
         name: Static analysis ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
@@ -113,7 +113,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            php-versions: [ '7.4', '8.0' ]
+            php-versions: ['7.4', '8.0', '8.1']
         name: Unused composer dependencies ${{ matrix.php-versions }}
         steps:
             -   name: 📤 Checkout project

--- a/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
+++ b/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
@@ -110,7 +110,7 @@ class EventJsonToTurtleConverterTest extends TestCase
             },
             E_ALL
         );
-        $this->expectExceptionMessage('Undefined index: name');
+        $this->expectException(Exception::class);
 
         $this->eventJsonToTurtleConverter->convert($eventId);
     }

--- a/tests/Place/ReadModel/RDF/PlaceJsonToTurtleConverterTest.php
+++ b/tests/Place/ReadModel/RDF/PlaceJsonToTurtleConverterTest.php
@@ -123,8 +123,8 @@ class PlaceJsonToTurtleConverterTest extends TestCase
             },
             E_ALL
         );
-        $this->expectExceptionMessage('Undefined index: name');
-
+        $this->expectException(Exception::class);
+        
         $this->placeJsonToTurtleConverter->convert($placeId);
     }
 

--- a/tests/Place/ReadModel/RDF/PlaceJsonToTurtleConverterTest.php
+++ b/tests/Place/ReadModel/RDF/PlaceJsonToTurtleConverterTest.php
@@ -124,7 +124,7 @@ class PlaceJsonToTurtleConverterTest extends TestCase
             E_ALL
         );
         $this->expectException(Exception::class);
-        
+
         $this->placeJsonToTurtleConverter->convert($placeId);
     }
 


### PR DESCRIPTION
### Changed
- Run GitHub actions also on PHP 8.0

### Note
- Running GitHub Actions on PHP 8.1 is not yet possible because of issues with the `easyrdf/easyrdf` and deprecation of `PHP-CS-Fixer`

---
Ticket: https://jira.uitdatabank.be/browse/III-5031
