### PR TITLE
III-4601 Made format error message RFC7807 compliant for duplicate places

### DIFF
--- a/features/Steps/PlaceSteps.php
+++ b/features/Steps/PlaceSteps.php
@@ -52,6 +52,23 @@ trait PlaceSteps
     }
 
     /**
+     * @Given /^I create a minimal place then I should get a "([^"]*)" response code$/
+     */
+    public function iCreateAMinimalPlaceThenIShouldGetAResponseCode(int $responseCode): void
+    {
+        $json = $this->fixtures->loadJson('places/place-with-required-fields-and-variable-name.json', $this->variableState);
+
+        $response = $this->getHttpClient()->postJSON(
+            '/places',
+            $json
+        );
+        $this->responseState->setResponse($response);
+
+        $this->theResponseStatusShouldBe($responseCode);
+        $this->theResponseBodyShouldBeValidJson();
+    }
+
+    /**
      * @Given I create a place from :fileName and save the :jsonPath as :variableName
      */
     public function iCreateAPlaceFromAndSaveTheAs(string $fileName, string $jsonPath, string $variableName): void

--- a/features/place/duplicate.feature
+++ b/features/place/duplicate.feature
@@ -11,7 +11,7 @@ Feature: Test creating places
     Given I create a random name of 6 characters and keep it as "name"
     Given I create a minimal place and save the "id" as "originalPlaceId" then I should get a "201" response code
     Then I wait for the place with url "/places/%{originalPlaceId}" to be indexed
-    Given I create a minimal place and save the "query" as "query" then I should get a "409" response code
+    Given I create a minimal place then I should get a "409" response code
     Then the JSON response should be:
     """
     {

--- a/features/place/duplicate.feature
+++ b/features/place/duplicate.feature
@@ -15,7 +15,7 @@ Feature: Test creating places
     Then the JSON response should be:
     """
     {
-        "query": "%{baseUrl}/place/%{originalPlaceId}",
+        "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}",
         "type": "https://api.publiq.be/probs/url/status-conflict",
         "title": "Status conflict",
         "status": 409,

--- a/features/place/duplicate.feature
+++ b/features/place/duplicate.feature
@@ -19,7 +19,7 @@ Feature: Test creating places
         "type": "https://api.publiq.be/probs/url/status-conflict",
         "title": "Status conflict",
         "status": 409,
-        "detail": "This place already exists. Use the attached query to get existing place(s) for the place you tried to create."
+        "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes."
     }
     """
     Then I restore the duplicate configuration

--- a/features/place/duplicate.feature
+++ b/features/place/duplicate.feature
@@ -11,9 +11,15 @@ Feature: Test creating places
     Given I create a random name of 6 characters and keep it as "name"
     Given I create a minimal place and save the "id" as "originalPlaceId" then I should get a "201" response code
     Then I wait for the place with url "/places/%{originalPlaceId}" to be indexed
-    Given I create a minimal place and save the "originalPlace" as "newPlaceUri" then I should get a "409" response code
-    Then the JSON response at "originalPlace" should be:
+    Given I create a minimal place and save the "query" as "query" then I should get a "409" response code
+    Then the JSON response should be:
     """
