### PR TITLE
III-6117 BUGFIX put saved search gave error when saving twice

### DIFF
--- a/features/saved_searches/update.feature
+++ b/features/saved_searches/update.feature
@@ -33,8 +33,33 @@ Feature: Test the UDB3 saved searches API
 
     When I send a GET request to "/saved-searches/v3"
     Then the response status should be "200"
-    And the response body should be valid JSON
+#    And the response body should be valid JSON
     And the JSON response should include:
       """
       {"name":"%{name}","query":"Lessen in de avond","id":"%{id}"}
       """
+
+  #Bugfix https://jira.publiq.be/browse/III-6019
+  Scenario: I update a saved search twice
+    Given I create a random name of 12 characters
+    And I set the JSON request payload to:
+       """
+       {"name":"This should change","query":"Lessen in de ochtend"}
+       """
+    When I send a POST request to "/saved-searches/v3/"
+    Then the response status should be "201"
+    And I keep the value of the JSON response at "id" as "id"
+
+    And I set the JSON request payload to:
+       """
+       {"name":"%{name}","query":"Lessen in de avond"}
+       """
+    When I send a PUT request to "/saved-searches/v3/%{id}"
+    Then the response status should be "204"
+
+    And I set the JSON request payload to:
+       """
+       {"name":"%{name}","query":"Lessen in de avond"}
+       """
+    When I send a PUT request to "/saved-searches/v3/%{id}"
+    Then the response status should be "204"

