### PR TITLE
III-6035 Limit Google Maps API calls

### DIFF
--- a/src/Address/Parser/GoogleMapsAddressParser.php
+++ b/src/Address/Parser/GoogleMapsAddressParser.php
@@ -28,7 +28,6 @@ final class GoogleMapsAddressParser implements AddressParser, LoggerAwareInterfa
             $address = $addresses->first();
             if ($address->getStreetNumber() === null) {
                 $this->logger->warning('No street number found for address: "' . $formattedAddress . '"');
-                return null;
             }
 
             return new ParsedAddress(

--- a/tests/Address/Parser/GoogleMapsAddressParserTest.php
+++ b/tests/Address/Parser/GoogleMapsAddressParserTest.php
@@ -127,7 +127,13 @@ class GoogleMapsAddressParserTest extends TestCase
         $this->geocoder->expects($this->once())
             ->method('geocode')
             ->with('Martelarenplein 1, 3000 Leuven, BE')
-            ->willThrowException(new CollectionIsEmpty());
+            ->willThrowException(new CollectionIsEmpty('Collection is empty.'));
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                'No results for address: "Martelarenplein 1, 3000 Leuven, BE". Exception message: Collection is empty.'
+            );
 
         $parsedAddress = $this->parser->parse('Martelarenplein 1, 3000 Leuven, BE');
 

--- a/tests/Address/Parser/GoogleMapsAddressParserTest.php
+++ b/tests/Address/Parser/GoogleMapsAddressParserTest.php
@@ -12,6 +12,7 @@ use Geocoder\Model\AdminLevelCollection;
 use Geocoder\Model\Country;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class GoogleMapsAddressParserTest extends TestCase
 {
@@ -22,10 +23,18 @@ class GoogleMapsAddressParserTest extends TestCase
 
     private GoogleMapsAddressParser $parser;
 
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $logger;
+
     protected function setUp(): void
     {
         $this->geocoder = $this->createMock(Geocoder::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
         $this->parser = new GoogleMapsAddressParser($this->geocoder);
+        $this->parser->setLogger($this->logger);
 
         parent::setUp();
     }
@@ -68,6 +77,51 @@ class GoogleMapsAddressParserTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function it_geocodes_an_address_with_missing_number_and_returns_a_parsed_address(): void
+    {
+        $this->geocoder->expects($this->once())
+            ->method('geocode')
+            ->with('Martelarenplein, 3000 Leuven, BE')
+            ->willReturn(
+                new AddressCollection([
+                    new Address(
+                        'Google',
+                        new AdminLevelCollection(),
+                        null,
+                        null,
+                        null,
+                        'Martelarenplein',
+                        '3000',
+                        'Leuven',
+                        null,
+                        new Country('BE')
+                    ),
+                ])
+            );
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with('No street number found for address: "Martelarenplein, 3000 Leuven, BE"');
+
+        $parsedAddress = $this->parser->parse('Martelarenplein, 3000 Leuven, BE');
+
+        $this->assertEquals(
+            new ParsedAddress(
+                'Martelarenplein',
+                null,
+                '3000',
+                'Leuven'
+            ),
+            $parsedAddress
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_handles_a_geocoder_exception(): void
     {
         $this->geocoder->expects($this->once())


### PR DESCRIPTION
### Fixed
- Limited the amount of Google Maps API calls by storing parsed addresses from Google Maps even when the house number is missing

---
Ticket: https://jira.uitdatabank.be/browse/III-6035
