### PR TITLE
III-6072 Add endpoint to reject ownership

### DIFF
--- a/app/CommandHandling/CommandBusServiceProvider.php
+++ b/app/CommandHandling/CommandBusServiceProvider.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Event\EventCommandHandler;
 use CultuurNet\UDB3\Event\Productions\ProductionCommandHandler;
 use CultuurNet\UDB3\Log\SocketIOEmitterHandler;
 use CultuurNet\UDB3\Ownership\CommandHandlers\ApproveOwnershipHandler;
+use CultuurNet\UDB3\Ownership\CommandHandlers\RejectOwnershipHandler;
 use CultuurNet\UDB3\Ownership\CommandHandlers\RequestOwnershipHandler;
 use CultuurNet\UDB3\Place\CommandHandler as PlaceCommandHandler;
 use CultuurNet\UDB3\Place\ExtendedGeoCoordinatesCommandHandler;
@@ -215,6 +216,7 @@ final class CommandBusServiceProvider extends AbstractServiceProvider
 
                         $commandBus->subscribe($container->get(RequestOwnershipHandler::class));
                         $commandBus->subscribe($container->get(ApproveOwnershipHandler::class));
+                        $commandBus->subscribe($container->get(RejectOwnershipHandler::class));
 
                         $commandBus->subscribe($container->get(LabelServiceProvider::COMMAND_HANDLER));
                     }

--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -69,6 +69,7 @@ use CultuurNet\UDB3\Http\Organizer\DeleteEducationalDescriptionRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\UpdateEducationalDescriptionRequestHandler;
 use CultuurNet\UDB3\Http\Ownership\ApproveOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Ownership\GetOwnershipRequestHandler;
+use CultuurNet\UDB3\Http\Ownership\RejectOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Ownership\RequestOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Place\GetEventsRequestHandler;
 use CultuurNet\UDB3\Http\Place\UpdateAddressRequestHandler as UpdatePlaceAddressRequestHandler;
@@ -373,6 +374,7 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
         $router->group('ownerships', function (RouteGroup $routeGroup): void {
             $routeGroup->post('', RequestOwnershipRequestHandler::class);
             $routeGroup->post('{ownershipId}/approve/', ApproveOwnershipRequestHandler::class);
+            $routeGroup->post('{ownershipId}/reject/', RejectOwnershipRequestHandler::class);
             $routeGroup->get('{ownershipId}/', GetOwnershipRequestHandler::class);
         });
     }

--- a/app/Ownership/OwnershipCommandHandlerProvider.php
+++ b/app/Ownership/OwnershipCommandHandlerProvider.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Ownership;
 
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Ownership\CommandHandlers\ApproveOwnershipHandler;
+use CultuurNet\UDB3\Ownership\CommandHandlers\RejectOwnershipHandler;
 use CultuurNet\UDB3\Ownership\CommandHandlers\RequestOwnershipHandler;
 
 final class OwnershipCommandHandlerProvider extends AbstractServiceProvider
@@ -15,6 +16,7 @@ final class OwnershipCommandHandlerProvider extends AbstractServiceProvider
         return [
             RequestOwnershipHandler::class,
             ApproveOwnershipHandler::class,
+            RejectOwnershipHandler::class,
         ];
     }
 
@@ -32,6 +34,13 @@ final class OwnershipCommandHandlerProvider extends AbstractServiceProvider
         $container->addShared(
             ApproveOwnershipHandler::class,
             fn () => new ApproveOwnershipHandler(
+                $container->get(OwnershipRepository::class)
+            )
+        );
+
+        $container->addShared(
+            RejectOwnershipHandler::class,
+            fn () => new RejectOwnershipHandler(
                 $container->get(OwnershipRepository::class)
             )
         );

--- a/app/Ownership/OwnershipRequestHandlerServiceProvider.php
+++ b/app/Ownership/OwnershipRequestHandlerServiceProvider.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Ownership;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Http\Ownership\ApproveOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Ownership\GetOwnershipRequestHandler;
+use CultuurNet\UDB3\Http\Ownership\RejectOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Ownership\RequestOwnershipRequestHandler;
 use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
 use CultuurNet\UDB3\User\CurrentUser;
@@ -20,6 +21,7 @@ final class OwnershipRequestHandlerServiceProvider extends AbstractServiceProvid
             RequestOwnershipRequestHandler::class,
             GetOwnershipRequestHandler::class,
             ApproveOwnershipRequestHandler::class,
+            RejectOwnershipRequestHandler::class,
         ];
     }
 
@@ -48,6 +50,16 @@ final class OwnershipRequestHandlerServiceProvider extends AbstractServiceProvid
         $container->addShared(
             ApproveOwnershipRequestHandler::class,
             fn () => new ApproveOwnershipRequestHandler(
+                $container->get('event_command_bus'),
+                $container->get(OwnershipSearchRepository::class),
+                $container->get(CurrentUser::class),
+                $container->get('organizer_permission_voter')
+            )
+        );
+
+        $container->addShared(
+            RejectOwnershipRequestHandler::class,
+            fn () => new RejectOwnershipRequestHandler(
                 $container->get('event_command_bus'),
                 $container->get(OwnershipSearchRepository::class),
                 $container->get(CurrentUser::class),

--- a/features/Steps/OwnershipSteps.php
+++ b/features/Steps/OwnershipSteps.php
@@ -38,7 +38,7 @@ trait OwnershipSteps
         );
         $this->responseState->setResponse($response);
 
-        $this->theResponseStatusShouldBe(202);
+        $this->theResponseStatusShouldBe(204);
         $this->theResponseBodyShouldBeValidJson();
     }
 
@@ -53,7 +53,7 @@ trait OwnershipSteps
         );
         $this->responseState->setResponse($response);
 
-        $this->theResponseStatusShouldBe(202);
+        $this->theResponseStatusShouldBe(204);
         $this->theResponseBodyShouldBeValidJson();
     }
 

--- a/features/Steps/OwnershipSteps.php
+++ b/features/Steps/OwnershipSteps.php
@@ -43,6 +43,21 @@ trait OwnershipSteps
     }
 
     /**
+     * @When I reject the ownership with ownershipId :ownershipId
+     */
+    public function iRejectTheOwnershipWithOwnershipId(string $ownershipId): void
+    {
+        $response = $this->getHttpClient()->postJSON(
+            '/ownerships/' . $this->variableState->replaceVariables($ownershipId) . '/reject',
+            ''
+        );
+        $this->responseState->setResponse($response);
+
+        $this->theResponseStatusShouldBe(202);
+        $this->theResponseBodyShouldBeValidJson();
+    }
+
+    /**
      * @When I get the ownership with ownershipId :ownershipId
      */
     public function iGetTheOwnershipWithOwnershipId(string $ownershipId): void

