### PR TITLE
III-4918 kamp vakantie available to

### DIFF
--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -52,6 +52,12 @@ final class EventTypeResolver implements TypeResolverInterface
 
     public static function isOnlyAvailableUntilStartDate(EventType $eventType): bool
     {
-        return $eventType->getId() === '0.3.1.0.0';
+        return in_array(
+            $eventType->getId(),
+            [
+                '0.3.1.0.0',
+                '0.57.0.0.0',
+            ]
+        );
     }
 }

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -1507,54 +1507,6 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $this->assertEquals($expectedTerms, $updatedItem->terms);
     }
 
-
-    /**
-     * @test
-     */
-    public function it_keeps_start_date_for_lessen_reeks_on_calendar_updated(): void
-    {
-        $eventId = '1a08516e-aba4-47f0-887e-df37b61a1e8d';
-
-        $lessenReeksEvent = new JsonDocument(
-            $eventId,
-            Json::encode([
-                '@id' => $eventId,
-                '@type' => 'event',
-                'terms' => [
-                    (object) [
-                        'id' => '1.51.12.0.0',
-                        'label' => 'Omnisport en andere',
-                        'domain' => 'theme',
-                    ],
-                    (object) [
-                        'id' => '0.3.1.0.0',
-                        'label' => 'Lessenreeks',
-                        'domain' => 'eventtype',
-                    ],
-                ],
-            ])
-        );
-        $this->documentRepository->save($lessenReeksEvent);
-
-        $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
-        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
-        $calendarUpdated = new CalendarUpdated(
-            $eventId,
-            new Calendar(
-                CalendarType::SINGLE(),
-                $startDate,
-                $endDate,
-                [
-                    new Timestamp($startDate, $endDate),
-                ]
-            )
-        );
-
-        $updatedItem = $this->project($calendarUpdated, $eventId);
-
-        $this->assertEquals($startDate->format(DATE_ATOM), $updatedItem->availableTo);
-    }
-
     /**
      * @test
      * @dataProvider typesThatAreAvailableTillStart

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -1515,7 +1515,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
     {
         $eventId = '1a08516e-aba4-47f0-887e-df37b61a1e8d';
 
-        $lessenReeksEvent = new JsonDocument(
+        $eventThatsAvailableTillStart = new JsonDocument(
             $eventId,
             Json::encode([
                 '@id' => $eventId,
@@ -1534,7 +1534,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 ],
             ])
         );
-        $this->documentRepository->save($lessenReeksEvent);
+        $this->documentRepository->save($eventThatsAvailableTillStart);
 
         $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
         $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -1557,6 +1557,54 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
     /**
      * @test
+     * @dataProvider typesThatAreAvailableTillStart
+     */
+    public function it_keeps_start_date_for_selected_types_on_calendar_updated(string $termId, string $termName): void
+    {
+        $eventId = '1a08516e-aba4-47f0-887e-df37b61a1e8d';
+
+        $lessenReeksEvent = new JsonDocument(
+            $eventId,
+            Json::encode([
+                '@id' => $eventId,
+                '@type' => 'event',
+                'terms' => [
+                    (object) [
+                        'id' => '1.51.12.0.0',
+                        'label' => 'Omnisport en andere',
+                        'domain' => 'theme',
+                    ],
+                    (object) [
+                        'id' => $termId,
+                        'label' => $termName,
+                        'domain' => 'eventtype',
+                    ],
+                ],
+            ])
+        );
+        $this->documentRepository->save($lessenReeksEvent);
+
+        $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
+        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
+        $calendarUpdated = new CalendarUpdated(
+            $eventId,
+            new Calendar(
+                CalendarType::SINGLE(),
+                $startDate,
+                $endDate,
+                [
+                    new Timestamp($startDate, $endDate),
+                ]
+            )
+        );
+
+        $updatedItem = $this->project($calendarUpdated, $eventId);
+
+        $this->assertEquals($startDate->format(DATE_ATOM), $updatedItem->availableTo);
+    }
+
+    /**
+     * @test
      */
     public function it_handles_theme_removed(): void
     {
@@ -1613,6 +1661,14 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             $expectedMediaObjects,
             $this->documentRepository->fetch(CdbXMLEventFactory::AN_EVENT_ID)->getBody()->mediaObject
         );
+    }
+
+    public function typesThatAreAvailableTillStart(): array
+    {
+        return [
+            ['0.3.1.0.0', 'Lessenreeks'],
+            ['0.57.0.0.0', 'Kamp of vakantie'],
+        ];
     }
 
     public function eventUpdateDataProvider(): array


### PR DESCRIPTION
### Changed

- `EventTypeResolver`: make `isOnlyAvailableUntilStartDate()` compatible with multiple terms and add `0.57.0.0.0` `Kamp of vakantie` 
-  `EventLDProjectorTest`: refactor Unit Test the test multiple terms with new DataProvider `typesThatAreAvailableTillStart`

---
Ticket: https://jira.publiq.be/browse/III-4918