-    "%{baseUrl}/place/%{originalPlaceId}"
+    {
+        "query": "%{baseUrl}/place/%{originalPlaceId}",
+        "type": "https://api.publiq.be/probs/url/status-conflict",
+        "title": "Status conflict",
+        "status": 409,
+        "detail": "This place already exists. Use the attached query to get existing place(s) for the place you tried to create."
+    }
     """
     Then I restore the duplicate configuration

--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -19,7 +19,7 @@ use Fig\Http\Message\StatusCodeInterface;
  * - Type should be a URI
  * - Title should always be the same for the used type
  * - The "about:blank" type can only be used if the error needs no further explanation than the status code
- *     (for example, 400 is too vague)
+ *     (for example, StatusCodeInterface::STATUS_BAD_REQUEST is too vague)
  * - If the "about:blank" type is used, the title should be the HTTP status phrase for the used status code
  *     (for example, "Internal Server Error" for 500)
  * - Avoid using "about:blank" in cases where extra documentation can be helpful
@@ -198,7 +198,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/auth/unauthorized',
             'Unauthorized',
-            401,
+            StatusCodeInterface::STATUS_UNAUTHORIZED,
             $detail
         );
     }
@@ -208,7 +208,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/auth/forbidden',
             'Forbidden',
-            403,
+            StatusCodeInterface::STATUS_FORBIDDEN,
             $detail
         );
     }
@@ -218,7 +218,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/headers/not-acceptable',
             'Not Acceptable',
-            406,
+            StatusCodeInterface::STATUS_NOT_ACCEPTABLE,
             $detail
         );
     }
@@ -228,7 +228,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/method/not-allowed',
             'Method not allowed',
-            405,
+            StatusCodeInterface::STATUS_METHOD_NOT_ALLOWED,
             $detail
         );
     }
@@ -238,9 +238,25 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/url/not-found',
             'Not Found',
-            404,
+            StatusCodeInterface::STATUS_NOT_FOUND,
             $detail
         );
+    }
+
+    public static function statusConflict(string $detail = null, array $properties = null): self
+    {
+        $apiProblem = self::create(
+            'https://api.publiq.be/probs/url/status-conflict',
+            'Status conflict',
+            StatusCodeInterface::STATUS_CONFLICT,
+            $detail
+        );
+
+        if ($properties !== null) {
+            $apiProblem->setExtraProperties($properties);
+        }
+
+        return $apiProblem;
     }
 
     public static function queryParameterInvalidValue(string $parameterName, string $value, array $allowedValues): self
@@ -305,7 +321,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/body/missing',
             'Body missing',
-            400
+            StatusCodeInterface::STATUS_BAD_REQUEST
         );
     }
 
@@ -323,7 +339,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/body/invalid-syntax',
             'Invalid body syntax',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             'The given request body could not be parsed as ' . $format . '.'
         );
     }
@@ -333,7 +349,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/body/invalid-data',
             'Invalid body data',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             null,
             $schemaErrors
         );
@@ -344,7 +360,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/body/invalid-data',
             'Invalid body data',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             $detail
         );
     }
@@ -354,7 +370,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/uitdatabank/calendar-type-not-supported',
             'Calendar type not supported',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             $detail
         );
     }
@@ -364,7 +380,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/uitdatabank/incompatible-audience-type',
             'Incompatible audience type',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             $detail
         );
     }
@@ -374,7 +390,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/uitdatabank/resource-id-already-in-use',
             'Resource id already in use',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             'The id ' . $id . ' is already in use by a resource of a different type.'
         );
     }
@@ -384,7 +400,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/uitdatabank/duplicate-url',
             'Duplicate URL',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             'The url ' . $originalUrl . ' (normalized to ' . $normalized . ') is already in use.'
         );
     }
@@ -406,7 +422,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/uitdatabank/invalid-workflow-status-transition',
             'Invalid workflowStatus transition',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             'Cannot transition from workflowStatus "' . $from . '" to "' . $to . '".'
         );
     }
@@ -416,7 +432,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/uitdatabank/attendance-mode-not-supported',
             'Attendance mode not supported',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             $detail . ' For more information check the documentation of the update attendance mode endpoint. See: ' . Stoplight::ATTENDANCE_MODE_UPDATE
         );
     }
@@ -434,7 +450,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/uitdatabank/event-has-uitpas-ticket-sales',
             'Event has UiTPAS ticket sales',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             $detail
         );
     }
@@ -444,7 +460,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/body/file-missing',
             'File missing',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             $detail
         );
     }
@@ -454,7 +470,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/body/file-invalid-type',
             'Invalid file type',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             $detail
         );
     }
@@ -464,7 +480,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/body/file-invalid-size',
             'Invalid file size',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             $detail
         );
     }
@@ -482,7 +498,7 @@ final class ApiProblem extends Exception
         return self::create(
             'about:blank',
             'Bad Gateway',
-            502,
+            StatusCodeInterface::STATUS_BAD_GATEWAY,
             $detail
         );
     }
@@ -492,7 +508,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/body/image-must-be-linked-to-resource',
             'Image must be linked to resource',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             'The image with id ' . $imageId . ' is not linked to the resource. Add it first before you can perform an action.'
         );
     }
@@ -502,7 +518,7 @@ final class ApiProblem extends Exception
         return self::create(
             'https://api.publiq.be/probs/body/invalid-json-data',
             'Invalid JSON data for RDF creation',
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             $detail
         );
     }

--- a/src/Http/Place/ImportPlaceRequestHandler.php
+++ b/src/Http/Place/ImportPlaceRequestHandler.php
@@ -270,11 +270,12 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
             return;
         }
 
+
         try {
             $duplicatePlaceId = $this->lookupDuplicatePlace->getDuplicatePlaceUri($place);
             if ($duplicatePlaceId !== null) {
                 throw ApiProblem::statusConflict(
-                    MultipleDuplicatePlacesFound::ERROR_MSG,
+                    'A place with this address / name combination already exists. Please use the existing place for your purposes.',
                     ['query' => $duplicatePlaceId]
                 );
             }

--- a/src/Http/Place/ImportPlaceRequestHandler.php
+++ b/src/Http/Place/ImportPlaceRequestHandler.php
@@ -276,7 +276,7 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
             if ($duplicatePlaceId !== null) {
                 throw ApiProblem::statusConflict(
                     'A place with this address / name combination already exists. Please use the existing place for your purposes.',
-                    ['query' => $duplicatePlaceId]
+                    ['duplicatePlaceUri' => $duplicatePlaceId]
                 );
             }
         } catch (MultipleDuplicatePlacesFound $e) {

--- a/src/Place/ReadModel/Duplicate/MultipleDuplicatePlacesFound.php
+++ b/src/Place/ReadModel/Duplicate/MultipleDuplicatePlacesFound.php
@@ -8,11 +8,13 @@ use DomainException;
 
 class MultipleDuplicatePlacesFound extends DomainException
 {
+    public const ERROR_MSG = 'This place already exists. Use the attached query to get existing place(s) for the place you tried to create.';
+
     private string $query;
 
     public function __construct(string $query)
     {
-        parent::__construct('This place already exists multiple times in our database. We did not find a canonical place to suggest. Use the attached query to get all possible duplicates.', 0, null);
+        parent::__construct(self::ERROR_MSG, 0, null);
         $this->query = '/places?q=' . $query;
     }
 

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -5207,7 +5207,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
 
         $this->assertCallableThrowsApiProblem(ApiProblem::statusConflict(
             'A place with this address / name combination already exists. Please use the existing place for your purposes.',
-            ['query' => $originalPlaceUri]
+            ['duplicatePlaceUri' => $originalPlaceUri]
         ), function () use ($handler, $request): void {
             $handler->handle($request);
         });

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -5207,10 +5207,10 @@ final class ImportPlaceRequestHandlerTest extends TestCase
 
         $this->expectExceptionObject(ApiProblem::statusConflict(
             MultipleDuplicatePlacesFound::ERROR_MSG,
-            ['instance' => $originalPlaceUri]
+            ['query' => $originalPlaceUri]
         ));
 
-        $response = $handler->handle($request);
+        $handler->handle($request);
     }
 
     public function testHandleWithDuplicatePreventionEnabledHappyPath(): void


### PR DESCRIPTION
### Changed
I Made format error message RFC7807 compliant for duplicate places
I now throw ApiProblem for this new format.

Minor bonus: changed all the status codes in ApiProblem to use constants.

Related: https://github.com/cultuurnet/apidocs/pull/359

---
Ticket: https://jira.uitdatabank.be/browse/III-4601
