### PR TITLE
Remove geometry from RDF projection of place with invalid address

### DIFF
--- a/features/data/places/rdf/place-with-invalid-address.ttl
+++ b/features/data/places/rdf/place-with-invalid-address.ttl
@@ -5,7 +5,6 @@
 @prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
 @prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
-@prefix geosparql: <http://www.opengis.net/ont/geosparql#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix labeltype: <https://data.cultuurparticipatie.be/id/concept/LabelType/> .
 
@@ -31,9 +30,5 @@
     locn:postcode "Postcode" ;
     locn:fullAddress "Straat 1, Postcode Gemeente, BE"@nl ;
     locn:postName "Gemeente"@nl
-  ] ;
-  locn:geometry [
-    a locn:Geometry ;
-    geosparql:asGML "<gml:Point srsName='http://www.opengis.net/def/crs/OGC/1.3/CRS84'><gml:coordinates>4.469936, 50.503887</gml:coordinates></gml:Point>"^^geosparql:gmlLiteral
   ] ;
   rdfs:label "public-visible"^^labeltype:publiek, "public-invisible"^^labeltype:verborgen .


### PR DESCRIPTION
### Fixed
- Fixed acceptance test by removeing geometry from RDF projection of place with invalid address
