### PR TITLE
III-6051 Make 4th argument nullable in ParsedAddress

### DIFF
--- a/src/Address/Parser/GeopuntAddressParser.php
+++ b/src/Address/Parser/GeopuntAddressParser.php
@@ -68,7 +68,12 @@ final class GeopuntAddressParser implements AddressParser, LoggerAwareInterface
                     'items' => [
                         'type' => 'object',
                         'properties' => [
-                            'Municipality' => ['type' => 'string'],
+                            'Municipality' => [
+                                'anyOf' => [
+                                    ['type' => 'string'],
+                                    ['type' => 'null'],
+                                ],
+                            ],
                             'Zipcode' => [
                                 'anyOf' => [
                                     ['type' => 'string'],

--- a/src/Address/Parser/ParsedAddress.php
+++ b/src/Address/Parser/ParsedAddress.php
@@ -9,9 +9,9 @@ final class ParsedAddress
     private ?string $thoroughfare;
     private ?string $houseNumber;
     private ?string $postalCode;
-    private string $municipality;
+    private ?string $municipality;
 
-    public function __construct(?string $thoroughfare, ?string $houseNumber, ?string $postalCode, string $municipality)
+    public function __construct(?string $thoroughfare, ?string $houseNumber, ?string $postalCode, ?string $municipality)
     {
         $this->thoroughfare = $thoroughfare;
         $this->houseNumber = $houseNumber;
@@ -34,7 +34,7 @@ final class ParsedAddress
         return $this->postalCode;
     }
 
-    public function getMunicipality(): string
+    public function getMunicipality(): ?string
     {
         return $this->municipality;
     }

--- a/tests/Address/Parser/GeopuntAddressParserTest.php
+++ b/tests/Address/Parser/GeopuntAddressParserTest.php
@@ -408,6 +408,52 @@ class GeopuntAddressParserTest extends TestCase
         $this->assertLogs();
     }
 
+    /**
+     * @test
+     */
+    public function it_can_handle_an_empty_municipality(): void
+    {
+        $address = 'Marguerite Durassquare, 1000, BE';
+
+        $expectedRequest = new Request(
+            'GET',
+            $this->baseUrl . 'Location?q=Marguerite%20Durassquare,%201000,%20BE'
+        );
+
+        $mockResponseData = [
+            'LocationResult' => [
+                [
+                    'Municipality' => null,
+                    'Zipcode' => '1000',
+                    'Thoroughfarename' => 'Marguerite Durassquare',
+                    'Housenumber' => null,
+                ],
+            ],
+        ];
+
+        $mockResponse = new Response(200, [], Json::encode($mockResponseData));
+
+        $this->httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($expectedRequest)
+            ->willReturn($mockResponse);
+
+        $this->expectedLogs->info('GET ' . $this->baseUrl . 'Location?q=Marguerite%20Durassquare,%201000,%20BE responded with status code 200 and body {"LocationResult":[{"Municipality":null,"Zipcode":"1000","Thoroughfarename":"Marguerite Durassquare","Housenumber":null}]}');
+        $this->expectedLogs->info('Successfully parsed response body.');
+
+        $expectedParsedAddress = new ParsedAddress(
+            'Marguerite Durassquare',
+            null,
+            '1000',
+            null
+        );
+
+        $actualParsedAddress = $this->geopuntAddressParser->parse($address);
+
+        $this->assertEquals($expectedParsedAddress, $actualParsedAddress);
+        $this->assertLogs();
+    }
+
     private function assertLogs(): void
     {
         $this->assertEquals($this->expectedLogs->getLogs(), $this->logger->getLogs());

--- a/tests/Address/Parser/GeopuntAddressParserTest.php
+++ b/tests/Address/Parser/GeopuntAddressParserTest.php
@@ -265,6 +265,7 @@ class GeopuntAddressParserTest extends TestCase
                 'errors' => [
                     '/LocationResult/0/Municipality' => [
                         0 => 'The data (integer) must match the type: string',
+                        1 => 'The data (integer) must match the type: null',
                     ],
                     '/LocationResult/0/Thoroughfarename' => [
                         0 => 'The data (boolean) must match the type: string',


### PR DESCRIPTION
### Changed

- `ParsedAddress`:  Make `municipality` nullable
- `GeopuntAddressParser`: add type nullable to `municipality`
- `GeopuntAddressParserTest`: add test for nullable Municipality

### Fixed

- No more errors for events with a `null` municipality

---
Ticket: https://jira.publiq.be/browse/III-6051
