### PR TITLE
III-4954 Remove `polyfill_duplicate_places`

### DIFF
--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -140,13 +140,11 @@ final class PlaceJSONLDServiceProvider extends AbstractServiceProvider
                     $container->get(CurrentUser::class)->getId()
                 );
 
-                if (isset($container->get('config')['polyfill_duplicate_places']) && $container->get('config')['polyfill_duplicate_places']) {
-                    $repository = new DuplicatePlacesEnrichedPlaceRepository(
-                        $container->get('duplicate_place_repository'),
-                        $container->get('place_iri_generator'),
-                        $repository
-                    );
-                }
+                $repository = new DuplicatePlacesEnrichedPlaceRepository(
+                    $container->get('duplicate_place_repository'),
+                    $container->get('place_iri_generator'),
+                    $repository
+                );
 
                 $repository = new PropertyPolyfillOfferRepository(
                     $repository,


### PR DESCRIPTION
### Removed
- Removed `polyfill_duplicate_places` and always enrich with duplicate info.

### Note
- Also see https://github.com/cultuurnet/appconfig/pull/554 which can be merged once this is deployed on production

---
Ticket: https://jira.uitdatabank.be/browse/III-4954
