### PR TITLE
III-5912 Place majorInfoUpdated, change title to string to prepare for length limitation

### DIFF
--- a/src/Place/Events/MajorInfoUpdated.php
+++ b/src/Place/Events/MajorInfoUpdated.php
@@ -13,14 +13,14 @@ use CultuurNet\UDB3\Title;
 
 final class MajorInfoUpdated extends PlaceEvent implements ConvertsToGranularEvents
 {
-    private Title $title;
+    private string $title;
     private EventType $eventType;
     private Address $address;
     private Calendar $calendar;
 
     final public function __construct(
         string $placeId,
-        Title $title,
+        string $title,
         EventType $eventType,
         Address $address,
         Calendar $calendar
@@ -33,7 +33,7 @@ final class MajorInfoUpdated extends PlaceEvent implements ConvertsToGranularEve
         $this->calendar = $calendar;
     }
 
-    public function getTitle(): Title
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -58,7 +58,7 @@ final class MajorInfoUpdated extends PlaceEvent implements ConvertsToGranularEve
         return array_values(
             array_filter(
                 [
-                    new TitleUpdated($this->placeId, $this->title),
+                    new TitleUpdated($this->placeId, new Title($this->title)),
                     new TypeUpdated($this->placeId, $this->eventType),
                     new AddressUpdated($this->placeId, $this->address),
                     new CalendarUpdated($this->placeId, $this->calendar),
@@ -70,7 +70,7 @@ final class MajorInfoUpdated extends PlaceEvent implements ConvertsToGranularEve
     public function serialize(): array
     {
         return parent::serialize() + [
-            'title' => $this->getTitle()->toString(),
+            'title' => $this->getTitle(),
             'event_type' => $this->getEventType()->serialize(),
             'address' => $this->getAddress()->serialize(),
             'calendar' => $this->getCalendar()->serialize(),
@@ -81,7 +81,7 @@ final class MajorInfoUpdated extends PlaceEvent implements ConvertsToGranularEve
     {
         return new static(
             $data['place_id'],
-            new Title($data['title']),
+            $data['title'],
             EventType::deserialize($data['event_type']),
             Address::deserialize($data['address']),
             Calendar::deserialize($data['calendar'])

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -153,7 +153,7 @@ class Place extends Offer
         $this->apply(
             new MajorInfoUpdated(
                 $this->placeId,
-                $title,
+                $title->toString(),
                 $eventType,
                 $address,
                 $calendar

--- a/tests/Place/CommandHandlerTest.php
+++ b/tests/Place/CommandHandlerTest.php
@@ -55,7 +55,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
             ->when(
                 new UpdateMajorInfo($id, $title, $eventType, $address, $calendar)
             )
-            ->then([new MajorInfoUpdated($id, $title, $eventType, $address, $calendar)]);
+            ->then([new MajorInfoUpdated($id, $title->toString(), $eventType, $address, $calendar)]);
     }
 
     /**

--- a/tests/Place/Events/MajorInfoUpdatedTest.php
+++ b/tests/Place/Events/MajorInfoUpdatedTest.php
@@ -26,7 +26,7 @@ final class MajorInfoUpdatedTest extends TestCase
 
         $event = new MajorInfoUpdated(
             $placeId,
-            new Title('Title'),
+            'Title',
             new EventType('0.14.0.0.0', 'Monument'),
             new Address(
                 new Street('Martelarenlaan 1'),

--- a/tests/Place/GeoCoordinatesProcessManagerTest.php
+++ b/tests/Place/GeoCoordinatesProcessManagerTest.php
@@ -25,7 +25,6 @@ use CultuurNet\UDB3\Place\Events\MajorInfoUpdated;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use CultuurNet\UDB3\Place\Events\PlaceUpdatedFromUDB2;
-use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -209,7 +208,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new MajorInfoUpdated(
                         '4b735422-2bf3-4241-aabb-d70609d2d1d3',
-                        new Title('Het depot'),
+                        'Het depot',
                         new EventType('mock.1', 'Mock'),
                         new Address(
                             new Street('Teststraat 1'),

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -746,7 +746,7 @@ class HistoryProjectorTest extends TestCase
     {
         $event = new MajorInfoUpdated(
             'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
-            new Title('title'),
+            'title',
             new EventType('0.0.0.0', 'event type'),
             new Address(
                 new Street('straat'),

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -45,7 +45,6 @@ use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use CultuurNet\UDB3\Place\Events\PlaceUpdatedFromUDB2;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
-use CultuurNet\UDB3\Title;
 use DateTimeInterface;
 use stdClass;
 
@@ -645,7 +644,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
     public function it_projects_the_updating_of_major_info(): void
     {
         $id = 'foo';
-        $title = new Title('new title');
+        $title = 'new title';
         $eventType = new EventType('0.50.4.0.1', 'concertnew');
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
@@ -912,7 +911,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
 
         $majorInfoUpdated = new MajorInfoUpdated(
             '3c4850d7-689a-4729-8c5f-5f6c172ba52d',
-            new Title('New title'),
+            'New title',
             new EventType('1.0.0.0', 'Mock'),
             new Address(
                 new Street('Natieplein 2'),


### PR DESCRIPTION
### Changed
III-5912 Make title a string in MajorInfoUpdated for Places

This is to prepare for the title length limit in the commands later.

---
Ticket: https://jira.uitdatabank.be/browse/III-5912
