### PR TITLE
III-4955 Remove performance.resource_owner_cache check

### DIFF
--- a/app/Security/OfferSecurityServiceProvider.php
+++ b/app/Security/OfferSecurityServiceProvider.php
@@ -43,9 +43,7 @@ final class OfferSecurityServiceProvider extends AbstractServiceProvider
                 $container->get('god_user_voter'),
                 new ResourceOwnerVoter(
                     $container->get('offer_owner_query'),
-                    $container->get(ApiName::class) !== ApiName::CLI &&
-                    isset($container->get('config')['performance']['resource_owner_cache']) &&
-                    $container->get('config')['performance']['resource_owner_cache']
+                    $container->get(ApiName::class) !== ApiName::CLI
                 ),
                 new ContributorVoter(
                     $container->get(UserEmailAddressRepository::class),

--- a/app/Security/OrganizerSecurityServiceProvider.php
+++ b/app/Security/OrganizerSecurityServiceProvider.php
@@ -33,9 +33,7 @@ final class OrganizerSecurityServiceProvider extends AbstractServiceProvider
                 $container->get('god_user_voter'),
                 new ResourceOwnerVoter(
                     $container->get('organizer_owner.repository'),
-                    $container->get(ApiName::class) !== ApiName::CLI &&
-                    isset($container->get('config')['performance']['resource_owner_cache']) &&
-                    $container->get('config')['performance']['resource_owner_cache']
+                    $container->get(ApiName::class) !== ApiName::CLI
                 ),
                 new ContributorVoter(
                     $container->get(UserEmailAddressRepository::class),


### PR DESCRIPTION
### Removed

- `OfferSecurityServiceProvider` & `OrganizerSecurityServiceProvider`: Removed check on `performance.resource_owner_cache` which is true on every environment.

### Related PR:

- https://github.com/cultuurnet/appconfig/pull/549 


---
Ticket: https://jira.publiq.be/browse/III-4955