--- a/features/Steps/OwnershipSteps.php
+++ b/features/Steps/OwnershipSteps.php
@@ -39,7 +39,6 @@ trait OwnershipSteps
         $this->responseState->setResponse($response);
 
         $this->theResponseStatusShouldBe(204);
-        $this->theResponseBodyShouldBeValidJson();
     }
 
     /**
@@ -54,7 +53,6 @@ trait OwnershipSteps
         $this->responseState->setResponse($response);
 
         $this->theResponseStatusShouldBe(204);
-        $this->theResponseBodyShouldBeValidJson();
     }
 
     /**

--- a/features/Steps/OwnershipSteps.php
+++ b/features/Steps/OwnershipSteps.php
@@ -32,9 +32,8 @@ trait OwnershipSteps
      */
     public function iApproveTheOwnershipWithOwnershipId(string $ownershipId): void
     {
-        $response = $this->getHttpClient()->postJSON(
+        $response = $this->getHttpClient()->postEmpty(
             '/ownerships/' . $this->variableState->replaceVariables($ownershipId) . '/approve',
-            ''
         );
         $this->responseState->setResponse($response);
 
@@ -46,9 +45,8 @@ trait OwnershipSteps
      */
     public function iRejectTheOwnershipWithOwnershipId(string $ownershipId): void
     {
-        $response = $this->getHttpClient()->postJSON(
+        $response = $this->getHttpClient()->postEmpty(
             '/ownerships/' . $this->variableState->replaceVariables($ownershipId) . '/reject',
-            ''
         );
         $this->responseState->setResponse($response);
 

--- a/features/Steps/OwnershipSteps.php
+++ b/features/Steps/OwnershipSteps.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Steps;
 
-use Behat\Behat\Tester\Exception\PendingException;
-
 trait OwnershipSteps
 {
     /**

--- a/features/Support/HttpClient.php
+++ b/features/Support/HttpClient.php
@@ -50,6 +50,11 @@ final class HttpClient
         ]);
     }
 
+    public function postEmpty(string $url): ResponseInterface
+    {
+        return $this->client->post($url);
+    }
+
     public function postJSON(string $url, string $json): ResponseInterface
     {
         return $this->client->post(

--- a/features/ownership/reject.feature
+++ b/features/ownership/reject.feature
@@ -1,0 +1,20 @@
+Feature: Test approving ownership
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I send and accept "application/json"
+
+  Scenario: Rejecting ownership of an organizer as admin
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I request ownership for "40fadfd3-c4a6-4936-b1fe-20542ac56610" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    When I reject the ownership with ownershipId "%{ownershipId}"
+    And I get the ownership with ownershipId "%{ownershipId}"
+    Then the JSON response at "id" should be "%{ownershipId}"
+    And the JSON response at "itemId" should be "%{organizerId}"
+    And the JSON response at "itemType" should be "organizer"
+    And the JSON response at "ownerId" should be "40fadfd3-c4a6-4936-b1fe-20542ac56610"
+    And the JSON response at "requesterId" should be "40fadfd3-c4a6-4936-b1fe-20542ac56610"
+    And the JSON response at "state" should be "rejected"

--- a/features/ownership/reject.feature
+++ b/features/ownership/reject.feature
@@ -18,3 +18,45 @@ Feature: Test rejecting ownership
     And the JSON response at "ownerId" should be "40fadfd3-c4a6-4936-b1fe-20542ac56610"
     And the JSON response at "requesterId" should be "40fadfd3-c4a6-4936-b1fe-20542ac56610"
     And the JSON response at "state" should be "rejected"
+
+  Scenario: Rejecting ownership of an organizer as creator
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I request ownership for "40fadfd3-c4a6-4936-b1fe-20542ac56610" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    When I reject the ownership with ownershipId "%{ownershipId}"
+    And I get the ownership with ownershipId "%{ownershipId}"
+    Then the JSON response at "id" should be "%{ownershipId}"
+    And the JSON response at "itemId" should be "%{organizerId}"
+    And the JSON response at "itemType" should be "organizer"
+    And the JSON response at "ownerId" should be "40fadfd3-c4a6-4936-b1fe-20542ac56610"
+    And the JSON response at "requesterId" should be "40fadfd3-c4a6-4936-b1fe-20542ac56610"
+    And the JSON response at "state" should be "rejected"
+
+  Scenario: Rejecting a non-existing ownership
+    When I send a POST request to '/ownerships/21a5c45b-78f8-4034-ab4d-5528847860b3/reject'
+    Then the response status should be 404
+    And the JSON response should be:
+      """
+      {
+       "type": "https://api.publiq.be/probs/url/not-found",
+       "title": "Not Found",
+       "status": 404,
+       "detail": "The Ownership with id \"21a5c45b-78f8-4034-ab4d-5528847860b3\" was not found."
+      }
+      """
+
+  Scenario: Rejecting an organizer as non-authorized user
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I request ownership for "40fadfd3-c4a6-4936-b1fe-20542ac56610" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    When I send a POST request to '/ownerships/%{ownershipId}/reject'
+    Then the response status should be 403
+    And the JSON response should be:
+      """
+      {
+        "type": "https://api.publiq.be/probs/auth/forbidden",
+        "title": "Forbidden",
+        "status": 403,
+        "detail": "You are not allowed to reject this ownership"
+      }
+      """

--- a/features/ownership/reject.feature
+++ b/features/ownership/reject.feature
@@ -1,4 +1,4 @@
-Feature: Test approving ownership
+Feature: Test rejecting ownership
   Background:
     Given I am using the UDB3 base URL
     And I am using an UiTID v1 API key of consumer "uitdatabank"

--- a/src/Http/Ownership/ApproveOwnershipRequestHandler.php
+++ b/src/Http/Ownership/ApproveOwnershipRequestHandler.php
@@ -66,7 +66,7 @@ final class ApproveOwnershipRequestHandler implements RequestHandlerInterface
 
         return new JsonResponse(
             [],
-            StatusCodeInterface::STATUS_ACCEPTED
+            StatusCodeInterface::STATUS_NO_CONTENT
         );
     }
 

--- a/src/Http/Ownership/ApproveOwnershipRequestHandler.php
+++ b/src/Http/Ownership/ApproveOwnershipRequestHandler.php
@@ -8,7 +8,6 @@ use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
-use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Commands\ApproveOwnership;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
@@ -61,7 +60,7 @@ final class ApproveOwnershipRequestHandler implements RequestHandlerInterface
         }
 
         $this->commandBus->dispatch(
-            new ApproveOwnership(new UUID($ownershipId), new UserId($this->currentUser->getId()))
+            new ApproveOwnership(new UUID($ownershipId))
         );
 
         return new JsonResponse(

--- a/src/Http/Ownership/RejectOwnershipRequestHandler.php
+++ b/src/Http/Ownership/RejectOwnershipRequestHandler.php
@@ -66,7 +66,7 @@ final class RejectOwnershipRequestHandler implements RequestHandlerInterface
 
         return new JsonResponse(
             [],
-            StatusCodeInterface::STATUS_ACCEPTED
+            StatusCodeInterface::STATUS_NO_CONTENT
         );
     }
 

--- a/src/Http/Ownership/RejectOwnershipRequestHandler.php
+++ b/src/Http/Ownership/RejectOwnershipRequestHandler.php
@@ -8,7 +8,6 @@ use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
-use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Commands\RejectOwnership;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
@@ -60,9 +59,7 @@ final class RejectOwnershipRequestHandler implements RequestHandlerInterface
             throw ApiProblem::forbidden('You are not allowed to reject this ownership');
         }
 
-        $this->commandBus->dispatch(
-            new RejectOwnership(new UUID($ownershipId), new UserId($this->currentUser->getId()))
-        );
+        $this->commandBus->dispatch(new RejectOwnership(new UUID($ownershipId)));
 
         return new JsonResponse(
             [],

--- a/src/Http/Ownership/RejectOwnershipRequestHandler.php
+++ b/src/Http/Ownership/RejectOwnershipRequestHandler.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Ownership;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\JsonResponse;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Ownership\Commands\RejectOwnership;
+use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
+use CultuurNet\UDB3\Ownership\Repositories\OwnershipItemNotFound;
+use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\Permission\PermissionVoter;
+use CultuurNet\UDB3\User\CurrentUser;
+use Fig\Http\Message\StatusCodeInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class RejectOwnershipRequestHandler implements RequestHandlerInterface
+{
+    private CommandBus $commandBus;
+    private OwnershipSearchRepository $ownershipSearchRepository;
+    private CurrentUser $currentUser;
+    private PermissionVoter $permissionVoter;
+
+    public function __construct(
+        CommandBus $commandBus,
+        OwnershipSearchRepository $ownershipSearchRepository,
+        CurrentUser $currentUser,
+        PermissionVoter $permissionVoter
+    ) {
+        $this->commandBus = $commandBus;
+        $this->ownershipSearchRepository = $ownershipSearchRepository;
+        $this->currentUser = $currentUser;
+        $this->permissionVoter = $permissionVoter;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+        $ownershipId = $routeParameters->getOwnershipId();
+
+        // Make sure there is an ownership
+        try {
+            $ownership = $this->ownershipSearchRepository->getById($ownershipId);
+        } catch (OwnershipItemNotFound $exception) {
+            throw ApiProblem::ownershipNotFound($ownershipId);
+        }
+
+        // Make sure the current user can reject the ownership
+        // This means that the current user is a god user
+        // Or that the current user is the owner of the item
+        if (!$this->isAllowedToRejectOwnership($ownership)) {
+            throw ApiProblem::forbidden('You are not allowed to reject this ownership');
+        }
+
+        $this->commandBus->dispatch(
+            new RejectOwnership(new UUID($ownershipId), new UserId($this->currentUser->getId()))
+        );
+
+        return new JsonResponse(
+            [],
+            StatusCodeInterface::STATUS_ACCEPTED
+        );
+    }
+
+    private function isAllowedToRejectOwnership(OwnershipItem $ownership): bool
+    {
+        if ($this->currentUser->isGodUser()) {
+            return true;
+        }
+
+        return $this->permissionVoter->isAllowed(
+            Permission::organisatiesBeheren(),
+            $ownership->getItemId(),
+            $this->currentUser->getId()
+        );
+    }
+}

--- a/src/Ownership/CommandHandlers/ApproveOwnershipHandler.php
+++ b/src/Ownership/CommandHandlers/ApproveOwnershipHandler.php
@@ -25,7 +25,7 @@ final class ApproveOwnershipHandler implements CommandHandler
 
         $ownership = $this->ownershipRepository->load($command->getId()->toString());
 
-        $ownership->approve($command->getRequesterId());
+        $ownership->approve();
 
         $this->ownershipRepository->save($ownership);
     }

--- a/src/Ownership/CommandHandlers/ApproveOwnershipHandler.php
+++ b/src/Ownership/CommandHandlers/ApproveOwnershipHandler.php
@@ -25,7 +25,7 @@ final class ApproveOwnershipHandler implements CommandHandler
 
         $ownership = $this->ownershipRepository->load($command->getId()->toString());
 
-        $ownership->approve($command->getApproverId());
+        $ownership->approve($command->getRequesterId());
 
         $this->ownershipRepository->save($ownership);
     }

--- a/src/Ownership/CommandHandlers/RejectOwnershipHandler.php
+++ b/src/Ownership/CommandHandlers/RejectOwnershipHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\CommandHandlers;
+
+use Broadway\CommandHandling\CommandHandler;
+use CultuurNet\UDB3\Ownership\Commands\RejectOwnership;
+use CultuurNet\UDB3\Ownership\OwnershipRepository;
+
+final class RejectOwnershipHandler implements CommandHandler
+{
+    private OwnershipRepository $ownershipRepository;
+
+    public function __construct(OwnershipRepository $ownershipRepository)
+    {
+        $this->ownershipRepository = $ownershipRepository;
+    }
+
+    public function handle($command): void
+    {
+        if (!$command instanceof RejectOwnership) {
+            return;
+        }
+
+        $ownership = $this->ownershipRepository->load($command->getId()->toString());
+
+        $ownership->reject($command->getRequesterId());
+
+        $this->ownershipRepository->save($ownership);
+    }
+}

--- a/src/Ownership/CommandHandlers/RejectOwnershipHandler.php
+++ b/src/Ownership/CommandHandlers/RejectOwnershipHandler.php
@@ -25,7 +25,7 @@ final class RejectOwnershipHandler implements CommandHandler
 
         $ownership = $this->ownershipRepository->load($command->getId()->toString());
 
-        $ownership->reject($command->getRequesterId());
+        $ownership->reject();
 
         $this->ownershipRepository->save($ownership);
     }

--- a/src/Ownership/Commands/ApproveOwnership.php
+++ b/src/Ownership/Commands/ApproveOwnership.php
@@ -10,12 +10,12 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 final class ApproveOwnership
 {
     private UUID $id;
-    private UserId $approverId;
+    private UserId $requesterId;
 
     public function __construct(UUID $id, UserId $requesterId)
     {
         $this->id = $id;
-        $this->approverId = $requesterId;
+        $this->requesterId = $requesterId;
     }
 
     public function getId(): UUID
@@ -23,8 +23,8 @@ final class ApproveOwnership
         return $this->id;
     }
 
-    public function getApproverId(): UserId
+    public function getRequesterId(): UserId
     {
-        return $this->approverId;
+        return $this->requesterId;
     }
 }

--- a/src/Ownership/Commands/ApproveOwnership.php
+++ b/src/Ownership/Commands/ApproveOwnership.php
@@ -4,27 +4,19 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Ownership\Commands;
 
-use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 
 final class ApproveOwnership
 {
     private UUID $id;
-    private UserId $requesterId;
 
-    public function __construct(UUID $id, UserId $requesterId)
+    public function __construct(UUID $id)
     {
         $this->id = $id;
-        $this->requesterId = $requesterId;
     }
 
     public function getId(): UUID
     {
         return $this->id;
-    }
-
-    public function getRequesterId(): UserId
-    {
-        return $this->requesterId;
     }
 }

--- a/src/Ownership/Commands/RejectOwnership.php
+++ b/src/Ownership/Commands/RejectOwnership.php
@@ -4,27 +4,19 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Ownership\Commands;
 
-use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 
 final class RejectOwnership
 {
     private UUID $id;
-    private UserId $requesterId;
 
-    public function __construct(UUID $id, UserId $requesterId)
+    public function __construct(UUID $id)
     {
         $this->id = $id;
-        $this->requesterId = $requesterId;
     }
 
     public function getId(): UUID
     {
         return $this->id;
-    }
-
-    public function getRequesterId(): UserId
-    {
-        return $this->requesterId;
     }
 }

--- a/src/Ownership/Commands/RejectOwnership.php
+++ b/src/Ownership/Commands/RejectOwnership.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\Commands;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+
+final class RejectOwnership
+{
+    private UUID $id;
+    private UserId $requesterId;
+
+    public function __construct(UUID $id, UserId $requesterId)
+    {
+        $this->id = $id;
+        $this->requesterId = $requesterId;
+    }
+
+    public function getId(): UUID
+    {
+        return $this->id;
+    }
+
+    public function getRequesterId(): UserId
+    {
+        return $this->requesterId;
+    }
+}

--- a/src/Ownership/Events/OwnershipApproved.php
+++ b/src/Ownership/Events/OwnershipApproved.php
@@ -9,12 +9,10 @@ use Broadway\Serializer\Serializable;
 final class OwnershipApproved implements Serializable
 {
     private string $id;
-    private string $requesterId;
 
-    public function __construct(string $id, string $requesterId)
+    public function __construct(string $id)
     {
         $this->id = $id;
-        $this->requesterId = $requesterId;
     }
 
     public function getId(): string
@@ -22,24 +20,15 @@ final class OwnershipApproved implements Serializable
         return $this->id;
     }
 
-    public function getRequesterId(): string
-    {
-        return $this->requesterId;
-    }
-
     public static function deserialize(array $data): self
     {
-        return new OwnershipApproved(
-            $data['ownershipId'],
-            $data['requesterId']
-        );
+        return new OwnershipApproved($data['ownershipId']);
     }
 
     public function serialize(): array
     {
         return [
             'ownershipId' => $this->id,
-            'requesterId' => $this->requesterId,
         ];
     }
 }

--- a/src/Ownership/Events/OwnershipRejected.php
+++ b/src/Ownership/Events/OwnershipRejected.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\Events;
+
+use Broadway\Serializer\Serializable;
+
+final class OwnershipRejected implements Serializable
+{
+    private string $id;
+    private string $requesterId;
+
+    public function __construct(string $id, string $requesterId)
+    {
+        $this->id = $id;
+        $this->requesterId = $requesterId;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getRequesterId(): string
+    {
+        return $this->requesterId;
+    }
+
+    public static function deserialize(array $data): self
+    {
+        return new OwnershipRejected(
+            $data['ownershipId'],
+            $data['requesterId']
+        );
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'ownershipId' => $this->id,
+            'requesterId' => $this->requesterId,
+        ];
+    }
+}

--- a/src/Ownership/Events/OwnershipRejected.php
+++ b/src/Ownership/Events/OwnershipRejected.php
@@ -9,12 +9,10 @@ use Broadway\Serializer\Serializable;
 final class OwnershipRejected implements Serializable
 {
     private string $id;
-    private string $requesterId;
 
-    public function __construct(string $id, string $requesterId)
+    public function __construct(string $id)
     {
         $this->id = $id;
-        $this->requesterId = $requesterId;
     }
 
     public function getId(): string
@@ -22,24 +20,15 @@ final class OwnershipRejected implements Serializable
         return $this->id;
     }
 
-    public function getRequesterId(): string
-    {
-        return $this->requesterId;
-    }
-
     public static function deserialize(array $data): self
     {
-        return new OwnershipRejected(
-            $data['ownershipId'],
-            $data['requesterId']
-        );
+        return new OwnershipRejected($data['ownershipId']);
     }
 
     public function serialize(): array
     {
         return [
             'ownershipId' => $this->id,
-            'requesterId' => $this->requesterId,
         ];
     }
 }

--- a/src/Ownership/Ownership.php
+++ b/src/Ownership/Ownership.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
+use CultuurNet\UDB3\Ownership\Events\OwnershipRejected;
 use CultuurNet\UDB3\Ownership\Events\OwnershipRequested;
 
 final class Ownership extends EventSourcedAggregateRoot
@@ -55,6 +56,18 @@ final class Ownership extends EventSourcedAggregateRoot
         }
     }
 
+    public function reject(UserId $requesterId): void
+    {
+        if ($this->state->sameAs(OwnershipState::requested())) {
+            $this->apply(
+                new OwnershipRejected(
+                    $this->id,
+                    $requesterId->toString()
+                )
+            );
+        }
+    }
+
     protected function applyOwnershipRequested(OwnershipRequested $ownershipRequested): void
     {
         $this->id = $ownershipRequested->getId();
@@ -64,5 +77,10 @@ final class Ownership extends EventSourcedAggregateRoot
     protected function applyOwnershipApproved(OwnershipApproved $ownershipApproved): void
     {
         $this->state = OwnershipState::approved();
+    }
+
+    protected function applyOwnershipRejected(OwnershipRejected $ownershipRejected): void
+    {
+        $this->state = OwnershipState::rejected();
     }
 }

--- a/src/Ownership/Ownership.php
+++ b/src/Ownership/Ownership.php
@@ -43,13 +43,13 @@ final class Ownership extends EventSourcedAggregateRoot
         return $ownership;
     }
 
-    public function approve(UserId $approverId): void
+    public function approve(UserId $requesterId): void
     {
         if ($this->state->sameAs(OwnershipState::requested())) {
             $this->apply(
                 new OwnershipApproved(
                     $this->id,
-                    $approverId->toString()
+                    $requesterId->toString()
                 )
             );
         }

--- a/src/Ownership/Ownership.php
+++ b/src/Ownership/Ownership.php
@@ -44,27 +44,19 @@ final class Ownership extends EventSourcedAggregateRoot
         return $ownership;
     }
 
-    public function approve(UserId $requesterId): void
+    public function approve(): void
     {
         if ($this->state->sameAs(OwnershipState::requested())) {
             $this->apply(
-                new OwnershipApproved(
-                    $this->id,
-                    $requesterId->toString()
-                )
+                new OwnershipApproved($this->id)
             );
         }
     }
 
-    public function reject(UserId $requesterId): void
+    public function reject(): void
     {
         if ($this->state->sameAs(OwnershipState::requested())) {
-            $this->apply(
-                new OwnershipRejected(
-                    $this->id,
-                    $requesterId->toString()
-                )
-            );
+            $this->apply(new OwnershipRejected($this->id));
         }
     }
 

--- a/src/Ownership/Readmodels/OwnershipLDProjector.php
+++ b/src/Ownership/Readmodels/OwnershipLDProjector.php
@@ -9,6 +9,7 @@ use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListener;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
+use CultuurNet\UDB3\Ownership\Events\OwnershipRejected;
 use CultuurNet\UDB3\Ownership\Events\OwnershipRequested;
 use CultuurNet\UDB3\Ownership\OwnershipState;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
@@ -72,6 +73,16 @@ final class OwnershipLDProjector implements EventListener
 
         $body = $jsonDocument->getBody();
         $body->state = OwnershipState::approved()->toString();
+
+        return $jsonDocument->withBody($body);
+    }
+
+    public function applyOwnershipRejected(OwnershipRejected $ownershipRejected, DomainMessage $domainMessage): JsonDocument
+    {
+        $jsonDocument = $this->repository->fetch($ownershipRejected->getId());
+
+        $body = $jsonDocument->getBody();
+        $body->state = OwnershipState::rejected()->toString();
 
         return $jsonDocument->withBody($body);
     }

--- a/tests/Http/Ownership/ApproveOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/ApproveOwnershipRequestHandlerTest.php
@@ -8,7 +8,6 @@ use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
-use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Commands\ApproveOwnership;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
@@ -80,10 +79,7 @@ class ApproveOwnershipRequestHandlerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
-                new ApproveOwnership(
-                    new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
-                    new UserId('auth0|63e22626e39a8ca1264bd29b')
-                ),
+                new ApproveOwnership(new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')),
             ],
             $this->commandBus->getRecordedCommands()
         );
@@ -118,10 +114,7 @@ class ApproveOwnershipRequestHandlerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
-                new ApproveOwnership(
-                    new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
-                    new UserId('auth0|63e22626e39a8ca1264bd29b')
-                ),
+                new ApproveOwnership(new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')),
             ],
             $this->commandBus->getRecordedCommands()
         );

--- a/tests/Http/Ownership/ApproveOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/ApproveOwnershipRequestHandlerTest.php
@@ -77,7 +77,7 @@ class ApproveOwnershipRequestHandlerTest extends TestCase
 
         $response = $this->approveOwnershipRequestHandler->handle($request);
 
-        $this->assertEquals(202, $response->getStatusCode());
+        $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
                 new ApproveOwnership(
@@ -115,7 +115,7 @@ class ApproveOwnershipRequestHandlerTest extends TestCase
 
         $response = $this->approveOwnershipRequestHandler->handle($request);
 
-        $this->assertEquals(202, $response->getStatusCode());
+        $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
                 new ApproveOwnership(

--- a/tests/Http/Ownership/RejectOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/RejectOwnershipRequestHandlerTest.php
@@ -8,7 +8,6 @@ use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
-use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Commands\RejectOwnership;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
@@ -80,10 +79,7 @@ class RejectOwnershipRequestHandlerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
-                new RejectOwnership(
-                    new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
-                    new UserId('auth0|63e22626e39a8ca1264bd29b')
-                ),
+                new RejectOwnership(new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')),
             ],
             $this->commandBus->getRecordedCommands()
         );
@@ -118,10 +114,7 @@ class RejectOwnershipRequestHandlerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
-                new RejectOwnership(
-                    new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
-                    new UserId('auth0|63e22626e39a8ca1264bd29b')
-                ),
+                new RejectOwnership(new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')),
             ],
             $this->commandBus->getRecordedCommands()
         );

--- a/tests/Http/Ownership/RejectOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/RejectOwnershipRequestHandlerTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Ownership;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Ownership\Commands\RejectOwnership;
+use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
+use CultuurNet\UDB3\Ownership\Repositories\OwnershipItemNotFound;
+use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
+use CultuurNet\UDB3\Security\Permission\PermissionVoter;
+use CultuurNet\UDB3\User\CurrentUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class RejectOwnershipRequestHandlerTest extends TestCase
+{
+    use AssertApiProblemTrait;
+
+    private TraceableCommandBus $commandBus;
+
+    /** @var OwnershipSearchRepository&MockObject */
+    private $ownerShipSearchRepository;
+
+    /** @var PermissionVoter&MockObject */
+    private $permissionVoter;
+
+    private RejectOwnershipRequestHandler $rejectOwnershipRequestHandler;
+
+    public function setUp(): void
+    {
+        $this->commandBus = new TraceableCommandBus();
+        $this->commandBus->record();
+
+        $this->ownerShipSearchRepository = $this->createMock(OwnershipSearchRepository::class);
+
+        $this->permissionVoter = $this->createMock(PermissionVoter::class);
+
+        $this->rejectOwnershipRequestHandler = new RejectOwnershipRequestHandler(
+            $this->commandBus,
+            $this->ownerShipSearchRepository,
+            new CurrentUser('auth0|63e22626e39a8ca1264bd29b'),
+            $this->permissionVoter
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_rejecting_an_ownership(): void
+    {
+        CurrentUser::configureGodUserIds([]);
+
+        $ownershipId = 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e';
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('ownershipId', $ownershipId)
+            ->build('POST');
+
+        $this->ownerShipSearchRepository->expects($this->once())
+            ->method('getById')
+            ->willReturn(new OwnershipItem(
+                $ownershipId,
+                '9e68dafc-01d8-4c1c-9612-599c918b981d',
+                'organizer',
+                'auth0|63e22626e39a8ca1264bd29b'
+            ));
+
+        $this->permissionVoter->expects($this->once())
+            ->method('isAllowed')
+            ->willReturn(true);
+
+        $response = $this->rejectOwnershipRequestHandler->handle($request);
+
+        $this->assertEquals(202, $response->getStatusCode());
+        $this->assertEquals(
+            [
+                new RejectOwnership(
+                    new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                    new UserId('auth0|63e22626e39a8ca1264bd29b')
+                ),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_rejecting_an_ownership_as_god_user(): void
+    {
+        CurrentUser::configureGodUserIds(['auth0|63e22626e39a8ca1264bd29b']);
+
+        $ownershipId = 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e';
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('ownershipId', $ownershipId)
+            ->build('POST');
+
+        $this->ownerShipSearchRepository->expects($this->once())
+            ->method('getById')
+            ->willReturn(new OwnershipItem(
+                $ownershipId,
+                '9e68dafc-01d8-4c1c-9612-599c918b981d',
+                'organizer',
+                'auth0|63e22626e39a8ca1264bd29b'
+            ));
+
+        $this->permissionVoter->expects($this->never())
+            ->method('isAllowed');
+
+        $response = $this->rejectOwnershipRequestHandler->handle($request);
+
+        $this->assertEquals(202, $response->getStatusCode());
+        $this->assertEquals(
+            [
+                new RejectOwnership(
+                    new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                    new UserId('auth0|63e22626e39a8ca1264bd29b')
+                ),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_an_api_problem_when_the_ownership_is_not_found(): void
+    {
+        $ownershipId = 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e';
+
+        $this->ownerShipSearchRepository->expects($this->once())
+            ->method('getById')
+            ->willThrowException(OwnershipItemNotFound::byId($ownershipId));
+
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('ownershipId', $ownershipId)
+            ->build('POST');
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::ownershipNotFound('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+            fn () => $this->rejectOwnershipRequestHandler->handle($request)
+        );
+
+        $this->assertEquals([], $this->commandBus->getRecordedCommands());
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_an_api_problem_when_the_user_is_not_allowed_to_reject_the_ownership(): void
+    {
+        $ownershipId = 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e';
+        CurrentUser::configureGodUserIds([]);
+
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('ownershipId', $ownershipId)
+            ->build('POST');
+
+        $this->ownerShipSearchRepository->expects($this->once())
+            ->method('getById')
+            ->willReturn(new OwnershipItem(
+                $ownershipId,
+                '9e68dafc-01d8-4c1c-9612-599c918b981d',
+                'organizer',
+                'auth0|63e22626e39a8ca1264bd29b'
+            ));
+
+        $this->permissionVoter->expects($this->once())
+            ->method('isAllowed')
+            ->willReturn(false);
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::forbidden('You are not allowed to reject this ownership'),
+            fn () => $this->rejectOwnershipRequestHandler->handle($request)
+        );
+
+        $this->assertEquals([], $this->commandBus->getRecordedCommands());
+    }
+}

--- a/tests/Http/Ownership/RejectOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/RejectOwnershipRequestHandlerTest.php
@@ -77,7 +77,7 @@ class RejectOwnershipRequestHandlerTest extends TestCase
 
         $response = $this->rejectOwnershipRequestHandler->handle($request);
 
-        $this->assertEquals(202, $response->getStatusCode());
+        $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
                 new RejectOwnership(
@@ -115,7 +115,7 @@ class RejectOwnershipRequestHandlerTest extends TestCase
 
         $response = $this->rejectOwnershipRequestHandler->handle($request);
 
-        $this->assertEquals(202, $response->getStatusCode());
+        $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
                 new RejectOwnership(

--- a/tests/Ownership/CommandHandlers/ApproveOwnershipHandlerTest.php
+++ b/tests/Ownership/CommandHandlers/ApproveOwnershipHandlerTest.php
@@ -8,7 +8,6 @@ use Broadway\CommandHandling\CommandHandler;
 use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
 use Broadway\EventHandling\EventBus;
 use Broadway\EventStore\EventStore;
-use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Commands\ApproveOwnership;
 use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
@@ -39,13 +38,11 @@ class ApproveOwnershipHandlerTest extends CommandHandlerScenarioTestCase
                 ),
             ])
             ->when(new ApproveOwnership(
-                new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
-                new UserId('google-oauth2|102486314601596809843')
+                new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
             ))
             ->then([
                 new OwnershipApproved(
-                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
-                    'google-oauth2|102486314601596809843'
+                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'
                 ),
             ]);
     }

--- a/tests/Ownership/CommandHandlers/RejectOwnershipHandlerTest.php
+++ b/tests/Ownership/CommandHandlers/RejectOwnershipHandlerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\CommandHandlers;
+
+use Broadway\CommandHandling\CommandHandler;
+use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
+use Broadway\EventHandling\EventBus;
+use Broadway\EventStore\EventStore;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Ownership\Commands\RejectOwnership;
+use CultuurNet\UDB3\Ownership\Events\OwnershipRejected;
+use CultuurNet\UDB3\Ownership\Events\OwnershipRequested;
+use CultuurNet\UDB3\Ownership\OwnershipRepository;
+
+class RejectOwnershipHandlerTest extends CommandHandlerScenarioTestCase
+{
+    protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
+    {
+        return new RejectOwnershipHandler(new OwnershipRepository($eventStore, $eventBus));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_approving_ownership(): void
+    {
+        $this->scenario
+            ->withAggregateId('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
+            ->given([
+                new OwnershipRequested(
+                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+                    '9e68dafc-01d8-4c1c-9612-599c918b981d',
+                    'organizer',
+                    'auth0|63e22626e39a8ca1264bd29b',
+                    'google-oauth2|102486314601596809843'
+                ),
+            ])
+            ->when(new RejectOwnership(
+                new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                new UserId('google-oauth2|102486314601596809843')
+            ))
+            ->then([
+                new OwnershipRejected(
+                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+                    'google-oauth2|102486314601596809843'
+                ),
+            ]);
+    }
+}

--- a/tests/Ownership/CommandHandlers/RejectOwnershipHandlerTest.php
+++ b/tests/Ownership/CommandHandlers/RejectOwnershipHandlerTest.php
@@ -8,7 +8,6 @@ use Broadway\CommandHandling\CommandHandler;
 use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
 use Broadway\EventHandling\EventBus;
 use Broadway\EventStore\EventStore;
-use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Commands\RejectOwnership;
 use CultuurNet\UDB3\Ownership\Events\OwnershipRejected;
@@ -38,15 +37,11 @@ class RejectOwnershipHandlerTest extends CommandHandlerScenarioTestCase
                     'google-oauth2|102486314601596809843'
                 ),
             ])
-            ->when(new RejectOwnership(
-                new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
-                new UserId('google-oauth2|102486314601596809843')
-            ))
+            ->when(
+                new RejectOwnership(new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'))
+            )
             ->then([
-                new OwnershipRejected(
-                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
-                    'google-oauth2|102486314601596809843'
-                ),
+                new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
             ]);
     }
 }

--- a/tests/Ownership/Commands/ApproveOwnershipTest.php
+++ b/tests/Ownership/Commands/ApproveOwnershipTest.php
@@ -36,11 +36,11 @@ class ApproveOwnershipTest extends TestCase
     /**
      * @test
      */
-    public function it_stores_an_approver_id(): void
+    public function it_stores_a_requester_id(): void
     {
         $this->assertEquals(
             new UserId('auth0|63e22626e39a8ca1264bd29b'),
-            $this->approveOwnership->getApproverId()
+            $this->approveOwnership->getRequesterId()
         );
     }
 }

--- a/tests/Ownership/Commands/ApproveOwnershipTest.php
+++ b/tests/Ownership/Commands/ApproveOwnershipTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Ownership\Commands;
 
-use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
 
@@ -17,8 +16,7 @@ class ApproveOwnershipTest extends TestCase
         parent::setUp();
 
         $this->approveOwnership = new ApproveOwnership(
-            new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
-            new UserId('auth0|63e22626e39a8ca1264bd29b')
+            new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
         );
     }
 
@@ -30,17 +28,6 @@ class ApproveOwnershipTest extends TestCase
         $this->assertEquals(
             new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
             $this->approveOwnership->getId()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_stores_a_requester_id(): void
-    {
-        $this->assertEquals(
-            new UserId('auth0|63e22626e39a8ca1264bd29b'),
-            $this->approveOwnership->getRequesterId()
         );
     }
 }

--- a/tests/Ownership/Commands/RejectOwnershipTest.php
+++ b/tests/Ownership/Commands/RejectOwnershipTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Ownership\Commands;
 
-use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
 
@@ -16,10 +15,7 @@ class RejectOwnershipTest extends TestCase
     {
         parent::setUp();
 
-        $this->rejectOwnership = new RejectOwnership(
-            new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
-            new UserId('auth0|63e22626e39a8ca1264bd29b')
-        );
+        $this->rejectOwnership = new RejectOwnership(new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'));
     }
 
     /**
@@ -30,17 +26,6 @@ class RejectOwnershipTest extends TestCase
         $this->assertEquals(
             new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
             $this->rejectOwnership->getId()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_stores_a_requester_id(): void
-    {
-        $this->assertEquals(
-            new UserId('auth0|63e22626e39a8ca1264bd29b'),
-            $this->rejectOwnership->getRequesterId()
         );
     }
 }

--- a/tests/Ownership/Commands/RejectOwnershipTest.php
+++ b/tests/Ownership/Commands/RejectOwnershipTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\Commands;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use PHPUnit\Framework\TestCase;
+
+class RejectOwnershipTest extends TestCase
+{
+    private RejectOwnership $rejectOwnership;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rejectOwnership = new RejectOwnership(
+            new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+            new UserId('auth0|63e22626e39a8ca1264bd29b')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_id(): void
+    {
+        $this->assertEquals(
+            new UUID('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+            $this->rejectOwnership->getId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_requester_id(): void
+    {
+        $this->assertEquals(
+            new UserId('auth0|63e22626e39a8ca1264bd29b'),
+            $this->rejectOwnership->getRequesterId()
+        );
+    }
+}

--- a/tests/Ownership/Events/OwnershipApprovedTest.php
+++ b/tests/Ownership/Events/OwnershipApprovedTest.php
@@ -14,10 +14,7 @@ class OwnershipApprovedTest extends TestCase
     {
         parent::setUp();
 
-        $this->ownershipApproved = new OwnershipApproved(
-            'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
-            'auth0|63e22626e39a8ca1264bd29b'
-        );
+        $this->ownershipApproved = new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e');
     }
 
     /**
@@ -33,24 +30,12 @@ class OwnershipApprovedTest extends TestCase
 
     /**
      * @test
-     */
-    public function it_stores_a_requester_id(): void
-    {
-        $this->assertEquals(
-            'auth0|63e22626e39a8ca1264bd29b',
-            $this->ownershipApproved->getRequesterId()
-        );
-    }
-
-    /**
-     * @test
     */
     public function it_can_be_serialized(): void
     {
         $this->assertEquals(
             [
                 'ownershipId' => 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
-                'requesterId' => 'auth0|63e22626e39a8ca1264bd29b',
             ],
             $this->ownershipApproved->serialize()
         );
@@ -63,7 +48,6 @@ class OwnershipApprovedTest extends TestCase
     {
         $serialized = [
             'ownershipId' => 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
-            'requesterId' => 'auth0|63e22626e39a8ca1264bd29b',
         ];
 
         $this->assertEquals($this->ownershipApproved, OwnershipApproved::deserialize($serialized));

--- a/tests/Ownership/Events/OwnershipRejectedTest.php
+++ b/tests/Ownership/Events/OwnershipRejectedTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\Events;
+
+use PHPUnit\Framework\TestCase;
+
+class OwnershipRejectedTest extends TestCase
+{
+    private OwnershipRejected $ownershipRejected;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ownershipRejected = new OwnershipRejected(
+            'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+            'auth0|63e22626e39a8ca1264bd29b'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_id(): void
+    {
+        $this->assertEquals(
+            'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+            $this->ownershipRejected->getId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_requester_id(): void
+    {
+        $this->assertEquals(
+            'auth0|63e22626e39a8ca1264bd29b',
+            $this->ownershipRejected->getRequesterId()
+        );
+    }
+}

--- a/tests/Ownership/Events/OwnershipRejectedTest.php
+++ b/tests/Ownership/Events/OwnershipRejectedTest.php
@@ -14,10 +14,7 @@ class OwnershipRejectedTest extends TestCase
     {
         parent::setUp();
 
-        $this->ownershipRejected = new OwnershipRejected(
-            'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
-            'auth0|63e22626e39a8ca1264bd29b'
-        );
+        $this->ownershipRejected = new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e');
     }
 
     /**
@@ -34,11 +31,25 @@ class OwnershipRejectedTest extends TestCase
     /**
      * @test
      */
-    public function it_stores_a_requester_id(): void
+    public function it_can_be_serialized(): void
     {
         $this->assertEquals(
-            'auth0|63e22626e39a8ca1264bd29b',
-            $this->ownershipRejected->getRequesterId()
+            [
+                'ownershipId' => 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+            ],
+            $this->ownershipRejected->serialize()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_deserialized(): void
+    {
+        $serialized = [
+            'ownershipId' => 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+        ];
+
+        $this->assertEquals($this->ownershipRejected, OwnershipRejected::deserialize($serialized));
     }
 }

--- a/tests/Ownership/OwnershipTest.php
+++ b/tests/Ownership/OwnershipTest.php
@@ -62,13 +62,10 @@ class OwnershipTest extends AggregateRootScenarioTestCase
                 ),
             ])
             ->when(function (Ownership $ownership) {
-                $ownership->approve(new UserId('google-oauth2|102486314601596809843'));
+                $ownership->approve();
             })
             ->then([
-                new OwnershipApproved(
-                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
-                    'google-oauth2|102486314601596809843'
-                ),
+                new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
             ]);
     }
 
@@ -87,13 +84,10 @@ class OwnershipTest extends AggregateRootScenarioTestCase
                     'auth0|63e22626e39a8ca1264bd29b',
                     'google-oauth2|102486314601596809843'
                 ),
-                new OwnershipApproved(
-                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
-                    'google-oauth2|102486314601596809843'
-                ),
+                new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
             ])
             ->when(function (Ownership $ownership) {
-                $ownership->approve(new UserId('google-oauth2|102486314601596809843'));
+                $ownership->approve();
             })
             ->then([]);
     }
@@ -115,13 +109,10 @@ class OwnershipTest extends AggregateRootScenarioTestCase
                 ),
             ])
             ->when(function (Ownership $ownership) {
-                $ownership->reject(new UserId('google-oauth2|102486314601596809843'));
+                $ownership->reject();
             })
             ->then([
-                new OwnershipRejected(
-                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
-                    'google-oauth2|102486314601596809843'
-                ),
+                new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
             ]);
     }
 
@@ -140,13 +131,10 @@ class OwnershipTest extends AggregateRootScenarioTestCase
                     'auth0|63e22626e39a8ca1264bd29b',
                     'google-oauth2|102486314601596809843'
                 ),