--- a/features/saved_searches/update.feature
+++ b/features/saved_searches/update.feature
@@ -63,3 +63,30 @@ Feature: Test the UDB3 saved searches API
        """
     When I send a PUT request to "/saved-searches/v3/%{id}"
     Then the response status should be "204"
+
+  Scenario: I cannot update a saved search from another user
+    Given I create a random name of 12 characters
+    And I set the JSON request payload to:
+       """
+       {"name":"This should change","query":"Lessen in de ochtend"}
+       """
+    When I send a POST request to "/saved-searches/v3/"
+    Then the response status should be "201"
+    And I keep the value of the JSON response at "id" as "id"
+
+    And I am authorized as JWT provider v1 user "validator_diest"
+
+    And I set the JSON request payload to:
+       """
+       {"name":"%{name}","query":"Lessen in de avond"}
+       """
+    When I send a PUT request to "/saved-searches/v3/%{id}"
+    Then the response status should be "401"
+
+  Scenario: I cannot update a saved search that does not exist
+    Given I set the JSON request payload to:
+       """
+       {"name":"%{name}","query":"Lessen in de avond"}
+       """
+    When I send a PUT request to "/saved-searches/v3/404"
+    Then the response status should be "404"

--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -203,6 +203,11 @@ final class ApiProblem extends Exception
         );
     }
 
+    public static function unauthorizedSavedSearch(): self
+    {
+        return self::unauthorized('You do not own this saved search');
+    }
+
     public static function forbidden(string $detail = null): self
     {
         return self::create(

--- a/src/Http/SavedSearches/ReadSavedSearchesRequestHandler.php
+++ b/src/Http/SavedSearches/ReadSavedSearchesRequestHandler.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\SavedSearches;
 
 use CultuurNet\UDB3\Http\Response\JsonResponse;
-use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchesOwnedByCurrentUser;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 final class ReadSavedSearchesRequestHandler implements RequestHandlerInterface
 {
-    private SavedSearchRepositoryInterface $savedSearchRepository;
+    private SavedSearchesOwnedByCurrentUser $savedSearchRepository;
 
-    public function __construct(SavedSearchRepositoryInterface $savedSearchRepository)
+    public function __construct(SavedSearchesOwnedByCurrentUser $savedSearchRepository)
     {
         $this->savedSearchRepository = $savedSearchRepository;
     }

--- a/src/Http/SavedSearches/UpdateSavedSearchRequestHandler.php
+++ b/src/Http/SavedSearches/UpdateSavedSearchRequestHandler.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\SavedSearches;
 
 use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\SavedSearches\Command\UpdateSavedSearchJSONDeserializer;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchReadRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -15,21 +17,32 @@ use Psr\Http\Server\RequestHandlerInterface;
 final class UpdateSavedSearchRequestHandler implements RequestHandlerInterface
 {
     private string $userId;
-
     private CommandBus $commandBus;
+    private SavedSearchReadRepository $savedSearchReadRepository;
 
     public function __construct(
         string $userId,
-        CommandBus $commandBus
+        CommandBus $commandBus,
+        SavedSearchReadRepository $savedSearchReadRepository
     ) {
         $this->userId = $userId;
         $this->commandBus = $commandBus;
+        $this->savedSearchReadRepository = $savedSearchReadRepository;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $routeParameters = new RouteParameters($request);
         $id = $routeParameters->get('id');
+
+        $savedSearch = $this->savedSearchReadRepository->findById($id);
+        if ($savedSearch === null) {
+            throw ApiProblem::savedSearchNotFound($id);
+        }
+
+        if ($savedSearch->getUserId() !== $this->userId) {
+            throw ApiProblem::unauthorizedSavedSearch();
+        }
 
         $commandDeserializer = new UpdateSavedSearchJSONDeserializer(
             $this->userId,

--- a/src/SavedSearches/CombinedSavedSearchRepository.php
+++ b/src/SavedSearches/CombinedSavedSearchRepository.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SavedSearches;
 
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
-use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchesOwnedByCurrentUser;
 
-class CombinedSavedSearchRepository implements SavedSearchRepositoryInterface
+class CombinedSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
 {
     /**
-     * @var SavedSearchRepositoryInterface[]
+     * @var SavedSearchesOwnedByCurrentUser[]
      */
     protected array $repositories;
 
-    public function __construct(SavedSearchRepositoryInterface ...$repositories)
+    public function __construct(SavedSearchesOwnedByCurrentUser ...$repositories)
     {
         $this->repositories = $repositories;
     }

--- a/src/SavedSearches/ReadModel/SavedSearch.php
+++ b/src/SavedSearches/ReadModel/SavedSearch.php
@@ -9,16 +9,23 @@ use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 class SavedSearch implements \JsonSerializable
 {
     protected ?string $id;
+    protected ?string $userId;
 
     protected string $name;
 
     protected QueryString $query;
 
-    public function __construct(string $name, QueryString $query, string $id = null)
+    public function __construct(string $name, QueryString $query, string $id = null, string $userId = null)
     {
         $this->name = $name;
         $this->query = $query;
         $this->id = $id;
+        $this->userId = $userId;
+    }
+
+    public function getUserId(): ?string
+    {
+        return $this->userId;
     }
 
     /**

--- a/src/SavedSearches/ReadModel/SavedSearchReadRepository.php
+++ b/src/SavedSearches/ReadModel/SavedSearchReadRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\SavedSearches\ReadModel;
+
+use CultuurNet\UDB3\SavedSearches\Doctrine\SchemaConfigurator;
+use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
+use Doctrine\DBAL\Connection;
+
+class SavedSearchReadRepository
+{
+    private Connection $connection;
+
+    private string $tableName;
+
+    public function __construct(
+        Connection $connection,
+        string $tableName
+    ) {
+        $this->connection = $connection;
+        $this->tableName = $tableName;
+    }
+
+    public function findById(string $id): ?SavedSearch
+    {
+        $queryBuilder = $this->connection->createQueryBuilder()
+            ->select('*')
+            ->from($this->tableName)
+            ->andWhere(SchemaConfigurator::ID . ' = ?')
+            ->setParameters(
+                [
+                    $id,
+                ]
+            );
+
+        $row = $queryBuilder->execute()->fetchAssociative();
+
+        if ($row === false) {
+            return null;
+        }
+
+        return new SavedSearch(
+            $row[SchemaConfigurator::NAME],
+            new QueryString($row[SchemaConfigurator::QUERY]),
+            $row[SchemaConfigurator::ID],
+            $row[SchemaConfigurator::USER],
+        );
+    }
+}

--- a/src/SavedSearches/ReadModel/SavedSearchesOwnedByCurrentUser.php
+++ b/src/SavedSearches/ReadModel/SavedSearchesOwnedByCurrentUser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SavedSearches\ReadModel;
 
-interface SavedSearchRepositoryInterface
+interface SavedSearchesOwnedByCurrentUser
 {
     /**
      * @return SavedSearch[]

--- a/src/SavedSearches/Sapi3FixedSavedSearchRepository.php
+++ b/src/SavedSearches/Sapi3FixedSavedSearchRepository.php
@@ -7,11 +7,11 @@ namespace CultuurNet\UDB3\SavedSearches;
 use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
 use CultuurNet\UDB3\SavedSearches\Properties\CreatorQueryString;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
-use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchesOwnedByCurrentUser;
 use CultuurNet\UDB3\SavedSearches\ValueObject\CreatedByQueryMode;
 use CultuurNet\UDB3\User\UserIdentityResolver;
 
-class Sapi3FixedSavedSearchRepository implements SavedSearchRepositoryInterface
+class Sapi3FixedSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
 {
     private JsonWebToken $token;
 

--- a/src/SavedSearches/UDB3SavedSearchRepository.php
+++ b/src/SavedSearches/UDB3SavedSearchRepository.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\SavedSearches;
 use CultuurNet\UDB3\SavedSearches\Doctrine\SchemaConfigurator;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
-use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface as SavedSearchReadModelRepositoryInterface;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchesOwnedByCurrentUser as SavedSearchReadModelRepositoryInterface;
 use CultuurNet\UDB3\SavedSearches\WriteModel\SavedSearchRepositoryInterface as SavedSearchWriteModelRepositoryInterface;
 use Doctrine\DBAL\Connection;
 
@@ -122,41 +122,12 @@ class UDB3SavedSearchRepository implements SavedSearchReadModelRepositoryInterfa
             $savedSearches[] = new SavedSearch(
                 $row[SchemaConfigurator::NAME],
                 new QueryString($row[SchemaConfigurator::QUERY]),
-                $row[SchemaConfigurator::ID]
+                $row[SchemaConfigurator::ID],
+                $row[SchemaConfigurator::USER]
             );
         }
 
 
         return $savedSearches;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function findSavedSearchOwnedByCurrentUser(string $id): ?SavedSearch
-    {
-        $queryBuilder = $this->connection->createQueryBuilder()
-            ->select('*')
-            ->from($this->tableName)
-            ->where(SchemaConfigurator::USER . ' = ?')
-            ->andWhere(SchemaConfigurator::ID . ' = ?')
-            ->setParameters(
-                [
-                    $this->userId,
-                    $id,
-                ]
-            );
-
-        $row = $queryBuilder->execute()->fetchAssociative();
-
-        if ($row === false) {
-            return null;
-        }
-
-        return new SavedSearch(
-            $row[SchemaConfigurator::NAME],
-            new QueryString($row[SchemaConfigurator::QUERY]),
-            $row[SchemaConfigurator::ID]
-        );
     }
 }

--- a/src/SavedSearches/UDB3SavedSearchesCommandHandler.php
+++ b/src/SavedSearches/UDB3SavedSearchesCommandHandler.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SavedSearches;
 
 use Broadway\CommandHandling\SimpleCommandHandler;
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\SavedSearches\Command\SubscribeToSavedSearch;
 use CultuurNet\UDB3\SavedSearches\Command\UnsubscribeFromSavedSearch;
 use CultuurNet\UDB3\SavedSearches\Command\UpdateSavedSearch;
@@ -36,10 +35,6 @@ class UDB3SavedSearchesCommandHandler extends SimpleCommandHandler
         $name = $subscribeToSavedSearch->getName();
         $query = $subscribeToSavedSearch->getQuery();
         $id = $subscribeToSavedSearch->getId();
-
-        if ($this->savedSearchRepository->findSavedSearchOwnedByCurrentUser($id) === null) {
-            throw ApiProblem::savedSearchNotFound($id);
-        }
 
         $this->savedSearchRepository->update($id, $userId, $name, $query);
     }

--- a/src/SavedSearches/UDB3SavedSearchesCommandHandler.php
+++ b/src/SavedSearches/UDB3SavedSearchesCommandHandler.php
@@ -37,11 +37,11 @@ class UDB3SavedSearchesCommandHandler extends SimpleCommandHandler
         $query = $subscribeToSavedSearch->getQuery();
         $id = $subscribeToSavedSearch->getId();
 
-        $howManyRowsAffected = $this->savedSearchRepository->update($id, $userId, $name, $query);
-
-        if ($howManyRowsAffected === 0) {
+        if ($this->savedSearchRepository->findSavedSearchOwnedByCurrentUser($id) === null) {
             throw ApiProblem::savedSearchNotFound($id);
         }
+
+        $this->savedSearchRepository->update($id, $userId, $name, $query);
     }
 
     public function handleUnsubscribeFromSavedSearch(UnsubscribeFromSavedSearch $unsubscribeFromSavedSearch): void

--- a/src/SavedSearches/WriteModel/SavedSearchRepositoryInterface.php
+++ b/src/SavedSearches/WriteModel/SavedSearchRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SavedSearches\WriteModel;
 
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 
 interface SavedSearchRepositoryInterface
 {
@@ -20,10 +21,12 @@ interface SavedSearchRepositoryInterface
         string $userId,
         string $name,
         QueryString $queryString
-    ): int;
+    ): void;
 
     public function delete(
         string $userId,
         string $searchId
     ): void;
+
+    public function findSavedSearchOwnedByCurrentUser(string $id): ?SavedSearch;
 }

--- a/src/SavedSearches/WriteModel/SavedSearchRepositoryInterface.php
+++ b/src/SavedSearches/WriteModel/SavedSearchRepositoryInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SavedSearches\WriteModel;
 
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
-use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 
 interface SavedSearchRepositoryInterface
 {
@@ -27,6 +26,4 @@ interface SavedSearchRepositoryInterface
         string $userId,
         string $searchId
     ): void;
-
-    public function findSavedSearchOwnedByCurrentUser(string $id): ?SavedSearch;
 }

--- a/tests/Http/SavedSearches/ReadSavedSearchesRequestHandlerTest.php
+++ b/tests/Http/SavedSearches/ReadSavedSearchesRequestHandlerTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
-use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchesOwnedByCurrentUser;
 use Fig\Http\Message\StatusCodeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +19,7 @@ class ReadSavedSearchesRequestHandlerTest extends TestCase
     use AssertJsonResponseTrait;
 
     /**
-     * @var SavedSearchRepositoryInterface|MockObject
+     * @var SavedSearchesOwnedByCurrentUser|MockObject
      */
     private $savedSearchRepository;
 
@@ -29,7 +29,7 @@ class ReadSavedSearchesRequestHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->savedSearchRepository = $this->createMock(SavedSearchRepositoryInterface::class);
+        $this->savedSearchRepository = $this->createMock(SavedSearchesOwnedByCurrentUser::class);
         $this->readSavedSearchesRequestHandler = new ReadSavedSearchesRequestHandler($this->savedSearchRepository);
         $this->psr7RequestBuilder = new Psr7RequestBuilder();
     }

--- a/tests/SavedSearches/CombinedSavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/CombinedSavedSearchRepositoryTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\SavedSearches;
 use CultuurNet\UDB3\SavedSearches\Properties\CreatedByQueryString;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
-use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchesOwnedByCurrentUser;
 use PHPUnit\Framework\TestCase;
 
 class CombinedSavedSearchRepositoryTest extends TestCase
@@ -36,14 +36,14 @@ class CombinedSavedSearchRepositoryTest extends TestCase
             ),
         ];
 
-        $firstRepository = $this->createMock(SavedSearchRepositoryInterface::class);
+        $firstRepository = $this->createMock(SavedSearchesOwnedByCurrentUser::class);
         $firstRepository->expects($this->once())
             ->method('ownedByCurrentUser')
             ->willReturn([
                 $savedSearches[0],
             ]);
 
-        $secondRepository = $this->createMock(SavedSearchRepositoryInterface::class);
+        $secondRepository = $this->createMock(SavedSearchesOwnedByCurrentUser::class);
         $secondRepository->expects($this->once())
             ->method('ownedByCurrentUser')
             ->willReturn([
@@ -51,7 +51,7 @@ class CombinedSavedSearchRepositoryTest extends TestCase
                 $savedSearches[2],
             ]);
 
-        $thirdRepository = $this->createMock(SavedSearchRepositoryInterface::class);
+        $thirdRepository = $this->createMock(SavedSearchesOwnedByCurrentUser::class);
         $thirdRepository->expects($this->once())
             ->method('ownedByCurrentUser')
             ->willReturn([

--- a/tests/SavedSearches/UDB3SavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/UDB3SavedSearchRepositoryTest.php
@@ -67,7 +67,8 @@ class UDB3SavedSearchRepositoryTest extends TestCase
             'In Leuven',
             new QueryString('q=city:leuven')
         );
-        $affectedRows = $this->udb3SavedSearchRepository->update(
+
+        $this->udb3SavedSearchRepository->update(
             '1c483d5e40cc-4dd1-4dd1-eaab-96fd6c13',
             '96fd6c13-eaab-4dd1-bb6a-1c483d5e40cc',
             'In Antwerpen, de echte stad',
@@ -76,7 +77,6 @@ class UDB3SavedSearchRepositoryTest extends TestCase
 
         $savedSearches = $this->getSavedSearches();
 
-        $this->assertEquals(1, $affectedRows);
         $this->assertEquals(
             [
                 new SavedSearch(
@@ -87,21 +87,6 @@ class UDB3SavedSearchRepositoryTest extends TestCase
             ],
             $savedSearches
         );
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_0_when_updating_search_that_does_not_exist(): void
-    {
-        $affectedRows = $this->udb3SavedSearchRepository->update(
-            '1c483d5e40cc-4dd1-4dd1-eaab-96fd6c13',
-            '96fd6c13-eaab-4dd1-bb6a-1c483d5e40cc',
-            'El Dorado',
-            new QueryString('q=city:eldorado')
-        );
-
-        $this->assertEquals(0, $affectedRows);
     }
 
     /**

--- a/tests/SavedSearches/UDB3SavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/UDB3SavedSearchRepositoryTest.php
@@ -14,6 +14,7 @@ class UDB3SavedSearchRepositoryTest extends TestCase
 {
     use DBALTestConnectionTrait;
 
+    private const USERID = '6f072ba8-c510-40ac-b387-51f582650e26';
     private string $tableName;
 
     private UDB3SavedSearchRepository $udb3SavedSearchRepository;
@@ -26,7 +27,7 @@ class UDB3SavedSearchRepositoryTest extends TestCase
         $this->udb3SavedSearchRepository = new UDB3SavedSearchRepository(
             $this->getConnection(),
             $this->tableName,
-            '6f072ba8-c510-40ac-b387-51f582650e26'
+            self::USERID
         );
     }
 
@@ -97,7 +98,7 @@ class UDB3SavedSearchRepositoryTest extends TestCase
         $this->seedSavedSearches();
 
         $this->udb3SavedSearchRepository->delete(
-            '6f072ba8-c510-40ac-b387-51f582650e26',
+            self::USERID,
             'db4c4690-84fb-4ed9-9a64-fccdd6e29f53'
         );
 
@@ -134,12 +135,14 @@ class UDB3SavedSearchRepositoryTest extends TestCase
                 new SavedSearch(
                     'Permanent in Rotselaar',
                     new QueryString('q=city:Rotselaar AND permanent:TRUE'),
-                    'db4c4690-84fb-4ed9-9a64-fccdd6e29f53'
+                    'db4c4690-84fb-4ed9-9a64-fccdd6e29f53',
+                    self::USERID
                 ),
                 new SavedSearch(
                     'Alles in Tienen',
                     new QueryString('q=city:Tienen'),
-                    '4de79378-d9a9-47ec-9b38-6f76f9d6df37'
+                    '4de79378-d9a9-47ec-9b38-6f76f9d6df37',
+                    self::USERID
                 ),
             ],
             $savedSearches
@@ -190,14 +193,14 @@ class UDB3SavedSearchRepositoryTest extends TestCase
 
         $this->udb3SavedSearchRepository->insert(
             'db4c4690-84fb-4ed9-9a64-fccdd6e29f53',
-            '6f072ba8-c510-40ac-b387-51f582650e26',
+            self::USERID,
             'Permanent in Rotselaar',
             new QueryString('q=city:Rotselaar AND permanent:TRUE')
         );
 
         $this->udb3SavedSearchRepository->insert(
             '4de79378-d9a9-47ec-9b38-6f76f9d6df37',
-            '6f072ba8-c510-40ac-b387-51f582650e26',
+            self::USERID,
             'Alles in Tienen',
             new QueryString('q=city:Tienen')
         );

--- a/tests/SavedSearches/UDB3SavedSearchesCommandHandlerTest.php
+++ b/tests/SavedSearches/UDB3SavedSearchesCommandHandlerTest.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SavedSearches;
 
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\SavedSearches\Command\SubscribeToSavedSearch;
 use CultuurNet\UDB3\SavedSearches\Command\UnsubscribeFromSavedSearch;
 use CultuurNet\UDB3\SavedSearches\Command\UpdateSavedSearch;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
-use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 use CultuurNet\UDB3\SavedSearches\WriteModel\SavedSearchRepositoryInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -77,65 +75,7 @@ class UDB3SavedSearchesCommandHandlerTest extends TestCase
                 $query
             );
 
-        $this->savedSearchesRepository->expects($this->once())
-            ->method('findSavedSearchOwnedByCurrentUser')
-            ->with(
-                $id
-            )
-            ->willReturn(new SavedSearch($name, $query, $id));
-
         $this->udb3SavedSearchesCommandHandler->handle($subscribeToSavedSearch);
-    }
-
-    /**
-     * @test
-     */
-    public function it_throws_an_exception_which_saving_nonexisting_saved_search(): void
-    {
-        $id = '9b68b83c-366e-4d64-9d5d-fba58ef8b94f';
-        $userId = '2bf5b8bf-7dbf-4a21-ab31-6da376cb315b';
-        $name = 'My very first saved search!';
-        $query = new QueryString('city:"Leuven"');
-
-        $subscribeToSavedSearch = new UpdateSavedSearch($id, $userId, $name, $query);
-
-        $this->savedSearchesRepository->expects($this->once())
-            ->method('findSavedSearchOwnedByCurrentUser')
-            ->with(
-                $id
-            )
-            ->willReturn(null);
-
-        $this->assertCallableThrowsApiProblem(
-            ApiProblem::savedSearchNotFound($id),
-            fn () => $this->udb3SavedSearchesCommandHandler->handle($subscribeToSavedSearch)
-        );
-    }
-
-    public function it_will_fail_to_update_a_nonexisting_saved_search(): void
-    {
-        $id = '9b68b83c-366e-4d64-9d5d-fba58ef8b94f';
-        $userId = '2bf5b8bf-7dbf-4a21-ab31-6da376cb315b';
-        $name = 'My very first saved search!';
-        $query = new QueryString('city:"Leuven"');
-
-        $subscribeToSavedSearch = new UpdateSavedSearch($id, $userId, $name, $query);
-
-        $this->savedSearchesRepository->expects($this->once())
-            ->method('update')
-            ->with(
-                $id,
-                $userId,
-                $name,
-                $query
-            )
-            ->willReturn(0);
-
-        $this->expectException(ApiProblem::class);
-        $this->assertCallableThrowsApiProblem(
-            ApiProblem::savedSearchNotFound($id),
-            fn () => $this->udb3SavedSearchesCommandHandler->handle($subscribeToSavedSearch)
-        );
     }
 
     /**

--- a/tests/SavedSearches/UDB3SavedSearchesCommandHandlerTest.php
+++ b/tests/SavedSearches/UDB3SavedSearchesCommandHandlerTest.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\SavedSearches\Command\SubscribeToSavedSearch;
 use CultuurNet\UDB3\SavedSearches\Command\UnsubscribeFromSavedSearch;
 use CultuurNet\UDB3\SavedSearches\Command\UpdateSavedSearch;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 use CultuurNet\UDB3\SavedSearches\WriteModel\SavedSearchRepositoryInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -74,10 +75,41 @@ class UDB3SavedSearchesCommandHandlerTest extends TestCase
                 $userId,
                 $name,
                 $query
+            );
+
+        $this->savedSearchesRepository->expects($this->once())
+            ->method('findSavedSearchOwnedByCurrentUser')
+            ->with(
+                $id
             )
-            ->willReturn(1);
+            ->willReturn(new SavedSearch($name, $query, $id));
 
         $this->udb3SavedSearchesCommandHandler->handle($subscribeToSavedSearch);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_an_exception_which_saving_nonexisting_saved_search(): void
+    {
+        $id = '9b68b83c-366e-4d64-9d5d-fba58ef8b94f';
+        $userId = '2bf5b8bf-7dbf-4a21-ab31-6da376cb315b';
+        $name = 'My very first saved search!';
+        $query = new QueryString('city:"Leuven"');
+
+        $subscribeToSavedSearch = new UpdateSavedSearch($id, $userId, $name, $query);
+
+        $this->savedSearchesRepository->expects($this->once())
+            ->method('findSavedSearchOwnedByCurrentUser')
+            ->with(
+                $id
+            )
+            ->willReturn(null);
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::savedSearchNotFound($id),
+            fn () => $this->udb3SavedSearchesCommandHandler->handle($subscribeToSavedSearch)
+        );
     }
 
     public function it_will_fail_to_update_a_nonexisting_saved_search(): void


### PR DESCRIPTION
### Fixed
Fixed a bug with the PUT of saved searches.
If you saved a saved search without modifying any value, it would throw an `ApiProblem::savedSearchNotFound()`.

This is because I listened to the "affected rows", which will return 0 if the update does not have to change anything in the db.

I now use a proper select query.

I provided an extra feature test to prove the bug is fixed.


---
Ticket: https://jira.uitdatabank.be/browse/III-6117 
