### PR TITLE
III-6120 Clean place names before sending api call

### DIFF
--- a/src/Address/Address.php
+++ b/src/Address/Address.php
@@ -6,8 +6,11 @@ namespace CultuurNet\UDB3\Address;
 
 use Broadway\Serializer\Serializable;
 use CultuurNet\UDB3\JsonLdSerializableInterface;
-use CultuurNet\UDB3\Model\ValueObject\Geography\Address as Udb3ModelAddress;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\Model\ValueObject\Geography\Address as Udb3ModelAddress;
+use CultuurNet\UDB3\Model\ValueObject\Geography\Locality as Udb3Locality;
+use CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode as Udb3PostalCode;
+use CultuurNet\UDB3\Model\ValueObject\Geography\Street as Udb3Street;
 
 /**
  * @deprecated
@@ -94,6 +97,16 @@ final class Address implements Serializable, JsonLdSerializableInterface
             new PostalCode($address->getPostalCode()->toString()),
             new Locality($address->getLocality()->toString()),
             new CountryCode($address->getCountryCode()->toString())
+        );
+    }
+
+    public function toUdb3ModelAddress(): Udb3ModelAddress
+    {
+        return new Udb3ModelAddress(
+            new Udb3Street($this->getStreetAddress()->toString()),
+            new Udb3PostalCode($this->getPostalCode()->toString()),
+            new Udb3Locality($this->getLocality()->toString()),
+            new CountryCode($this->getCountryCode()->toString())
         );
     }
 }

--- a/src/Offer/AbstractGeoCoordinatesCommandHandler.php
+++ b/src/Offer/AbstractGeoCoordinatesCommandHandler.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Address\Formatter\AddressFormatter;
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
 use CultuurNet\UDB3\Offer\Commands\AbstractUpdateGeoCoordinatesFromAddress;
+use CultuurNet\UDB3\Place\ReadModel\Duplicate\CleanPlaceName;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use JsonException;
@@ -53,7 +54,11 @@ abstract class AbstractGeoCoordinatesCommandHandler extends Udb3CommandHandler i
         AbstractUpdateGeoCoordinatesFromAddress $updateGeoCoordinates
     ): void {
         $offerId = $updateGeoCoordinates->getItemId();
-        $locationName = $this->fetchOfferName($offerId);
+
+        $locationName = CleanPlaceName::transform(
+            $updateGeoCoordinates->getAddress()->toUdb3ModelAddress(),
+            $this->fetchOfferName($offerId)
+        );
 
         $exactAddress = $this->defaultAddressFormatter->format(
             $updateGeoCoordinates->getAddress()
@@ -94,8 +99,6 @@ abstract class AbstractGeoCoordinatesCommandHandler extends Udb3CommandHandler i
         $offer->updateGeoCoordinates($coordinates);
         $this->offerRepository->save($offer);
     }
-
-
 
     private function fetchOfferName(string $offerId): string
     {

--- a/src/Offer/Commands/AbstractUpdateGeoCoordinatesFromAddress.php
+++ b/src/Offer/Commands/AbstractUpdateGeoCoordinatesFromAddress.php
@@ -8,24 +8,15 @@ use CultuurNet\UDB3\Address\Address;
 
 abstract class AbstractUpdateGeoCoordinatesFromAddress extends AbstractCommand
 {
-    /**
-     * @var Address
-     */
-    private $address;
+    private Address $address;
 
-    /**
-     * @param string $itemId
-     */
-    public function __construct($itemId, Address $address)
+    public function __construct(string $itemId, Address $address)
     {
         parent::__construct($itemId);
         $this->address = $address;
     }
 
-    /**
-     * @return Address
-     */
-    public function getAddress()
+    public function getAddress(): Address
     {
         return $this->address;
     }

