### PR TITLE
III-6117 Add id to response create saved searches

### DIFF
--- a/app/SavedSearches/SavedSearchesServiceProvider.php
+++ b/app/SavedSearches/SavedSearchesServiceProvider.php
@@ -40,7 +40,6 @@ final class SavedSearchesServiceProvider extends AbstractServiceProvider
                 return new UDB3SavedSearchRepository(
                     $container->get('dbal_connection'),
                     'saved_searches_sapi3',
-                    new Version4Generator(),
                     $container->get(CurrentUser::class)->getId()
                 );
             }
@@ -83,7 +82,8 @@ final class SavedSearchesServiceProvider extends AbstractServiceProvider
             function () use ($container) {
                 return new CreateSavedSearchRequestHandler(
                     $container->get(CurrentUser::class)->getId(),
-                    $container->get('event_command_bus')
+                    $container->get('event_command_bus'),
+                    new Version4Generator(),
                 );
             }
         );

--- a/features/saved_searches/create.feature
+++ b/features/saved_searches/create.feature
@@ -14,3 +14,4 @@ Feature: Test the UDB3 saved searches API
        """
     When I send a POST request to "/saved-searches/v3"
     Then the response status should be "201"
+    And the JSON response should have "id"

--- a/src/Http/SavedSearches/CreateSavedSearchRequestHandler.php
+++ b/src/Http/SavedSearches/CreateSavedSearchRequestHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\SavedSearches;
 
 use Broadway\CommandHandling\CommandBus;
+use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
 use CultuurNet\UDB3\SavedSearches\Command\SubscribeToSavedSearchJSONDeserializer;
 use Fig\Http\Message\StatusCodeInterface;
@@ -18,17 +19,24 @@ final class CreateSavedSearchRequestHandler implements RequestHandlerInterface
 
     private CommandBus $commandBus;
 
+    private UuidGeneratorInterface $uuidGenerator;
+
     public function __construct(
         string $userId,
-        CommandBus $commandBus
+        CommandBus $commandBus,
+        UuidGeneratorInterface $uuidGenerator
     ) {
         $this->userId = $userId;
         $this->commandBus = $commandBus;
+        $this->uuidGenerator = $uuidGenerator;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $id = $this->uuidGenerator->generate();
+
         $commandDeserializer = new SubscribeToSavedSearchJSONDeserializer(
+            $id,
             $this->userId
         );
 
@@ -36,6 +44,6 @@ final class CreateSavedSearchRequestHandler implements RequestHandlerInterface
 
         $this->commandBus->dispatch($command);
 
-        return new JsonResponse(null, StatusCodeInterface::STATUS_CREATED);
+        return new JsonResponse(['id' => $id], StatusCodeInterface::STATUS_CREATED);
     }
 }

--- a/src/SavedSearches/Command/SubscribeToSavedSearch.php
+++ b/src/SavedSearches/Command/SubscribeToSavedSearch.php
@@ -10,18 +10,18 @@ class SubscribeToSavedSearch extends SavedSearchCommand
 {
     protected string $name;
 
-    /**
-     * @var QueryString
-     */
-    protected $query;
+    protected QueryString $query;
 
+    private string $id;
 
     public function __construct(
+        string $id,
         string $userId,
         string $name,
         QueryString $query
     ) {
         parent::__construct($userId);
+        $this->id = $id;
         $this->name = $name;
         $this->query = $query;
     }
@@ -31,11 +31,13 @@ class SubscribeToSavedSearch extends SavedSearchCommand
         return $this->name;
     }
 
-    /**
-     * @return QueryString
-     */
-    public function getQuery()
+    public function getQuery(): QueryString
     {
         return $this->query;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
     }
 }

--- a/src/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializer.php
+++ b/src/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializer.php
@@ -15,10 +15,12 @@ use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 final class SubscribeToSavedSearchJSONDeserializer extends JSONDeserializer
 {
     private string $userId;
+    private string $id;
 
-    public function __construct(string $userId)
+    public function __construct(string $id, string $userId)
     {
         parent::__construct();
+        $this->id = $id;
         $this->userId = $userId;
     }
 
@@ -35,6 +37,7 @@ final class SubscribeToSavedSearchJSONDeserializer extends JSONDeserializer
         }
 
         return new SubscribeToSavedSearch(
+            $this->id,
             $this->userId,
             $json->name,
             new QueryString($json->query)

--- a/src/SavedSearches/UDB3SavedSearchRepository.php
+++ b/src/SavedSearches/UDB3SavedSearchRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SavedSearches;
 
-use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\SavedSearches\Doctrine\SchemaConfigurator;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
@@ -18,24 +17,21 @@ class UDB3SavedSearchRepository implements SavedSearchReadModelRepositoryInterfa
 
     private string $tableName;
 
-    private UuidGeneratorInterface $uuidGenerator;
-
     private string $userId;
 
 
     public function __construct(
         Connection $connection,
         string $tableName,
-        UuidGeneratorInterface $uuidGenerator,
         string $userId
     ) {
         $this->connection = $connection;
         $this->tableName = $tableName;
-        $this->uuidGenerator = $uuidGenerator;
         $this->userId = $userId;
     }
 
     public function write(
+        string $id,
         string $userId,
         string $name,
         QueryString $queryString
@@ -52,7 +48,7 @@ class UDB3SavedSearchRepository implements SavedSearchReadModelRepositoryInterfa
             )
             ->setParameters(
                 [
-                    $this->uuidGenerator->generate(),
+                    $id,
                     $userId,
                     $name,
                     $queryString->toString(),

--- a/src/SavedSearches/UDB3SavedSearchesCommandHandler.php
+++ b/src/SavedSearches/UDB3SavedSearchesCommandHandler.php
@@ -11,10 +11,7 @@ use CultuurNet\UDB3\SavedSearches\WriteModel\SavedSearchRepositoryInterface;
 
 class UDB3SavedSearchesCommandHandler extends SimpleCommandHandler
 {
-    /**
-     * @var SavedSearchRepositoryInterface
-     */
-    private $savedSearchRepository;
+    private SavedSearchRepositoryInterface $savedSearchRepository;
 
     public function __construct(SavedSearchRepositoryInterface $savedSearchRepository)
     {
@@ -23,11 +20,12 @@ class UDB3SavedSearchesCommandHandler extends SimpleCommandHandler
 
     public function handleSubscribeToSavedSearch(SubscribeToSavedSearch $subscribeToSavedSearch): void
     {
+        $id = $subscribeToSavedSearch->getId();
         $userId = $subscribeToSavedSearch->getUserId();
         $name = $subscribeToSavedSearch->getName();
         $query = $subscribeToSavedSearch->getQuery();
 
-        $this->savedSearchRepository->write($userId, $name, $query);
+        $this->savedSearchRepository->write($id, $userId, $name, $query);
     }
 
     public function handleUnsubscribeFromSavedSearch(UnsubscribeFromSavedSearch $unsubscribeFromSavedSearch): void

--- a/src/SavedSearches/WriteModel/SavedSearchRepositoryInterface.php
+++ b/src/SavedSearches/WriteModel/SavedSearchRepositoryInterface.php
@@ -9,11 +9,11 @@ use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 interface SavedSearchRepositoryInterface
 {
     public function write(
+        string $id,
         string $userId,
         string $name,
         QueryString $queryString
     ): void;
-
 
     public function delete(
         string $userId,

--- a/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
+++ b/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
 {
+    private const ID = '3c504b25-b221-4aa5-ad75-5510379ba502';
     private string $userId;
 
     private SubscribeToSavedSearchJSONDeserializer $deserializer;
@@ -19,6 +20,7 @@ final class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
         $this->userId ='xyx';
 
         $this->deserializer = new SubscribeToSavedSearchJSONDeserializer(
+            self::ID,
             $this->userId
         );
     }
@@ -34,6 +36,7 @@ final class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
 
         $this->assertEquals(
             new SubscribeToSavedSearch(
+                self::ID,
                 $this->userId,
                 'My very first saved search.',
                 new QueryString('city:"Leuven"')

--- a/tests/SavedSearches/Command/SubscribeToSavedSearchTest.php
+++ b/tests/SavedSearches/Command/SubscribeToSavedSearchTest.php
@@ -14,12 +14,14 @@ class SubscribeToSavedSearchTest extends TestCase
      */
     public function it_returns_the_stored_data(): void
     {
+        $id = '3c504b25-b221-4aa5-ad75-5510379ba502';
         $userId = 'some-user-id';
         $name = 'My very first saved search.';
         $query = new QueryString('city:"Leuven"');
 
-        $command = new SubscribeToSavedSearch($userId, $name, $query);
+        $command = new SubscribeToSavedSearch($id, $userId, $name, $query);
 
+        $this->assertEquals($id, $command->getId());
         $this->assertEquals($userId, $command->getUserId());
         $this->assertEquals($name, $command->getName());
         $this->assertEquals($query, $command->getQuery());

--- a/tests/SavedSearches/UDB3SavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/UDB3SavedSearchRepositoryTest.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SavedSearches;
 
-use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\DBALTestConnectionTrait;
 use CultuurNet\UDB3\SavedSearches\Doctrine\SchemaConfigurator;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class UDB3SavedSearchRepositoryTest extends TestCase
@@ -18,26 +16,16 @@ class UDB3SavedSearchRepositoryTest extends TestCase
 
     private string $tableName;
 
-    /**
-     * @var UuidGeneratorInterface|MockObject
-     */
-    private $uuidGenerator;
-
-    /**
-     * @var UDB3SavedSearchRepository
-     */
-    private $udb3SavedSearchRepository;
+    private UDB3SavedSearchRepository $udb3SavedSearchRepository;
 
     protected function setUp(): void
     {
         $this->createTable();
 
-        $this->uuidGenerator = $this->createMock(UuidGeneratorInterface::class);
 
         $this->udb3SavedSearchRepository = new UDB3SavedSearchRepository(
             $this->getConnection(),
             $this->tableName,
-            $this->uuidGenerator,
             '6f072ba8-c510-40ac-b387-51f582650e26'
         );
     }
@@ -47,11 +35,8 @@ class UDB3SavedSearchRepositoryTest extends TestCase
      */
     public function it_can_save_a_query_with_name_for_a_user(): void
     {
-        $this->uuidGenerator->expects($this->once())
-            ->method('generate')
-            ->willReturn('73bf2160-058c-4e4e-bbee-6bcbe9298596');
-
         $this->udb3SavedSearchRepository->write(
+            '73bf2160-058c-4e4e-bbee-6bcbe9298596',
             '96fd6c13-eaab-4dd1-bb6a-1c483d5e40cc',
             'In Leuven',
             new QueryString('q=city:leuven')
@@ -163,27 +148,22 @@ class UDB3SavedSearchRepositoryTest extends TestCase
 
     private function seedSavedSearches(): void
     {
-        $this->uuidGenerator->expects($this->exactly(3))
-            ->method('generate')
-            ->willReturnOnConsecutiveCalls(
-                '73bf2160-058c-4e4e-bbee-6bcbe9298596',
-                'db4c4690-84fb-4ed9-9a64-fccdd6e29f53',
-                '4de79378-d9a9-47ec-9b38-6f76f9d6df37'
-            );
-
         $this->udb3SavedSearchRepository->write(
+            '73bf2160-058c-4e4e-bbee-6bcbe9298596',
             '96fd6c13-eaab-4dd1-bb6a-1c483d5e40cc',
             'In Leuven',
             new QueryString('q=city:leuven')
         );
 
         $this->udb3SavedSearchRepository->write(
+            'db4c4690-84fb-4ed9-9a64-fccdd6e29f53',
             '6f072ba8-c510-40ac-b387-51f582650e26',
             'Permanent in Rotselaar',
             new QueryString('q=city:Rotselaar AND permanent:TRUE')
         );
 
         $this->udb3SavedSearchRepository->write(
+            '4de79378-d9a9-47ec-9b38-6f76f9d6df37',
             '6f072ba8-c510-40ac-b387-51f582650e26',
             'Alles in Tienen',
             new QueryString('q=city:Tienen')

--- a/tests/SavedSearches/UDB3SavedSearchesCommandHandlerTest.php
+++ b/tests/SavedSearches/UDB3SavedSearchesCommandHandlerTest.php
@@ -18,10 +18,7 @@ class UDB3SavedSearchesCommandHandlerTest extends TestCase
      */
     private $savedSearchesRepository;
 
-    /**
-     * @var UDB3SavedSearchesCommandHandler
-     */
-    private $udb3SavedSearchesCommandHandler;
+    private UDB3SavedSearchesCommandHandler $udb3SavedSearchesCommandHandler;
 
     protected function setUp(): void
     {
@@ -34,15 +31,17 @@ class UDB3SavedSearchesCommandHandlerTest extends TestCase
      */
     public function it_can_handle_subscribe_to_saved_search_commands(): void
     {
+        $id = '3c504b25-b221-4aa5-ad75-5510379ba502';
         $userId = 'some-user-id';
         $name = 'My very first saved search!';
         $query = new QueryString('city:"Leuven"');
 
-        $subscribeToSavedSearch = new SubscribeToSavedSearch($userId, $name, $query);
+        $subscribeToSavedSearch = new SubscribeToSavedSearch($id, $userId, $name, $query);
 
         $this->savedSearchesRepository->expects($this->once())
             ->method('write')
             ->with(
+                $id,
                 $userId,
                 $name,
                 $query


### PR DESCRIPTION
### Changed
I changed the output of the Saved Searches endpoint.
It used to return a NULL, which I found very confusing and not consistent with most of our create statements.
(I thought that the script just failed the first time I called it.)

I refactored the endpoint to now return the id of the created saved search.

I also need this for a feature test for the next feature I am creating, a PUT command for Saved Searches.

![Screenshot 2024-03-06 at 12 43 58](https://github.com/cultuurnet/udb3-backend/assets/13052911/cf146264-061e-4561-9758-17e16cfdf7d0)


---
Ticket: https://jira.uitdatabank.be/browse/III-6117
