### PR TITLE
III-5995 Fix typo in PrijsInfo RDF namespace

### DIFF
--- a/features/data/events/rdf/event-with-all-fields.ttl
+++ b/features/data/events/rdf/event-with-all-fields.ttl
@@ -11,7 +11,7 @@
 @prefix schema: <https://schema.org/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix labeltype: <https://data.cultuurparticipatie.be/id/concept/LabelType/> .
-@prefix cpp: <https://data.vlaanderen.be/ns/cultuurparticipatie#Prijsinfo> .
+@prefix cpp: <https://data.vlaanderen.be/ns/cultuurparticipatie#Prijsinfo.> .
 
 <http://host.docker.internal:8080/events/%{eventId}>
   a cidoc:E7_Activity ;

--- a/features/data/events/rdf/event-with-price-info.ttl
+++ b/features/data/events/rdf/event-with-price-info.ttl
@@ -8,7 +8,7 @@
 @prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix schema: <https://schema.org/> .
-@prefix cpp: <https://data.vlaanderen.be/ns/cultuurparticipatie#Prijsinfo> .
+@prefix cpp: <https://data.vlaanderen.be/ns/cultuurparticipatie#Prijsinfo.> .
 
 <http://host.docker.internal:8080/events/%{eventId}>
   a cidoc:E7_Activity ;

--- a/src/RDF/RdfNamespaces.php
+++ b/src/RDF/RdfNamespaces.php
@@ -24,7 +24,7 @@ final class RdfNamespaces
         RdfNamespace::set('m8g', 'http://data.europa.eu/m8g/');
         RdfNamespace::set('cpa', 'https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.');
         RdfNamespace::set('cpr', 'https://data.vlaanderen.be/ns/cultuurparticipatie#Realisator.');
-        RdfNamespace::set('cpp', 'https://data.vlaanderen.be/ns/cultuurparticipatie#Prijsinfo');
+        RdfNamespace::set('cpp', 'https://data.vlaanderen.be/ns/cultuurparticipatie#Prijsinfo.');
         RdfNamespace::set('cp', 'https://data.vlaanderen.be/ns/cultuurparticipatie#');
         RdfNamespace::set('schema', 'https://schema.org/');
         RdfNamespace::set('foaf', 'http://xmlns.com/foaf/0.1/');

--- a/tests/Event/ReadModel/RDF/ttl/event-with-price-info.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-price-info.ttl
@@ -9,7 +9,7 @@
 @prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix schema: <https://schema.org/> .
-@prefix cpp: <https://data.vlaanderen.be/ns/cultuurparticipatie#Prijsinfo> .
+@prefix cpp: <https://data.vlaanderen.be/ns/cultuurparticipatie#Prijsinfo.> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a cidoc:E7_Activity ;


### PR DESCRIPTION
### Fixed
- Fix typo in PrijsInfo RDF namespace

---
Ticket: https://jira.uitdatabank.be/browse/III-5995