--- a/src/Place/ReadModel/Duplicate/CleanPlaceName.php
+++ b/src/Place/ReadModel/Duplicate/CleanPlaceName.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Place\ReadModel\Duplicate;
+
+use CultuurNet\UDB3\Model\Place\Place;
+use CultuurNet\UDB3\Model\ValueObject\Geography\Address;
+
+/**
+ * This class converts place names (title) with the following rules:
+ * Lowercase all letters
+ * Remove dots
+ * Remove accents
+ * Replace these symbols ["'?!()&_,:] by a white space
+ * Remove duplicate words
+ * Remove city name out of location name
+ * */
+class CleanPlaceName
+{
+    public static function transform(Place $place): string
+    {
+        $title = $place->getTitle()->getOriginalValue();
+
+        $title = str_replace(['.', ''], '', mb_strtolower(trim($title->toString())));
+
+        $title = self::removeAccents($title);
+
+        $title = str_replace(['"', '\'', '?', '!', '(', ')', '&', ',', '_', ':'], ' ', $title);
+
+        $title = self::removeCityName($place, $title);
+
+        $title = self::removeDuplicateWords($title);
+
+        return self::reduceMultipleSpaces($title);
+    }
+
+    private static function removeAccents(string $title): string
+    {
+        // believe it or not - this function was "loaned" from the Wordpress engine (GPLv2)
+
+        if (!preg_match('/[\x80-\xff]/', $title)) {
+            return $title;
+        }
+
+        return strtr($title, [
+            // Decompositions for Latin-1 Supplement
+            chr(195) . chr(128) => 'A',
+            chr(195) . chr(129) => 'A',
+            chr(195) . chr(130) => 'A',
+            chr(195) . chr(131) => 'A',
+            chr(195) . chr(132) => 'A',
+            chr(195) . chr(133) => 'A',
+            chr(195) . chr(135) => 'C',
+            chr(195) . chr(136) => 'E',
+            chr(195) . chr(137) => 'E',
+            chr(195) . chr(138) => 'E',
+            chr(195) . chr(139) => 'E',
+            chr(195) . chr(140) => 'I',
+            chr(195) . chr(141) => 'I',
+            chr(195) . chr(142) => 'I',
+            chr(195) . chr(143) => 'I',
+            chr(195) . chr(145) => 'N',
+            chr(195) . chr(146) => 'O',
+            chr(195) . chr(147) => 'O',
+            chr(195) . chr(148) => 'O',
+            chr(195) . chr(149) => 'O',
+            chr(195) . chr(150) => 'O',
+            chr(195) . chr(153) => 'U',
+            chr(195) . chr(154) => 'U',
+            chr(195) . chr(155) => 'U',
+            chr(195) . chr(156) => 'U',
+            chr(195) . chr(157) => 'Y',
+            chr(195) . chr(159) => 's',
+            chr(195) . chr(160) => 'a',
+            chr(195) . chr(161) => 'a',
+            chr(195) . chr(162) => 'a',
+            chr(195) . chr(163) => 'a',
+            chr(195) . chr(164) => 'a',
+            chr(195) . chr(165) => 'a',
+            chr(195) . chr(167) => 'c',
+            chr(195) . chr(168) => 'e',
+            chr(195) . chr(169) => 'e',
+            chr(195) . chr(170) => 'e',
+            chr(195) . chr(171) => 'e',
+            chr(195) . chr(172) => 'i',
+            chr(195) . chr(173) => 'i',
+            chr(195) . chr(174) => 'i',
+            chr(195) . chr(175) => 'i',
+            chr(195) . chr(177) => 'n',
+            chr(195) . chr(178) => 'o',
+            chr(195) . chr(179) => 'o',
+            chr(195) . chr(180) => 'o',
+            chr(195) . chr(181) => 'o',
+            chr(195) . chr(182) => 'o',
+            chr(195) . chr(182) => 'o',
+            chr(195) . chr(185) => 'u',
+            chr(195) . chr(186) => 'u',
+            chr(195) . chr(187) => 'u',
+            chr(195) . chr(188) => 'u',
+            chr(195) . chr(189) => 'y',
+            chr(195) . chr(191) => 'y',
+            // Decompositions for Latin Extended-A
+            chr(196) . chr(128) => 'A',
+            chr(196) . chr(129) => 'a',
+            chr(196) . chr(130) => 'A',
+            chr(196) . chr(131) => 'a',
+            chr(196) . chr(132) => 'A',
+            chr(196) . chr(133) => 'a',
+            chr(196) . chr(134) => 'C',
+            chr(196) . chr(135) => 'c',
+            chr(196) . chr(136) => 'C',
+            chr(196) . chr(137) => 'c',
+            chr(196) . chr(138) => 'C',
+            chr(196) . chr(139) => 'c',
+            chr(196) . chr(140) => 'C',
+            chr(196) . chr(141) => 'c',
+            chr(196) . chr(142) => 'D',
+            chr(196) . chr(143) => 'd',
+            chr(196) . chr(144) => 'D',
+            chr(196) . chr(145) => 'd',
+            chr(196) . chr(146) => 'E',
+            chr(196) . chr(147) => 'e',
+            chr(196) . chr(148) => 'E',
+            chr(196) . chr(149) => 'e',
+            chr(196) . chr(150) => 'E',
+            chr(196) . chr(151) => 'e',
+            chr(196) . chr(152) => 'E',
+            chr(196) . chr(153) => 'e',
+            chr(196) . chr(154) => 'E',
+            chr(196) . chr(155) => 'e',
+            chr(196) . chr(156) => 'G',
+            chr(196) . chr(157) => 'g',
+            chr(196) . chr(158) => 'G',
+            chr(196) . chr(159) => 'g',
+            chr(196) . chr(160) => 'G',
+            chr(196) . chr(161) => 'g',
+            chr(196) . chr(162) => 'G',
+            chr(196) . chr(163) => 'g',
+            chr(196) . chr(164) => 'H',
+            chr(196) . chr(165) => 'h',
+            chr(196) . chr(166) => 'H',
+            chr(196) . chr(167) => 'h',
+            chr(196) . chr(168) => 'I',
+            chr(196) . chr(169) => 'i',
+            chr(196) . chr(170) => 'I',
+            chr(196) . chr(171) => 'i',
+            chr(196) . chr(172) => 'I',
+            chr(196) . chr(173) => 'i',
+            chr(196) . chr(174) => 'I',
+            chr(196) . chr(175) => 'i',
+            chr(196) . chr(176) => 'I',
+            chr(196) . chr(177) => 'i',
+            chr(196) . chr(178) => 'IJ',
+            chr(196) . chr(179) => 'ij',
+            chr(196) . chr(180) => 'J',
+            chr(196) . chr(181) => 'j',
+            chr(196) . chr(182) => 'K',
+            chr(196) . chr(183) => 'k',
+            chr(196) . chr(184) => 'k',
+            chr(196) . chr(185) => 'L',
+            chr(196) . chr(186) => 'l',
+            chr(196) . chr(187) => 'L',
+            chr(196) . chr(188) => 'l',
+            chr(196) . chr(189) => 'L',
+            chr(196) . chr(190) => 'l',
+            chr(196) . chr(191) => 'L',
+            chr(197) . chr(128) => 'l',
+            chr(197) . chr(129) => 'L',
+            chr(197) . chr(130) => 'l',
+            chr(197) . chr(131) => 'N',
+            chr(197) . chr(132) => 'n',
+            chr(197) . chr(133) => 'N',
+            chr(197) . chr(134) => 'n',
+            chr(197) . chr(135) => 'N',
+            chr(197) . chr(136) => 'n',
+            chr(197) . chr(137) => 'N',
+            chr(197) . chr(138) => 'n',
+            chr(197) . chr(139) => 'N',
+            chr(197) . chr(140) => 'O',
+            chr(197) . chr(141) => 'o',
+            chr(197) . chr(142) => 'O',
+            chr(197) . chr(143) => 'o',
+            chr(197) . chr(144) => 'O',
+            chr(197) . chr(145) => 'o',
+            chr(197) . chr(146) => 'OE',
+            chr(197) . chr(147) => 'oe',
+            chr(197) . chr(148) => 'R',
+            chr(197) . chr(149) => 'r',
+            chr(197) . chr(150) => 'R',
+            chr(197) . chr(151) => 'r',
+            chr(197) . chr(152) => 'R',
+            chr(197) . chr(153) => 'r',
+            chr(197) . chr(154) => 'S',
+            chr(197) . chr(155) => 's',
+            chr(197) . chr(156) => 'S',
+            chr(197) . chr(157) => 's',
+            chr(197) . chr(158) => 'S',
+            chr(197) . chr(159) => 's',
+            chr(197) . chr(160) => 'S',
+            chr(197) . chr(161) => 's',
+            chr(197) . chr(162) => 'T',
+            chr(197) . chr(163) => 't',
+            chr(197) . chr(164) => 'T',
+            chr(197) . chr(165) => 't',
+            chr(197) . chr(166) => 'T',
+            chr(197) . chr(167) => 't',
+            chr(197) . chr(168) => 'U',
+            chr(197) . chr(169) => 'u',
+            chr(197) . chr(170) => 'U',
+            chr(197) . chr(171) => 'u',
+            chr(197) . chr(172) => 'U',
+            chr(197) . chr(173) => 'u',
+            chr(197) . chr(174) => 'U',
+            chr(197) . chr(175) => 'u',
+            chr(197) . chr(176) => 'U',
+            chr(197) . chr(177) => 'u',
+            chr(197) . chr(178) => 'U',
+            chr(197) . chr(179) => 'u',
+            chr(197) . chr(180) => 'W',
+            chr(197) . chr(181) => 'w',
+            chr(197) . chr(182) => 'Y',
+            chr(197) . chr(183) => 'y',
+            chr(197) . chr(184) => 'Y',
+            chr(197) . chr(185) => 'Z',
+            chr(197) . chr(186) => 'z',
+            chr(197) . chr(187) => 'Z',
+            chr(197) . chr(188) => 'z',
+            chr(197) . chr(189) => 'Z',
+            chr(197) . chr(190) => 'z',
+            chr(197) . chr(191) => 's',
+        ]);
+    }
+
+    private static function removeDuplicateWords(string $title): string
+    {
+        $words = explode(' ', $title);
+
+        $uniqueWords = array_unique($words);
+
+        return implode(' ', $uniqueWords);
+    }
+
+    private static function removeCityName(Place $place, string $title): string
+    {
+        $address = $place->getAddress()->getOriginalValue();
+        if ($address instanceof Address) {
+            $title = str_replace(mb_strtolower($address->getLocality()->toString()), '', $title);
+        }
+        return $title;
+    }
+
+    private static function reduceMultipleSpaces(string $title): string
+    {
+        // Use preg_replace with a regular expression to replace multiple spaces in a row with a single space
+        return trim(preg_replace('/\s+/', ' ', $title));
+    }
+}

