### PR TITLE
Fix failing RDF test

### DIFF
--- a/features/data/events/rdf/event-with-videos.ttl
+++ b/features/data/events/rdf/event-with-videos.ttl
@@ -30,15 +30,15 @@
   schema:video [
     a schema:VideoObject ;
     schema:identifier "6bab1cba-18d0-42e7-b0c9-3b869eb68934" ;
-    schema:url "https://youtu.be/fn-4RbxXThE" ;
+    schema:url "https://youtu.be/fn-4RbxXThE"^^schema:URL ;
     schema:embedUrl "https://www.youtube.com/embed/fn-4RbxXThE"^^schema:URL ;
-    schema:copyrightHolder "Copyright afgehandeld door YouTube"^^schema:URL ;
+    schema:copyrightHolder "Copyright afgehandeld door YouTube" ;
     schema:inLanguage "nl"
   ], [
     a schema:VideoObject ;
     schema:identifier "58716d9e-46c8-4145-a0b2-60381ec3bd92" ;
-    schema:url "https://youtu.be/fd-5FGTh3se" ;
+    schema:url "https://youtu.be/fd-5FGTh3se"^^schema:URL ;
     schema:embedUrl "https://www.youtube.com/embed/fd-5FGTh3se"^^schema:URL ;
-    schema:copyrightHolder "Copyright afgehandeld door YouTube"^^schema:URL ;
+    schema:copyrightHolder "Copyright afgehandeld door YouTube" ;
     schema:inLanguage "nl"
   ] .


### PR DESCRIPTION
### Fixed
- Fixed failing RDF acceptance tests by setting `schema:URL` to correct property
