### PR TITLE
III-6034 bugfix set availableTo to endDate on most TypeUpdated

### DIFF
--- a/features/event/update.feature
+++ b/features/event/update.feature
@@ -477,7 +477,6 @@ Feature: Test the UDB3 events API
   Scenario: Update event type from type that is available till start
     When I create a place from "places/place.json" and save the "url" as "placeUrl"
     And I create an event from "events/event-with-eventtype-lessenreeks.json" and save the "url" as "eventUrl"
-    And show me the unparsed response
     And I get the event at "%{eventUrl}"
     Then the JSON response at "availableTo" should be "2021-05-17T08:00:00+00:00"
     When I send a PUT request to "%{eventUrl}/type/0.50.4.0.0"

--- a/features/event/update.feature
+++ b/features/event/update.feature
@@ -475,12 +475,14 @@ Feature: Test the UDB3 events API
     And the JSON response at "terms/1/id" should be "0.57.0.0.0"
 
   Scenario: Update event type from type that is available till start
-    When I create an event from "events/event-with-eventtype-lessenreeks.json" and save the "url" as "eventUrl"
-    And I get the event at "eventUrl"
-    Then the JSON response at "availableTo" should be "2020-05-05T18:00:00+00:00"
+    When I create a place from "places/place.json" and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-eventtype-lessenreeks.json" and save the "url" as "eventUrl"
+    And show me the unparsed response
+    And I get the event at "%{eventUrl}"
+    Then the JSON response at "availableTo" should be "2021-05-17T08:00:00+00:00"
     When I send a PUT request to "%{eventUrl}/type/0.50.4.0.0"
-    And I get the event at "eventUrl"
-    Then the JSON response at "availableTo" should be "2020-05-12T21:00:00+00:00"
+    And I get the event at "%{eventUrl}"
+    Then the JSON response at "availableTo" should be "2021-05-18T22:00:00+00:00"
     And the JSON response at "terms/1/id" should be "0.50.4.0.0"
 
   Scenario: Update event type with term id that is not an eventtype

--- a/features/event/update.feature
+++ b/features/event/update.feature
@@ -474,6 +474,15 @@ Feature: Test the UDB3 events API
     Then the JSON response at "availableTo" should be "2020-05-05T18:00:00+00:00"
     And the JSON response at "terms/1/id" should be "0.57.0.0.0"
 
+  Scenario: Update event type from type that is available till start
+    When I create an event from "events/event-with-eventtype-lessenreeks.json" and save the "url" as "eventUrl"
+    And I get the event at "eventUrl"
+    Then the JSON response at "availableTo" should be "2020-05-05T18:00:00+00:00"
+    When I send a PUT request to "%{eventUrl}/type/0.50.4.0.0"
+    And I get the event at "eventUrl"
+    Then the JSON response at "availableTo" should be "2020-05-12T21:00:00+00:00"
+    And the JSON response at "terms/1/id" should be "0.50.4.0.0"
+
   Scenario: Update event type with term id that is not an eventtype
     When I send a PUT request to "/events/%{uuid_testevent}/type/1.17.0.0.0"
     Then the response status should be "404"

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -383,7 +383,7 @@ final class EventLDProjector extends OfferLDProjector implements
         } else {
             $offerLd->availableTo = $offerLd->endDate ?? $offerLd->availableTo;
         }
-        return $document->withBody($offerLd);
+        return $this->updateTerm($document->withBody($offerLd), $typeUpdated->getType());
     }
 
     private function getEventType(\stdClass $eventJsonLD): ?EventType

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -376,14 +376,14 @@ final class EventLDProjector extends OfferLDProjector implements
     protected function applyTypeUpdated(AbstractTypeUpdated $typeUpdated): JsonDocument
     {
         $document = $this->loadDocumentFromRepository($typeUpdated);
+        $offerLd = $document->getBody();
 
         if (EventTypeResolver::isOnlyAvailableUntilStartDate($typeUpdated->getType())) {
-            $offerLd = $document->getBody();
             $offerLd->availableTo = $offerLd->startDate ?? $offerLd->availableTo;
-            $document = $document->withBody($offerLd);
+        } else {
+            $offerLd->availableTo = $offerLd->endDate ?? $offerLd->availableTo;
         }
-
-        return $this->updateTerm($document, $typeUpdated->getType());
+        return $document->withBody($offerLd);
     }
 
     private function getEventType(\stdClass $eventJsonLD): ?EventType

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -1596,7 +1596,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
      * @test
      * @dataProvider typesThatAreAvailableTillStart
      */
-    public function it_updates_available_to_for_selected_types_on_type_updated(string $termId): void
+    public function it_sets_available_to_start_date_for_selected_types_on_type_updated(string $termId): void
     {
         $eventId = '1a08516e-aba4-47f0-887e-df37b61a1e8d';
 

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -1644,6 +1644,56 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
     /**
      * @test
+     * @dataProvider typesThatAreAvailableTillStart
+     */
+    public function it_sets_available_to_end_date_on_type_updated_from_selected_types(string $termId, string $termName): void
+    {
+        $eventId = '1a08516e-aba4-47f0-887e-df37b61a1e8d';
+
+        $eventThatShouldAvailableTillStart = new JsonDocument(
+            $eventId,
+            Json::encode([
+                '@id' => $eventId,
+                '@type' => 'event',
+                'calendar' => [
+                    'calendarType' => 'single',
+                    'timeSpans' => [
+                        [
+                            'start' => '2018-01-01T12:00:00+01:00',
+                            'end' => '2020-01-01T12:00:00+01:00',
+                        ],
+                    ],
+                ],
+                'startDate' => '2018-01-01T12:00:00+01:00',
+                'endDate' => '2020-01-01T12:00:00+01:00',
+                'availableTo' => '2018-01-01T12:00:00+01:00',
+                'terms' => [
+                    (object) [
+                        'id' => $termId,
+                        'label' => $termName,
+                        'domain' => 'theme',
+                    ],
+                    (object) [
+                        'id' => '0.7.0.0.0',
+                        'label' => 'Begeleide uitstap of rondleiding',
+                        'domain' => 'eventtype',
+                    ],
+                ],
+            ])
+        );
+        $this->documentRepository->save($eventThatShouldAvailableTillStart);
+
+        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
+
+        $typeUpdated = new TypeUpdated($eventId, (new EventTypeResolver())->byId('0.50.4.0.0'));
+
+        $updatedItem = $this->project($typeUpdated, $eventId);
+
+        $this->assertEquals($endDate->format(DATE_ATOM), $updatedItem->availableTo);
+    }
+
+    /**
+     * @test
      */
     public function it_keeps_available_to_for_standard_types_on_type_updated(): void
     {


### PR DESCRIPTION
### Changed

- `EventLDProjector`: Add logic to change `availableTo` to `endDate` when `TypeUpdated` happens from a `Kamp of Vakantie` or `Lessenreeks` to a Type that's available till the endDate.

### Added
- Unit Test for this bug
- Feature test for this bug

### Fixed

- Correct `availableTo`, when changing from a type that's available till start

---
Ticket: https://jira.publiq.be/browse/III-6034
