### PR TITLE
Fix geocoding command when place has no address

### DIFF
--- a/app/Console/Command/GeocodePlaceCommand.php
+++ b/app/Console/Command/GeocodePlaceCommand.php
@@ -34,11 +34,16 @@ class GeocodePlaceCommand extends AbstractGeocodeCommand
 
         $jsonLd = Json::decodeAssociatively($document->getRawBody());
 
+        if (!isset($jsonLd['address'])) {
+            $output->writeln("Skipping {$placeId}. (JSON-LD does not contain an address.)");
+            return;
+        }
+
         $addressLanguage = $jsonLd->mainLanguage ?? 'nl';
 
         if (!isset($jsonLd['address'][$addressLanguage])) {
             // Some places have an address in another language then the main language or `nl`
-            $addressLanguage = array_key_first($jsonLd['address'] ?? []);
+            $addressLanguage = array_key_first($jsonLd['address']);
             if ($addressLanguage === null) {
                 $output->writeln("Skipping {$placeId}. (JSON-LD does not contain an address for {$addressLanguage}.)");
                 return;

--- a/app/Console/Command/GeocodePlaceCommand.php
+++ b/app/Console/Command/GeocodePlaceCommand.php
@@ -38,7 +38,7 @@ class GeocodePlaceCommand extends AbstractGeocodeCommand
 
         if (!isset($jsonLd['address'][$addressLanguage])) {
             // Some places have an address in another language then the main language or `nl`
-            $addressLanguage = array_key_first($jsonLd['address']);
+            $addressLanguage = array_key_first($jsonLd['address'] ?: []);
             if ($addressLanguage === null) {
                 $output->writeln("Skipping {$placeId}. (JSON-LD does not contain an address for {$addressLanguage}.)");
                 return;

--- a/app/Console/Command/GeocodePlaceCommand.php
+++ b/app/Console/Command/GeocodePlaceCommand.php
@@ -38,7 +38,7 @@ class GeocodePlaceCommand extends AbstractGeocodeCommand
 
         if (!isset($jsonLd['address'][$addressLanguage])) {
             // Some places have an address in another language then the main language or `nl`
-            $addressLanguage = array_key_first($jsonLd['address'] ?: []);
+            $addressLanguage = array_key_first($jsonLd['address'] ?? []);
             if ($addressLanguage === null) {
                 $output->writeln("Skipping {$placeId}. (JSON-LD does not contain an address for {$addressLanguage}.)");
                 return;


### PR DESCRIPTION
### Changed
There is a minor bug with the geocoding event, some places do not have an address and the script throws an ugly error about this.
I now catch this in a more elegant solution.