### PR TITLE
III-5912 Place created make title string

### DIFF
--- a/src/Place/Events/PlaceCreated.php
+++ b/src/Place/Events/PlaceCreated.php
@@ -18,7 +18,7 @@ use DateTimeInterface;
 final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents, MainLanguageDefined
 {
     private Language $mainLanguage;
-    private Title $title;
+    private string $title;
     private EventType $eventType;
     private Address $address;
     private Calendar $calendar;
@@ -27,7 +27,7 @@ final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents,
     public function __construct(
         string $placeId,
         Language $mainLanguage,
-        Title $title,
+        string $title,
         EventType $eventType,
         Address $address,
         Calendar $calendar,
@@ -48,7 +48,7 @@ final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents,
         return $this->mainLanguage;
     }
 
-    public function getTitle(): Title
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -76,7 +76,7 @@ final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents,
     public function toGranularEvents(): array
     {
         return [
-            new TitleUpdated($this->placeId, $this->title),
+            new TitleUpdated($this->placeId, new Title($this->title)),
             new TypeUpdated($this->placeId, $this->eventType),
             new AddressUpdated($this->placeId, $this->address),
             new CalendarUpdated($this->placeId, $this->calendar),
@@ -91,7 +91,7 @@ final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents,
         }
         return parent::serialize() + [
             'main_language' => $this->mainLanguage->getCode(),
-            'title' => $this->getTitle()->toString(),
+            'title' => $this->getTitle(),
             'event_type' => $this->getEventType()->serialize(),
             'address' => $this->getAddress()->serialize(),
             'calendar' => $this->getCalendar()->serialize(),
@@ -111,7 +111,7 @@ final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents,
         return new static(
             $data['place_id'],
             new Language($data['main_language']),
-            new Title($data['title']),
+            $data['title'],
             EventType::deserialize($data['event_type']),
             Address::deserialize($data['address']),
             Calendar::deserialize($data['calendar']),

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -121,7 +121,7 @@ class Place extends Offer
         $place->apply(new PlaceCreated(
             $id,
             $mainLanguage,
-            $title,
+            $title->toString(),
             $eventType,
             $address,
             $calendar,
@@ -134,7 +134,7 @@ class Place extends Offer
     protected function applyPlaceCreated(PlaceCreated $placeCreated): void
     {
         $this->mainLanguage = $placeCreated->getMainLanguage();
-        $this->titles[$this->mainLanguage->getCode()] = $placeCreated->getTitle();
+        $this->titles[$this->mainLanguage->getCode()] = new Title($placeCreated->getTitle());
         $this->calendar = $placeCreated->getCalendar();
         $this->contactPoint = new ContactPoint();
         $this->bookingInfo = new BookingInfo();

--- a/tests/DomainMessage/CompositeDomainMessageEnricherTest.php
+++ b/tests/DomainMessage/CompositeDomainMessageEnricherTest.php
@@ -21,7 +21,6 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreated;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
-use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
@@ -162,7 +161,7 @@ class CompositeDomainMessageEnricherTest extends TestCase
             new PlaceCreated(
                 'fd9e986d-6a23-470c-bf0c-4ad40aa4515e',
                 new Language('nl'),
-                new Title('test title'),
+                'test title',
                 new EventType('0.0.1', 'label'),
                 new Address(
                     new Street('street'),

--- a/tests/EventListener/EnrichingEventListenerDecoratorTest.php
+++ b/tests/EventListener/EnrichingEventListenerDecoratorTest.php
@@ -21,7 +21,6 @@ use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
-use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
@@ -77,7 +76,7 @@ class EnrichingEventListenerDecoratorTest extends TestCase
             new PlaceCreated(
                 'fd9e986d-6a23-470c-bf0c-4ad40aa4515e',
                 new Language('nl'),
-                new Title('test title'),
+                'test title',
                 new EventType('0.0.1', 'label'),
                 new Address(
                     new Street('street'),

--- a/tests/Offer/ReadModel/Metadata/OfferMetadataProjectorTest.php
+++ b/tests/Offer/ReadModel/Metadata/OfferMetadataProjectorTest.php
@@ -23,7 +23,6 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
-use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -216,7 +215,7 @@ class OfferMetadataProjectorTest extends TestCase
         return new PlaceCreated(
             self::OFFER_ID,
             new Language('en'),
-            new Title('some representative title'),
+            'some representative title',
             new EventType('0.50.4.0.0', 'concert'),
             new Address(
                 new Street('street'),

--- a/tests/Place/CommandHandlerTest.php
+++ b/tests/Place/CommandHandlerTest.php
@@ -138,7 +138,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
         return new PlaceCreated(
             $id,
             new Language('nl'),
-            new Title('some representative title'),
+            'some representative title',
             new EventType('0.50.4.0.0', 'concert'),
             new Address(
                 new Street('Kerkstraat 69'),

--- a/tests/Place/Events/PlaceCreatedTest.php
+++ b/tests/Place/Events/PlaceCreatedTest.php
@@ -43,7 +43,7 @@ class PlaceCreatedTest extends TestCase
         $this->placeCreated = new PlaceCreated(
             'id',
             new Language('es'),
-            new Title('title'),
+            'title',
             new EventType('id', 'label'),
             $this->address,
             new Calendar(CalendarType::PERMANENT()),
@@ -91,7 +91,7 @@ class PlaceCreatedTest extends TestCase
      */
     public function it_stores_a_place_title(): void
     {
-        $this->assertEquals(new Title('title'), $this->placeCreated->getTitle());
+        $this->assertEquals('title', $this->placeCreated->getTitle());
     }
 
     /**
@@ -185,7 +185,7 @@ class PlaceCreatedTest extends TestCase
                 new PlaceCreated(
                     'test 456',
                     new Language('es'),
-                    new Title('title'),
+                    'title',
                     new EventType('bar_id', 'bar'),
                     new Address(
                         new Street('De straat'),
@@ -228,7 +228,7 @@ class PlaceCreatedTest extends TestCase
                 new PlaceCreated(
                     'test 456',
                     new Language('es'),
-                    new Title('title'),
+                    'title',
                     new EventType('bar_id', 'bar'),
                     new Address(
                         new Street('De straat'),
@@ -271,7 +271,7 @@ class PlaceCreatedTest extends TestCase
                 new PlaceCreated(
                     'test 456',
                     new Language('es'),
-                    new Title('title'),
+                    'title',
                     new EventType('bar_id', 'bar'),
                     new Address(
                         new Street('De straat'),

--- a/tests/Place/GeoCoordinatesCommandHandlerTest.php
+++ b/tests/Place/GeoCoordinatesCommandHandlerTest.php
@@ -28,7 +28,6 @@ use CultuurNet\UDB3\Place\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
-use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
@@ -92,7 +91,7 @@ class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
         $placeCreated = new PlaceCreated(
             self::PLACE_ID,
             new Language('en'),
-            new Title('Some place'),
+            'Some place',
             new EventType('01.01', 'Some category'),
             $address,
             new Calendar(CalendarType::PERMANENT())
@@ -134,7 +133,7 @@ class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
         $placeCreated = new PlaceCreated(
             self::PLACE_ID,
             new Language('en'),
-            new Title('Some place'),
+            'Some place',
             new EventType('01.01', 'Some category'),
             $address,
             new Calendar(CalendarType::PERMANENT())

--- a/tests/Place/GeoCoordinatesProcessManagerTest.php
+++ b/tests/Place/GeoCoordinatesProcessManagerTest.php
@@ -181,7 +181,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new PlaceCreated(
                         '4b735422-2bf3-4241-aabb-d70609d2d1d3',
                         new Language('es'),
-                        new Title('Het depot'),
+                        'Het depot',
                         new EventType('mock.1', 'Mock'),
                         new Address(
                             new Street('Teststraat 1'),

--- a/tests/Place/PlaceRepositoryTest.php
+++ b/tests/Place/PlaceRepositoryTest.php
@@ -94,7 +94,7 @@ class PlaceRepositoryTest extends TestCase
             new PlaceCreated(
                 '41c94f16-9edf-4eaf-914a-cfc01336b66e',
                 new Language('nl'),
-                new Title('Test title 1'),
+                'Test title 1',
                 new EventType('0.0.0.1', 'Fake event type'),
                 new Address(
                     new Street('Kerkstraat 1'),
@@ -111,7 +111,7 @@ class PlaceRepositoryTest extends TestCase
             new PlaceCreated(
                 'aed3f3cd-e3de-4361-8e53-1099cce8fef6',
                 new Language('nl'),
-                new Title('Test title 2'),
+                'Test title 2',
                 new EventType('0.0.0.1', 'Fake event type'),
                 new Address(
                     new Street('Kerkstraat 2'),

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -249,7 +249,7 @@ class PlaceTest extends AggregateRootScenarioTestCase
                     new PlaceCreated(
                         'c5c1b435-0f3c-4b75-9f28-94d93be7078b',
                         new Language('nl'),
-                        new Title('Test place'),
+                        'Test place',
                         new EventType('0.1.1', 'Jeugdhuis'),
                         $originalAddress,
                         new Calendar(CalendarType::PERMANENT())
@@ -427,7 +427,7 @@ class PlaceTest extends AggregateRootScenarioTestCase
                     new PlaceCreated(
                         'c5c1b435-0f3c-4b75-9f28-94d93be7078b',
                         new Language('nl'),
-                        new Title('Test place'),
+                        'Test place',
                         new EventType('0.1.1', 'Jeugdhuis'),
                         $originalAddress,
                         new Calendar(CalendarType::PERMANENT())
@@ -622,7 +622,7 @@ class PlaceTest extends AggregateRootScenarioTestCase
         return  new PlaceCreated(
             $placeId,
             new Language('nl'),
-            new Title('Test place'),
+            'Test place',
             new EventType('0.1.1', 'Jeugdhuis'),
             $address,
             new Calendar(CalendarType::PERMANENT())

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -989,7 +989,7 @@ class HistoryProjectorTest extends TestCase
         return new PlaceCreated(
             'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
             new LegacyLanguage('en'),
-            new Title('Foo'),
+            'Foo',
             new EventType('1.8.2', 'PARTY!'),
             new Address(
                 new Street('acmelane 12'),

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -135,7 +135,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $placeCreated = new PlaceCreated(
             $id,
             new Language('en'),
-            new Title('some representative title'),
+            'some representative title',
             new EventType('0.50.4.0.0', 'concert'),
             $this->address,
             new Calendar(CalendarType::PERMANENT())
@@ -200,7 +200,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $placeCreated = new PlaceCreated(
             $id,
             new Language('en'),
-            new Title('some representative title'),
+            'some representative title',
             new EventType('0.50.4.0.0', 'concert'),
             $this->address,
             new Calendar(CalendarType::PERMANENT())
@@ -469,7 +469,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $placeCreated = new PlaceCreated(
             $placeId,
             new Language('en'),
-            new Title('some representative title'),
+            'some representative title',
             new EventType('0.50.4.0.0', 'concert'),
             $this->address,
             new Calendar(CalendarType::PERMANENT())

--- a/tests/Place/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Place/ReadModel/Permission/ProjectorTest.php
@@ -20,7 +20,6 @@ use CultuurNet\UDB3\Place\Events\OwnerChanged;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
-use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -128,7 +127,7 @@ final class ProjectorTest extends TestCase
         $payload = new PlaceCreated(
             $placeId,
             new Language('en'),
-            new Title('test 123'),
+            'test 123',
             new EventType('0.50.4.0.0', 'concert'),
             new Address(
                 new Street('Kerkstraat 69'),


### PR DESCRIPTION
### Changed
III-5912 Make Title a string in PlaceCreated

This is to prepare for the title length limit in the commands later.

---
Ticket: https://jira.uitdatabank.be/browse/III-5912
