### PR TITLE
Fix failure on nil location

### DIFF
--- a/src/Http/CheckTypeOfOfferMiddleware.php
+++ b/src/Http/CheckTypeOfOfferMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http;
 
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
@@ -36,7 +37,12 @@ class CheckTypeOfOfferMiddleware implements MiddlewareInterface
 
         if (OfferType::event()->sameAs($offerType)) {
             $this->eventRepository->fetch($offerId);
-        } else {
+        }
+
+        if (OfferType::place()->sameAs($offerType)) {
+            if ((new LocationId($offerId))->isNilLocation()) {
+                return $handler->handle($request);
+            }
             $this->placeRepository->fetch($offerId);
         }
 


### PR DESCRIPTION
### Fixed
- Allow nill location in `CheckTypeOfOfferMiddleware` to prevent a 404 instead of 200

---
Ticket: https://jira.publiq.be/browse/III-5999