--- a/src/Place/ReadModel/Duplicate/CleanPlaceName.php
+++ b/src/Place/ReadModel/Duplicate/CleanPlaceName.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Place\ReadModel\Duplicate;
 
-use CultuurNet\UDB3\Model\Place\Place;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Address;
 
 /**
@@ -18,17 +17,15 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\Address;
  * */
 class CleanPlaceName
 {
-    public static function transform(Place $place): string
+    public static function transform(Address $address, string $title): string
     {
-        $title = $place->getTitle()->getOriginalValue();
-
-        $title = str_replace(['.', ''], '', mb_strtolower(trim($title->toString())));
+        $title = str_replace(['.', ''], '', mb_strtolower(trim($title)));
 
         $title = self::removeAccents($title);
 
         $title = str_replace(['"', '\'', '?', '!', '(', ')', '&', ',', '_', ':'], ' ', $title);
 
-        $title = self::removeCityName($place, $title);
+        $title = self::removeCityName($address, $title);
 
         $title = self::removeDuplicateWords($title);
 
@@ -241,13 +238,9 @@ class CleanPlaceName
         return implode(' ', $uniqueWords);
     }
 
-    private static function removeCityName(Place $place, string $title): string
+    private static function removeCityName(Address $address, string $title): string
     {
-        $address = $place->getAddress()->getOriginalValue();
-        if ($address instanceof Address) {
-            $title = str_replace(mb_strtolower($address->getLocality()->toString()), '', $title);
-        }
-        return $title;
+        return str_replace(mb_strtolower($address->getLocality()->toString()), '', $title);
     }
 
     private static function reduceMultipleSpaces(string $title): string

--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -55,4 +55,30 @@ class AddressTest extends TestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * @test
+     */
+    public function it_should_convert_to_an_udb3_model_address(): void
+    {
+        $originalAddress = new Address(
+            new Street('Henegouwenkaai 41-43'),
+            new PostalCode('1080'),
+            new Locality('Brussel'),
+            new CountryCode('BE')
+        );
+
+        $convertAddress = $originalAddress->toUdb3ModelAddress();
+
+        $udb3ModelAddress = new \CultuurNet\UDB3\Model\ValueObject\Geography\Address(
+            new \CultuurNet\UDB3\Model\ValueObject\Geography\Street('Henegouwenkaai 41-43'),
+            new \CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode('1080'),
+            new \CultuurNet\UDB3\Model\ValueObject\Geography\Locality('Brussel'),
+            new CountryCode('BE')
+        );
+
+        $this->assertEquals($udb3ModelAddress->getStreet()->toString(), $convertAddress->getStreet()->toString());
+        $this->assertEquals($udb3ModelAddress->getPostalCode()->toString(), $convertAddress->getPostalCode()->toString());
+        $this->assertEquals($udb3ModelAddress->getLocality()->toString(), $convertAddress->getLocality()->toString());
+    }
 }

