### PR TITLE
III-5912 Remove Title from Apply methods

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -209,7 +209,7 @@ final class Event extends Offer
     protected function applyEventCreated(EventCreated $eventCreated): void
     {
         $this->eventId = $eventCreated->getEventId();
-        $this->titles[$eventCreated->getMainLanguage()->getCode()] = new Title($eventCreated->getTitle());
+        $this->titles[$eventCreated->getMainLanguage()->getCode()] = $eventCreated->getTitle();
         $this->calendar = $eventCreated->getCalendar();
         $this->audience = new Audience(AudienceType::everyone());
         $this->contactPoint = new ContactPoint();

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -99,7 +99,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
     protected ?PriceInfo $priceInfo = null;
 
     /**
-     * @var Title[]
+     * @var string[]
      */
     protected array $titles;
 
@@ -332,12 +332,12 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     public function applyTitleTranslated(AbstractTitleTranslated $titleTranslated): void
     {
-        $this->titles[$titleTranslated->getLanguage()->getCode()] = new Title($titleTranslated->getTitle());
+        $this->titles[$titleTranslated->getLanguage()->getCode()] = $titleTranslated->getTitle();
     }
 
     public function applyTitleUpdated(AbstractTitleUpdated $titleUpdated): void
     {
-        $this->titles[$this->mainLanguage->getCode()] = new Title($titleUpdated->getTitle());
+        $this->titles[$this->mainLanguage->getCode()] = $titleUpdated->getTitle();
     }
 
     public function updateDescription(Description $description, LegacyLanguage $language): void
@@ -866,7 +866,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
         $languageCode = $language->getCode();
 
         return !isset($this->titles[$languageCode]) ||
-            !$title->sameAs($this->titles[$languageCode]);
+            $title->toString() !== $this->titles[$languageCode];
     }
 
     private function isDescriptionChanged(Description $description, LegacyLanguage $language): bool

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -63,7 +63,7 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
     private ?Url $website = null;
 
     /**
-     * @var Title[]
+     * @var string[]
      */
     private array $titles;
 
@@ -564,7 +564,7 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
 
         $this->mainLanguage = new Language('nl');
 
-        $this->setTitle(new Title($organizerCreated->getTitle()), $this->mainLanguage);
+        $this->setTitle($organizerCreated->getTitle(), $this->mainLanguage);
     }
 
     protected function applyOrganizerCreatedWithUniqueWebsite(OrganizerCreatedWithUniqueWebsite $organizerCreated): void
@@ -576,7 +576,7 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
         $this->website = new Url($organizerCreated->getWebsite());
 
         $this->setTitle(
-            new Title($organizerCreated->getTitle()),
+            $organizerCreated->getTitle(),
             $this->mainLanguage
         );
     }
@@ -597,7 +597,8 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
             $organizerImported->getCdbXml()
         );
 
-        $this->setTitle($this->getTitle($actor), $this->mainLanguage);
+        $title = $this->getTitle($actor) ? $this->getTitle($actor)->toString() : '';
+        $this->setTitle($title, $this->mainLanguage);
 
         $this->labels = LabelsArray::createFromKeywords($actor->getKeywords(true));
     }
@@ -615,7 +616,8 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
             $organizerUpdatedFromUDB2->getCdbXml()
         );
 
-        $this->setTitle($this->getTitle($actor), $this->mainLanguage);
+        $title = $this->getTitle($actor) ? $this->getTitle($actor)->toString() : '';
+        $this->setTitle($title, $this->mainLanguage);
 
         $this->labels = LabelsArray::createFromKeywords($actor->getKeywords(true));
     }
@@ -628,7 +630,7 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
     protected function applyTitleUpdated(TitleUpdated $titleUpdated): void
     {
         $this->setTitle(
-            new Title($titleUpdated->getTitle()),
+            $titleUpdated->getTitle(),//todo
             $this->mainLanguage
         );
     }
@@ -636,7 +638,7 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
     protected function applyTitleTranslated(TitleTranslated $titleTranslated): void
     {
         $this->setTitle(
-            new Title($titleTranslated->getTitle()),
+            $titleTranslated->getTitle(),
             new Language($titleTranslated->getLanguage())
         );
     }
@@ -785,15 +787,17 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
         return null;
     }
 
-    private function setTitle(Title $title, Language $language): void
+    private function setTitle(string $title, Language $language): void
     {
         $this->titles[$language->toString()] = $title;
     }
 
     private function isTitleChanged(Title $title, Language $language): bool
     {
-        return !isset($this->titles[$language->getCode()]) ||
-            $title->toString() !== $this->titles[$language->getCode()]->toString();
+        $languageCode = $language->getCode();
+
+        return !isset($this->titles[$languageCode]) ||
+            $title->toString() !== $this->titles[$languageCode];
     }
 
     private function setAddress(Address $address, Language $language): void

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -597,8 +597,7 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
             $organizerImported->getCdbXml()
         );
 
-        $title = $this->getTitle($actor) ? $this->getTitle($actor)->toString() : '';
-        $this->setTitle($title, $this->mainLanguage);
+        $this->setTitle($this->getTitle($actor), $this->mainLanguage);
 
         $this->labels = LabelsArray::createFromKeywords($actor->getKeywords(true));
     }
@@ -616,8 +615,7 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
             $organizerUpdatedFromUDB2->getCdbXml()
         );
 
-        $title = $this->getTitle($actor) ? $this->getTitle($actor)->toString() : '';
-        $this->setTitle($title, $this->mainLanguage);
+        $this->setTitle($this->getTitle($actor), $this->mainLanguage);
 
         $this->labels = LabelsArray::createFromKeywords($actor->getKeywords(true));
     }
@@ -630,7 +628,7 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
     protected function applyTitleUpdated(TitleUpdated $titleUpdated): void
     {
         $this->setTitle(
-            $titleUpdated->getTitle(),//todo
+            $titleUpdated->getTitle(),
             $this->mainLanguage
         );
     }
@@ -772,7 +770,7 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
         $this->workflowStatus = WorkflowStatus::DELETED();
     }
 
-    private function getTitle(\CultureFeed_Cdb_Item_Actor $actor): ?Title
+    private function getTitle(\CultureFeed_Cdb_Item_Actor $actor): string
     {
         $details = $actor->getDetails();
         $details->rewind();
@@ -781,10 +779,10 @@ class Organizer extends EventSourcedAggregateRoot implements LabelAwareAggregate
         // properties from which in UDB3 are not any longer considered
         // to be language specific.
         if ($details->valid()) {
-            return new Title($details->current()->getTitle());
+            return $details->current()->getTitle();
         }
 
-        return null;
+        return '';
     }
 
     private function setTitle(string $title, Language $language): void

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -134,7 +134,7 @@ class Place extends Offer
     protected function applyPlaceCreated(PlaceCreated $placeCreated): void
     {
         $this->mainLanguage = $placeCreated->getMainLanguage();
-        $this->titles[$this->mainLanguage->getCode()] = new Title($placeCreated->getTitle());
+        $this->titles[$this->mainLanguage->getCode()] = $placeCreated->getTitle();
         $this->calendar = $placeCreated->getCalendar();
         $this->contactPoint = new ContactPoint();
         $this->bookingInfo = new BookingInfo();


### PR DESCRIPTION
### Changed
Removed the typed Title from all apply() methods, instead working with string.

### How I tested?
- Created an org/place/event with a very long title. (disabled length check)
- Enable length check
- Try to update org/place/event -> success!

---
Ticket: https://jira.uitdatabank.be/browse/III-5912
