### PR TITLE
III-6094 Update place geocode command

### DIFF
--- a/app/Console/Command/AbstractGeocodeCommand.php
+++ b/app/Console/Command/AbstractGeocodeCommand.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 abstract class AbstractGeocodeCommand extends AbstractCommand
 {
+    private const OPT_ALL = 'all';
+
     private ResultsGeneratorInterface $searchResultsGenerator;
 
     private DocumentRepository $documentRepository;
@@ -51,6 +53,12 @@ abstract class AbstractGeocodeCommand extends AbstractCommand
                 null,
                 InputOption::VALUE_NONE,
                 'Skip confirmation.'
+            )
+            ->addOption(
+                self::OPT_ALL,
+                null,
+                InputOption::VALUE_NONE,
+                'Update all places that are not rejected or deleted.'
             );
     }
 
@@ -85,7 +93,7 @@ abstract class AbstractGeocodeCommand extends AbstractCommand
 
     private function geocodeByQuery(InputInterface $input, OutputInterface $output): int
     {
-        $query = $this->getQueryForMissingCoordinates();
+        $query = $this->getQueryForMissingCoordinates($input->getOption(self::OPT_ALL));
         $count = $this->searchResultsGenerator->count($query);
 
         if ($count === 0) {
@@ -134,5 +142,5 @@ abstract class AbstractGeocodeCommand extends AbstractCommand
 
     abstract protected function dispatchGeocodingCommand(string $itemId, OutputInterface $output): void;
 
-    abstract protected function getQueryForMissingCoordinates(): string;
+    abstract protected function getQueryForMissingCoordinates(bool $all): string;
 }

--- a/app/Console/Command/AbstractGeocodeCommand.php
+++ b/app/Console/Command/AbstractGeocodeCommand.php
@@ -58,7 +58,7 @@ abstract class AbstractGeocodeCommand extends AbstractCommand
                 self::OPT_ALL,
                 null,
                 InputOption::VALUE_NONE,
-                'Update all places that are not rejected or deleted.'
+                'Update all items that are not rejected or deleted.'
             );
     }
 

--- a/app/Console/Command/GeocodeEventCommand.php
+++ b/app/Console/Command/GeocodeEventCommand.php
@@ -19,10 +19,15 @@ class GeocodeEventCommand extends AbstractGeocodeCommand
             ->setDescription('Geocode events with missing or outdated coordinates.');
     }
 
-    protected function getQueryForMissingCoordinates(): string
+    protected function getQueryForMissingCoordinates(bool $all): string
     {
-        // Only geo-code events without location id. Events with a location id can only be geo-coded by geo-coding the
+        // Only geocode events without location id. Events with a location id can only be geocoded by geocoding the
         // linked place.
+
+        if ($all) {
+            return '_exists_:address NOT(_exists_:location.id OR workflowStatus:DELETED OR workflowStatus:REJECTED)';
+        }
+
         return '_exists:address NOT(_exists_:geo OR _exists_:location.id OR workflowStatus:DELETED OR workflowStatus:REJECTED)';
     }
 

--- a/app/Console/Command/GeocodeOrganizerCommand.php
+++ b/app/Console/Command/GeocodeOrganizerCommand.php
@@ -19,8 +19,12 @@ class GeocodeOrganizerCommand extends AbstractGeocodeCommand
             ->setDescription('Geocode organizers with missing or outdated coordinates.');
     }
 
-    protected function getQueryForMissingCoordinates(): string
+    protected function getQueryForMissingCoordinates(bool $all): string
     {
+        if ($all) {
+            return '_exists_:address NOT(workflowStatus:DELETED OR workflowStatus:REJECTED)';
+        }
+
         return '_exists_:address NOT(_exists_:geo OR workflowStatus:DELETED OR workflowStatus:REJECTED)';
     }
 

--- a/app/Console/Command/GeocodePlaceCommand.php
+++ b/app/Console/Command/GeocodePlaceCommand.php
@@ -19,8 +19,12 @@ class GeocodePlaceCommand extends AbstractGeocodeCommand
             ->setDescription('Geocode places with missing or outdated coordinates.');
     }
 
-    protected function getQueryForMissingCoordinates(): string
+    protected function getQueryForMissingCoordinates(bool $all): string
     {
+        if ($all) {
+            return '_exists_:address NOT(workflowStatus:DELETED OR workflowStatus:REJECTED)';
+        }
+
         return '_exists_:address NOT(_exists_:geo OR workflowStatus:DELETED OR workflowStatus:REJECTED)';
     }
 


### PR DESCRIPTION
### Changed
Added an option called "all", that forces the script to update all entities geocordinates, instead of only the ones with missing coordinates.

The following commands have changed:
- place:geocode
- event:geocode
- organizer:geocode

---
Ticket: https://jira.uitdatabank.be/browse/III-6094