-                new OwnershipRejected(
-                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
-                    'google-oauth2|102486314601596809843'
-                ),
+                new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
             ])
             ->when(function (Ownership $ownership) {
-                $ownership->reject(new UserId('google-oauth2|102486314601596809843'));
+                $ownership->reject();
             })
             ->then([]);
     }

--- a/tests/Ownership/OwnershipTest.php
+++ b/tests/Ownership/OwnershipTest.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
+use CultuurNet\UDB3\Ownership\Events\OwnershipRejected;
 use CultuurNet\UDB3\Ownership\Events\OwnershipRequested;
 
 class OwnershipTest extends AggregateRootScenarioTestCase
@@ -93,6 +94,59 @@ class OwnershipTest extends AggregateRootScenarioTestCase
             ])
             ->when(function (Ownership $ownership) {
                 $ownership->approve(new UserId('google-oauth2|102486314601596809843'));
+            })
+            ->then([]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_rejected(): void
+    {
+        $this->scenario
+            ->withAggregateId('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
+            ->given([
+                new OwnershipRequested(
+                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+                    '9e68dafc-01d8-4c1c-9612-599c918b981d',
+                    'organizer',
+                    'auth0|63e22626e39a8ca1264bd29b',
+                    'google-oauth2|102486314601596809843'
+                ),
+            ])
+            ->when(function (Ownership $ownership) {
+                $ownership->reject(new UserId('google-oauth2|102486314601596809843'));
+            })
+            ->then([
+                new OwnershipRejected(
+                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+                    'google-oauth2|102486314601596809843'
+                ),
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_rejects_only_once(): void
+    {
+        $this->scenario
+            ->withAggregateId('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
+            ->given([
+                new OwnershipRequested(
+                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+                    '9e68dafc-01d8-4c1c-9612-599c918b981d',
+                    'organizer',
+                    'auth0|63e22626e39a8ca1264bd29b',
+                    'google-oauth2|102486314601596809843'
+                ),
+                new OwnershipRejected(
+                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+                    'google-oauth2|102486314601596809843'
+                ),
+            ])
+            ->when(function (Ownership $ownership) {
+                $ownership->reject(new UserId('google-oauth2|102486314601596809843'));
             })
             ->then([]);
     }

--- a/tests/Ownership/Readmodels/OwnershipLDProjectorTest.php
+++ b/tests/Ownership/Readmodels/OwnershipLDProjectorTest.php
@@ -85,10 +85,7 @@ class OwnershipLDProjectorTest extends TestCase
             )
         );
 
-        $ownershipApproved = new OwnershipApproved(
-            $ownershipId,
-            '9e68dafc-01d8-4c1c-9612-599c918b981d'
-        );
+        $ownershipApproved = new OwnershipApproved($ownershipId);
 
         $domainMessage = new DomainMessage(
             $ownershipId,
@@ -128,10 +125,7 @@ class OwnershipLDProjectorTest extends TestCase
             )
         );
 
-        $ownershipRejected = new OwnershipRejected(
-            $ownershipId,
-            '9e68dafc-01d8-4c1c-9612-599c918b981d'
-        );
+        $ownershipRejected = new OwnershipRejected($ownershipId, );
 
         $domainMessage = new DomainMessage(
             $ownershipId,


### PR DESCRIPTION
### Added
- Added endpoint `POST /ownerships/{ownershipId}/reject` to reject an ownership

### Note
- There is some overlapping code in the request handler, I will change that in a follow-up pull request

---
Ticket: https://jira.uitdatabank.be/browse/III-6072
