### PR TITLE
III-6067 Bugfix - Duplicate places throws fatal error

### DIFF
--- a/src/Place/ReadModel/Duplicate/LookupDuplicatePlaceWithSapi3.php
+++ b/src/Place/ReadModel/Duplicate/LookupDuplicatePlaceWithSapi3.php
@@ -52,6 +52,7 @@ class LookupDuplicatePlaceWithSapi3 implements LookupDuplicatePlace
 
         // We have more than 1 result, lets do the call again with isDuplicate=false to see if without duplicates,
         // we only get 1 place back
+        $originalQuery = $query;
         $query .= '&isDuplicate=false';
 
         $results = $this->sapi3SearchService->search(
@@ -59,9 +60,7 @@ class LookupDuplicatePlaceWithSapi3 implements LookupDuplicatePlace
         );
 
         if ($results->getTotalItems() === 0) {
-            // This should be absolutely impossible to occur, but you never know.
-            // There is no clean solution in this case, we just give a fatal error to the user
-            throw ApiProblem::internalServerError('Duplicate places detected, but isDuplicate=false returns no duplicates.');
+            throw new MultipleDuplicatePlacesFound($originalQuery);
         }
 
         if ($results->getTotalItems() === 1) {

--- a/src/Place/ReadModel/Duplicate/LookupDuplicatePlaceWithSapi3.php
+++ b/src/Place/ReadModel/Duplicate/LookupDuplicatePlaceWithSapi3.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Place\ReadModel\Duplicate;
 
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Model\Place\Place;
 use CultuurNet\UDB3\Search\Sapi3SearchService;
 


### PR DESCRIPTION
### Added
The situation I thought "could never happen", happened a lot, which caused the code around duplicate places to throw a fatal error.
Solved this in a more elegant way.