--- a/tests/Place/ReadModel/Duplicate/CleanPlaceNameTest.php
+++ b/tests/Place/ReadModel/Duplicate/CleanPlaceNameTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Place\ReadModel\Duplicate;
+
+use CultuurNet\UDB3\Model\Place\ImmutablePlace;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Geography\Address as Udb3Address;
+use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\Model\ValueObject\Geography\Locality as Udb3Locality;
+use CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode as Udb3PostalCode;
+use CultuurNet\UDB3\Model\ValueObject\Geography\Street as Udb3Street;
+use CultuurNet\UDB3\Model\ValueObject\Geography\TranslatedAddress;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Categories;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Category;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryDomain;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryLabel;
+use CultuurNet\UDB3\Model\ValueObject\Text\Title;
+use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use PHPUnit\Framework\TestCase;
+
+class CleanPlaceNameTest extends TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testTransform(string $title, string $expectedOutput): void
+    {
+        $cleanPlaceName = new CleanPlaceName();
+        $this->assertEquals($expectedOutput, $cleanPlaceName->transform($this->createPlace($title)));
+    }
+
+    private function createPlace(string $title): ImmutablePlace
+    {
+        return new ImmutablePlace(
+            new UUID('aadcee95-6180-4924-a8eb-ed829d4957a2'),
+            new Language('nl'),
+            new TranslatedTitle(
+                new Language('nl'),
+                new Title($title)
+            ),
+            new PermanentCalendar(new OpeningHours()),
+            new TranslatedAddress(new Language('nl'), new Udb3Address(
+                new Udb3Street('Kerkstraat 1'),
+                new Udb3PostalCode('2000'),
+                new Udb3Locality('Antwerpen'),
+                new CountryCode('BE')
+            )),
+            new Categories(
+                new Category(
+                    new CategoryID('0.6.0.0.0'),
+                    new CategoryLabel('Beurs'),
+                    new CategoryDomain('eventtype')
+                )
+            )
+        );
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            // Test cases with various transformations
+            'happy path - nothing changed' => ['BELGIE', 'belgie'],
+            'Lowercase all letters' => ['BELGIE', 'belgie'],
+            'Remove dots' => ['b.e.l', 'bel'],
+            'Remove accents - simple' => ['belgië', 'belgie'],
+            'Remove accents - complex 1' => ['Élèvê', 'eleve'],
+            'Remove accents - complex 2' => ['garçon', 'garcon'],
+            'Remove accents - complex 3' => ['àá', 'aa'],
+            'Replace these symbols' => ["belgie\"'?&_,:(brussel)!", 'belgie brussel'],
+            'Remove duplicate words' => ['De gezellige mosterpot - gezellige sfeer', 'de gezellige mosterpot - sfeer'],
+            'Remove city name out of location name' => ['belgie antwerpen', 'belgie'],
+        ];
+    }
+}

