### PR TITLE
III-6092 full update image events

### DIFF
--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -637,14 +637,16 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
         }
 
         foreach ($updatedImages as $updatedImage) {
-            $this->apply(
-                $this->createImageUpdatedEvent(
-                    $updatedImage->getMediaObjectId(),
-                    $updatedImage->getDescription(),
-                    $updatedImage->getCopyrightHolder(),
-                    $updatedImage->getLanguage()->getCode()
-                )
-            );
+            if ($this->updateImageAllowed($updatedImage->getMediaObjectId(), $updatedImage->getDescription(), $updatedImage->getCopyrightHolder())) {
+                $this->apply(
+                    $this->createImageUpdatedEvent(
+                        $updatedImage->getMediaObjectId(),
+                        $updatedImage->getDescription(),
+                        $updatedImage->getCopyrightHolder(),
+                        $updatedImage->getLanguage()->getCode()
+                    )
+                );
+            }
         }
 
         foreach ($removedImages as $removedImage) {

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -612,7 +612,11 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
     public function importImages(ImageCollection $imageCollection): void
     {
         $currentImageCollection = $this->images;
+
+        $oldMainImage = $this->images->getMain();
         $newMainImage = $imageCollection->getMain();
+
+        $selectNewMainImage = isset($oldMainImage, $newMainImage) && !$oldMainImage->getMediaObjectId()->sameAs($newMainImage->getMediaObjectId());
 
         $importImages = $imageCollection->toArray();
         $currentImages = $currentImageCollection->toArray();
@@ -653,7 +657,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
             $this->apply($this->createImageRemovedEvent($removedImage));
         }
 
-        if ($newMainImage) {
+        if ($selectNewMainImage) {
             $this->apply($this->createMainImageSelectedEvent($newMainImage));
         }
     }

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -152,7 +152,6 @@ class OfferTest extends AggregateRootScenarioTestCase
         $this->scenario
             ->given([
                 new ItemCreated($itemId),
-                new ImageAdded($itemId, $image),
                 new ImageAdded($itemId, $secondImage),
                 new MainImageSelected($itemId, $image),
             ])

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -125,6 +125,58 @@ class OfferTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
+     * @dataProvider imageCollectionDataProvider
+     */
+    public function it_should_not_create_events_for_unaltered_images(Image $image): void
+    {
+        $itemId = '77b4df58-b7e9-40cf-979f-ec741a072282';
+
+        $updatedImage = new Image(
+            new UUID('de305d54-75b4-431b-adb2-eb6b9e546014'),
+            new MIMEType('image/jpg'),
+            new Description('my updated pic'),
+            new CopyrightHolder('Dirk Dirkingn updated'),
+            new Url('http://foo.bar/media/my_pic.jpg'),
+            new LegacyLanguage('en')
+        );
+        $secondImage = new Image(
+            new UUID('837bd340-e939-4210-8af9-e4baedd0d44e'),
+            new MIMEType('image/jpg'),
+            new Description('my second pic'),
+            new CopyrightHolder('Dirk Dirkingn again'),
+            new Url('http://foo.bar/media/my_2nd_pic.jpg'),
+            new LegacyLanguage('en')
+        );
+        $updatedImageCollection = ImageCollection::fromArray([$updatedImage])->withMain($secondImage);
+
+        $this->scenario
+            ->given([
+                new ItemCreated($itemId),
+                new ImageAdded($itemId, $image),
+                new ImageAdded($itemId, $secondImage),
+                new MainImageSelected($itemId, $image),
+            ])
+            ->when(
+                function (Item $item) use ($updatedImageCollection): void {
+                    $item->importImages($updatedImageCollection);
+                    $item->importImages($updatedImageCollection);
+                    $item->importImages($updatedImageCollection);
+                }
+            )
+            ->then([
+                new ImageUpdated(
+                    $itemId,
+                    'de305d54-75b4-431b-adb2-eb6b9e546014',
+                    'my updated pic',
+                    'Dirk Dirkingn updated',
+                    'en'
+                ),
+                new MainImageSelected($itemId, $secondImage),
+            ]);
+    }
+
+    /**
+     * @test
      */
     public function it_updates_facilities_when_changed(): void
     {


### PR DESCRIPTION
### Changed

- `Offer`: `importImages()`: check if `mainImage` has been updated & check if `Images` have been changed.
- `OfferTest`: added Unit Test

### Fixed

A full update on the `events|places` endpoint no longer add multiple `ImageUpdated|MainImageSelected` Events, when nothing in the `Media` has changed.

---
Ticket: https://jira.publiq.be/browse/III-6092
