### PR TITLE
Bugfix: disable Timeout when running the acceptance tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,10 @@
   ],
   "scripts": {
     "test": "vendor/bin/phpunit",
-    "feature": "vendor/bin/behat",
+    "feature": [
+      "Composer\\Config::disableProcessTimeout",
+      "vendor/bin/behat"
+    ],
     "phpstan": "vendor/bin/phpstan analyse",
     "migrate": "vendor/bin/doctrine-dbal migrations:migrate --no-interaction",
     "ci": [


### PR DESCRIPTION
### Changed

- `composer.json`: disable timeout, when running the acceptance tests.

### Fixed

- One can run the acceptance tests again, with the updated `2.6` version of `composer` without running into a timeout.

---