--- a/tests/Place/ReadModel/Duplicate/CleanPlaceNameTest.php
+++ b/tests/Place/ReadModel/Duplicate/CleanPlaceNameTest.php
@@ -4,24 +4,11 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Place\ReadModel\Duplicate;
 
-use CultuurNet\UDB3\Model\Place\ImmutablePlace;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Address as Udb3Address;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Locality as Udb3Locality;
 use CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode as Udb3PostalCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Street as Udb3Street;
-use CultuurNet\UDB3\Model\ValueObject\Geography\TranslatedAddress;
-use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Categories;
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Category;
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryDomain;
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryID;
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryLabel;
-use CultuurNet\UDB3\Model\ValueObject\Text\Title;
-use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
-use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use PHPUnit\Framework\TestCase;
 
 class CleanPlaceNameTest extends TestCase
@@ -31,34 +18,14 @@ class CleanPlaceNameTest extends TestCase
      */
     public function testTransform(string $title, string $expectedOutput): void
     {
-        $cleanPlaceName = new CleanPlaceName();
-        $this->assertEquals($expectedOutput, $cleanPlaceName->transform($this->createPlace($title)));
-    }
-
-    private function createPlace(string $title): ImmutablePlace
-    {
-        return new ImmutablePlace(
-            new UUID('aadcee95-6180-4924-a8eb-ed829d4957a2'),
-            new Language('nl'),
-            new TranslatedTitle(
-                new Language('nl'),
-                new Title($title)
-            ),
-            new PermanentCalendar(new OpeningHours()),
-            new TranslatedAddress(new Language('nl'), new Udb3Address(
-                new Udb3Street('Kerkstraat 1'),
-                new Udb3PostalCode('2000'),
-                new Udb3Locality('Antwerpen'),
-                new CountryCode('BE')
-            )),
-            new Categories(
-                new Category(
-                    new CategoryID('0.6.0.0.0'),
-                    new CategoryLabel('Beurs'),
-                    new CategoryDomain('eventtype')
-                )
-            )
+        $address = new Udb3Address(
+            new Udb3Street('Kerkstraat 1'),
+            new Udb3PostalCode('2000'),
+            new Udb3Locality('Antwerpen'),
+            new CountryCode('BE')
         );
+
+        $this->assertEquals($expectedOutput, CleanPlaceName::transform($address, $title));
     }
 
     public function dataProvider(): array


### PR DESCRIPTION
### Added
Clean place names to before sending them to google maps based on the following rules:

- Lowercase all letters
- Remove dots
- Remove accents
- Replace these symbols ["'?!()&_,:] by a white space
- Remove duplicate words
- Remove city name out of location name

---
Ticket: https://jira.uitdatabank.be/browse/III-6120