### PR TITLE
III-6109 Make batchscript to loop over other script

### DIFF
--- a/app/Console/Command/ExecuteCommandFromCsv.php
+++ b/app/Console/Command/ExecuteCommandFromCsv.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
@@ -15,6 +16,8 @@ class ExecuteCommandFromCsv extends Command
 {
     private const FILE = 'file';
     private const COMMAND = 'script';
+    private const SKIP_HEADERS = 'skip-headers';
+
     protected static $defaultName = 'execute-command-from-csv';
 
     protected function configure(): void
@@ -22,7 +25,8 @@ class ExecuteCommandFromCsv extends Command
         $this
             ->setDescription('Execute a CLI command for each row in a CSV file')
             ->addArgument(self::FILE, InputArgument::REQUIRED, 'The path to the CSV file')
-            ->addArgument(self::COMMAND, InputArgument::REQUIRED, 'The CLI command to execute. You can use %1, %2, ... as a placeholder for the arguments/options in the command.');
+            ->addArgument(self::COMMAND, InputArgument::REQUIRED, 'The CLI command to execute. You can use %1, %2, ... as a placeholder for the arguments/options in the command.')
+            ->addOption(self::SKIP_HEADERS, null,InputOption::VALUE_NONE, 'Skip the first row of the csv, because it contains headers');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -40,10 +44,10 @@ class ExecuteCommandFromCsv extends Command
         $progressBar = new ProgressBar($output, count(file($file)));
         $progressBar->start();
 
-        $firstRow = true;
+        $skipFirstRow = $input->getOption(self::SKIP_HEADERS);
         while (($arguments = fgetcsv($handle)) !== false) {
-            if ($firstRow) {
-                $firstRow = false;
+            if ($skipFirstRow) {
+                $skipFirstRow = false;
                 continue;
             }
 

--- a/app/Console/Command/ExecuteCommandFromCsv.php
+++ b/app/Console/Command/ExecuteCommandFromCsv.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+class ExecuteCommandFromCsv extends Command
+{
+    private const FILE = 'file';
+    private const COMMAND = 'script';
+    protected static $defaultName = 'execute-command-from-csv';
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Execute a CLI command for each row in a CSV file')
+            ->addArgument(self::FILE, InputArgument::REQUIRED, 'The path to the CSV file')
+            ->addArgument(self::COMMAND, InputArgument::REQUIRED, 'The CLI command to execute. You can use %1, %2, ... as a placeholder for the arguments/options in the command.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $file = $input->getArgument(self::FILE);
+        $command = 'bin/udb3.php ' . $input->getArgument(self::COMMAND);
+
+        if (!file_exists($file) || !is_readable($file)) {
+            $output->writeln(sprintf("<error>Could not find file '%s'</error>", $file));
+            return 0;
+        }
+
+        $handle = fopen($file, 'rb');
+
+        $progressBar = new ProgressBar($output, count(file($file)));
+        $progressBar->start();
+
+        $firstRow = true;
+        while (($arguments = fgetcsv($handle)) !== false) {
+            if ($firstRow) {
+                $firstRow = false;
+                continue;
+            }
+
+            $commandWithParam = $this->getCommandWithArguments($command, $arguments);
+
+            $process = Process::fromShellCommandline($commandWithParam);
+            $process->run();
+
+            if ($process->isSuccessful()) {
+                $output->writeln(sprintf('<info>Command executed successfully: %s</info>', $commandWithParam));
+            } else {
+                $output->writeln(sprintf('<error>Failed to execute command: %s</error>', $commandWithParam));
+                $output->writeln(sprintf('<error>Error: %s</error>', $process->getErrorOutput()));
+            }
+
+            $progressBar->advance();
+        }
+
+        fclose($handle);
+        $progressBar->finish();
+
+        return 1;
+    }
+
+    private function getCommandWithArguments(string $command, array $arguments): string
+    {
+        $commandWithParam = $command;
+        foreach ($arguments as $i => $argument) {
+            $commandWithParam = str_replace('%' . $i, escapeshellarg($argument), $commandWithParam);
+        }
+
+        return $commandWithParam;
+    }
+}

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Console\Command\ConvertDescriptionToEducationalDescriptionFo
 use CultuurNet\UDB3\Console\Command\EventAncestorsCommand;
 use CultuurNet\UDB3\Console\Command\ExcludeInvalidLabels;
 use CultuurNet\UDB3\Console\Command\ExcludeLabel;
+use CultuurNet\UDB3\Console\Command\ExecuteCommandFromCsv;
 use CultuurNet\UDB3\Console\Command\FindOutOfSyncProjections;
 use CultuurNet\UDB3\Console\Command\FireProjectedToJSONLDCommand;
 use CultuurNet\UDB3\Console\Command\FireProjectedToJSONLDForRelationsCommand;
@@ -83,6 +84,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         'console.offer:import-auto-classification-labels',
         'console.article:replace-publisher',
         'console.organizer:convert-educational-description',
+        'console.execute-command-from-csv',
     ];
 
     protected function getProvidedServiceNames(): array
@@ -378,6 +380,11 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
                 $container->get(OrganizersSapi3SearchService::class),
                 new CacheDocumentRepository($container->get('organizer_jsonld_cache'))
             )
+        );
+
+        $container->addShared(
+            'console.execute-command-from-csv',
+            fn () => new ExecuteCommandFromCsv()
         );
     }
 }


### PR DESCRIPTION
### Added
I made a batchscript that accepts a csv, loops over it and then runs a different shell command for each row in the file.
It is possible to pass columns as arguments by using a placeholder %1, %2, ...

Example:   bin/udb3.php execute-command-from-csv input.csv "place:delete %1 %2"

### Why?
Idea is for duplicate places to take the CSV from Frederic and delete all places in clusters (except the canonical), and we are going to do this one at a time. So other command "place:delete".
I did write this so it can be reused for different commands.

---
Ticket: https://jira.uitdatabank.be/browse/III-6109
