### PR TITLE
[opinionated] Improve performance - do not use array_merge in loop

### DIFF
--- a/src/SavedSearches/CombinedSavedSearchRepository.php
+++ b/src/SavedSearches/CombinedSavedSearchRepository.php
@@ -12,7 +12,7 @@ class CombinedSavedSearchRepository implements SavedSearchRepositoryInterface
     /**
      * @var SavedSearchRepositoryInterface[]
      */
-    protected $repositories;
+    protected array $repositories;
 
     public function __construct(SavedSearchRepositoryInterface ...$repositories)
     {
@@ -28,7 +28,9 @@ class CombinedSavedSearchRepository implements SavedSearchRepositoryInterface
 
         foreach ($this->repositories as $repository) {
             $append = array_values($repository->ownedByCurrentUser());
-            $savedSearches = array_merge($savedSearches, $append);
+            foreach ($append as $item) {
+                $savedSearches[] = $item;
+            }
         }
 
         return $savedSearches;


### PR DESCRIPTION
### Changed
I want to remove array_merge in a loop, because it is very inefficent. Array_merge always copies the entire array in memory instead of modifying the existing one, making it expensive to run in a loop.

I suggest an old school loop to improve the performance.