### PR TITLE
Just a handy script to copy config from apidocs to UDB3 codebase

### DIFF
--- a/bin/copy-json-schema.php
+++ b/bin/copy-json-schema.php
@@ -1,0 +1,29 @@
+#!/usr/bin/env php
+<?php
+$sourceDir = '../apidocs/projects/uitdatabank/models';
+$destinationDir = 'vendor/publiq/udb3-json-schemas';
+
+function copyDirectory($src, $dst): void
+{
+    $dir = opendir($src);
+//    @mkdir($dst);
+    while (($file = readdir($dir)) !== false) {
+        if ($file === '.' || $file === '..') {
+            continue;
+        }
+
+        if (is_dir($src . '/' . $file)) {
+            copyDirectory($src . '/' . $file, $dst . '/' . $file);
+        } else {
+            copy($src . '/' . $file, $dst . '/' . $file);
+        }
+    }
+
+    closedir($dir);
+}
+
+// Copy the directory
+copyDirectory($sourceDir, $destinationDir);
+
+echo "Copied json schema from apidocs!" . PHP_EOL;
+

--- a/bin/copy-json-schema.php
+++ b/bin/copy-json-schema.php
@@ -25,5 +25,4 @@ function copyDirectory($src, $dst): void
 // Copy the directory
 copyDirectory($sourceDir, $destinationDir);
 
-echo "Copied json schema from apidocs!" . PHP_EOL;
-
+echo 'Copied json schema from apidocs!' . PHP_EOL;

--- a/bin/start-xdebug.sh
+++ b/bin/start-xdebug.sh
@@ -1,0 +1,1 @@
+export XDEBUG_MODE=debug XDEBUG_SESSION=1 PHP_IDE_CONFIG="serverName=host.docker.internal"


### PR DESCRIPTION
### Added
I added a small script in the bin/ dir to copy the json schemas from the apidocs repo to our codebase, handy for local development.
The script does assume apidocs & udb3-backend share the same root directory.
