### PR TITLE
III-6030 Rename duplicate place creation flag

### DIFF
--- a/app/Place/PlaceRequestHandlerServiceProvider.php
+++ b/app/Place/PlaceRequestHandlerServiceProvider.php
@@ -78,7 +78,7 @@ final class PlaceRequestHandlerServiceProvider extends AbstractServiceProvider
                     $container->get('place_iri_generator'),
                     $container->get('event_command_bus'),
                     $container->get('import_image_collection_factory'),
-                    $container->get('config')['prevent_duplicate_creation'] ?? false,
+                    $container->get('config')['prevent_duplicate_places_creation'] ?? false,
                     new LookupDuplicatePlaceWithSapi3(
                         $container->get(PlacesSapi3SearchService::class),
                         new UniqueAddressIdentifierFactory(),

--- a/features/Steps/UtilitySteps.php
+++ b/features/Steps/UtilitySteps.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Steps;
 
 trait UtilitySteps
 {
-    private bool $initialPreventDuplicateCreationValue;
+    private bool $initialPreventDuplicatePlaceCreationValue;
 
     /**
      * @Given I create a random name of :nrOfCharacters characters
@@ -41,27 +41,27 @@ trait UtilitySteps
     }
 
     /**
-     * @Given /^I prevent duplicate creation$/
+     * @Given /^I prevent duplicate place creation$/
      */
-    public function iPreventDuplicateCreation(): void
+    public function iPreventDuplicatePlaceCreation(): void
     {
         $configFile = file_get_contents('config.php');
 
-        if (str_contains($configFile, "'prevent_duplicate_creation' => true")) {
+        if (str_contains($configFile, "'prevent_duplicate_places_creation' => true")) {
             // The config was already on true, so no further changes are required
-            $this->initialPreventDuplicateCreationValue = true;
+            $this->initialPreventDuplicatePlaceCreationValue = true;
             return;
         }
 
         $configFile = str_replace(
-            "'prevent_duplicate_creation' => false",
-            "'prevent_duplicate_creation' => true",
+            "'prevent_duplicate_places_creation' => false",
+            "'prevent_duplicate_places_creation' => true",
             $configFile
         );
 
         file_put_contents('config.php', $configFile);
 
-        $this->initialPreventDuplicateCreationValue = false;
+        $this->initialPreventDuplicatePlaceCreationValue = false;
     }
 
     /**
@@ -72,8 +72,8 @@ trait UtilitySteps
         $configFile = file_get_contents('config.php');
 
         $configFile = str_replace(
-            "'prevent_duplicate_creation' => true",
-            "'prevent_duplicate_creation' => " . ($this->initialPreventDuplicateCreationValue ? 'true' : 'false'),
+            "'prevent_duplicate_places_creation' => true",
+            "'prevent_duplicate_places_creation' => " . ($this->initialPreventDuplicatePlaceCreationValue ? 'true' : 'false'),
             $configFile
         );
 

--- a/features/place/duplicate.feature
+++ b/features/place/duplicate.feature
@@ -8,7 +8,7 @@ Feature: Test creating places
 
 
   Scenario: Allow creating a new place, if a "duplicate" place before was rejected
-    Given I prevent duplicate creation
+    Given I prevent duplicate place creation
     Given I create a random name of 6 characters and keep it as "name"
     Given I create a minimal place and save the "id" as "originalPlaceId" then I should get a "201" response code
     When I publish the place at "/places/%{originalPlaceId}"
@@ -18,7 +18,7 @@ Feature: Test creating places
     Then I restore the duplicate configuration
 
   Scenario: Be prevented from creating a new place if we already have one on that address
-    Given I prevent duplicate creation
+    Given I prevent duplicate place creation
     Given I create a random name of 6 characters and keep it as "name"
     Given I create a minimal place and save the "id" as "originalPlaceId" then I should get a "201" response code
     Then I wait for the place with url "/places/%{originalPlaceId}" to be indexed


### PR DESCRIPTION
### Changed
Renamed flag "prevent_duplicate_creation" to "prevent_duplicate_places_creation"

### Related


---
Ticket: https://jira.uitdatabank.be/browse/III-6030 
