### PR TITLE
III-6098 Add purge command for `*permission_readmodel`

### DIFF
--- a/app/Console/Command/ReplayCommand.php
+++ b/app/Console/Command/ReplayCommand.php
@@ -132,7 +132,7 @@ final class ReplayCommand extends AbstractCommand
 
         if ($cdbids !== null) {
             foreach ($cdbids as $cdbid) {
-                $this->purgePermissionReadmodels($cdbid);
+                $this->purgeReadmodels($cdbid);
             }
         }
 
@@ -246,7 +246,7 @@ final class ReplayCommand extends AbstractCommand
         return $eventStream;
     }
 
-    private function purgePermissionReadmodels(string $cdbid): void
+    private function purgeReadmodels(string $cdbid): void
     {
         foreach (self::TABLES_TO_PURGE as $tableName => $columnName) {
             $this->connection->delete(

--- a/app/Console/Command/ReplayCommand.php
+++ b/app/Console/Command/ReplayCommand.php
@@ -30,18 +30,13 @@ final class ReplayCommand extends AbstractCommand
 {
     private const TABLES_TO_PURGE = [
         'event_permission_readmodel' => 'event_id',
-        'event_relations' => '',
-        'labels_json' => 'place_id',
-        'label_roles' => '',
-        'labels_relations' => '',
-        'organizer_permission_readmodel' => '',
-        'place_permission_readmodel'=> '',
-        'place_relations' => '',
-        'role_permissions' => '',
-        'roles_search_v3' => '',
-        'user_roles' => '',
-        'offer_metadata' => '',
+        'event_relations' => 'event',
+        'offer_metadata' => 'id',
+        'organizer_permission_readmodel' => 'organizer_id',
+        'place_permission_readmodel'=> 'place_id',
+        'place_relations' => 'place',
     ];
+
     public const OPTION_START_ID = 'start-id';
     public const OPTION_DELAY = 'delay';
     public const OPTION_CDBID = 'cdbid';

--- a/app/Console/Command/ReplayCommand.php
+++ b/app/Console/Command/ReplayCommand.php
@@ -133,7 +133,7 @@ final class ReplayCommand extends AbstractCommand
         // since we cannot catch errors when multiple cdbids are giving
         // and this Command is mostly run via Jenkins with exactly 1 cdbid
         // we will only fix this for the first cdbid
-        if ($cdbids !== null && $cdbids[0] !== null) {
+        if ($cdbids !== null && sizeof($cdbids) === 1) {
             $this->purgeReadmodels($cdbids[0]);
         }
 

--- a/app/Console/Command/ReplayCommand.php
+++ b/app/Console/Command/ReplayCommand.php
@@ -28,6 +28,20 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 final class ReplayCommand extends AbstractCommand
 {
+    private const TABLES_TO_PURGE = [
+        'event_permission_readmodel' => 'event_id',
+        'event_relations' => '',
+        'labels_json' => 'place_id',
+        'label_roles' => '',
+        'labels_relations' => '',
+        'organizer_permission_readmodel' => '',
+        'place_permission_readmodel'=> '',
+        'place_relations' => '',
+        'role_permissions' => '',
+        'roles_search_v3' => '',
+        'user_roles' => '',
+        'offer_metadata' => '',
+    ];
     public const OPTION_START_ID = 'start-id';
     public const OPTION_DELAY = 'delay';
     public const OPTION_CDBID = 'cdbid';
@@ -239,18 +253,12 @@ final class ReplayCommand extends AbstractCommand
 
     private function purgePermissionReadmodels(string $cdbid): void
     {
-        $this->connection->delete(
-            'event_permission_readmodel',
-            ['event_id' => $cdbid]
-        );
-        $this->connection->delete(
-            'place_permission_readmodel',
-            ['place_id' => $cdbid]
-        );
-        $this->connection->delete(
-            'organizer_permission_readmodel',
-            ['organizer_id' => $cdbid]
-        );
+        foreach (self::TABLES_TO_PURGE as $tableName => $columnName) {
+            $this->connection->delete(
+                $tableName,
+                [$columnName => $cdbid]
+            );
+        }
     }
 
     private function getAggregateType(InputInterface $input): ?AggregateType

--- a/app/Console/Command/ReplayCommand.php
+++ b/app/Console/Command/ReplayCommand.php
@@ -121,6 +121,12 @@ final class ReplayCommand extends AbstractCommand
 
         $cdbids = $input->getOption(self::OPTION_CDBID);
 
+        if ($cdbids !== null) {
+            foreach ($cdbids as $cdbid) {
+                $this->purgePermissionReadmodels($cdbid);
+            }
+        }
+
         $stream = $this->getEventStream($startId, $aggregateType, $cdbids);
 
         ReplayFlaggingMiddleware::startReplayMode();
@@ -229,6 +235,22 @@ final class ReplayCommand extends AbstractCommand
         }
 
         return $eventStream;
+    }
+
+    private function purgePermissionReadmodels(string $cdbid): void
+    {
+        $this->connection->delete(
+            'event_permission_readmodel',
+            ['event_id' => $cdbid]
+        );
+        $this->connection->delete(
+            'place_permission_readmodel',
+            ['place_id' => $cdbid]
+        );
+        $this->connection->delete(
+            'organizer_permission_readmodel',
+            ['organizer_id' => $cdbid]
+        );
     }
 
     private function getAggregateType(InputInterface $input): ?AggregateType

--- a/app/Console/Command/ReplayCommand.php
+++ b/app/Console/Command/ReplayCommand.php
@@ -130,10 +130,11 @@ final class ReplayCommand extends AbstractCommand
 
         $cdbids = $input->getOption(self::OPTION_CDBID);
 
-        if ($cdbids !== null) {
-            foreach ($cdbids as $cdbid) {
-                $this->purgeReadmodels($cdbid);
-            }
+        // since we cannot catch errors when multiple cdbids are giving
+        // and this Command is mostly run via Jenkins with exactly 1 cdbid
+        // we will only fix this for the first cdbid
+        if ($cdbids !== null && $cdbids[0] !== null) {
+            $this->purgeReadmodels($cdbids[0]);
         }
 
         $stream = $this->getEventStream($startId, $aggregateType, $cdbids);


### PR DESCRIPTION
### Changed

- `ReplayCommand`: Add purge for `events`, `places` & `organizers` when replaying a item.

### Fixed

- `Offers` & `Organizers` can now be replayed without throwing an `UniqueConstraintException`

### Note:
I have also checked `app/Console/Command/PurgeModelCommand.php`, but that still seems up-to-date.

---
Ticket: https://jira.publiq.be/browse/III-6098
