### PR TITLE
III-6071 Add endpoint to search ownerships on item id

### DIFF
--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -72,6 +72,7 @@ use CultuurNet\UDB3\Http\Ownership\DeleteOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Ownership\GetOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Ownership\RejectOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Ownership\RequestOwnershipRequestHandler;
+use CultuurNet\UDB3\Http\Ownership\SearchOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Place\GetEventsRequestHandler;
 use CultuurNet\UDB3\Http\Place\UpdateAddressRequestHandler as UpdatePlaceAddressRequestHandler;
 use CultuurNet\UDB3\Http\Place\UpdateMajorInfoRequestHandler as UpdatePlaceMajorInfoRequestHandler;
@@ -373,10 +374,14 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
     private function bindOwnerships(Router $router): void
     {
         $router->group('ownerships', function (RouteGroup $routeGroup): void {
+            $routeGroup->get('', SearchOwnershipRequestHandler::class);
+            $routeGroup->get('{ownershipId}/', GetOwnershipRequestHandler::class);
+
             $routeGroup->post('', RequestOwnershipRequestHandler::class);
+
             $routeGroup->post('{ownershipId}/approve/', ApproveOwnershipRequestHandler::class);
             $routeGroup->post('{ownershipId}/reject/', RejectOwnershipRequestHandler::class);
-            $routeGroup->get('{ownershipId}/', GetOwnershipRequestHandler::class);
+
             $routeGroup->delete('{ownershipId}/', DeleteOwnershipRequestHandler::class);
         });
     }

--- a/app/Ownership/OwnershipRequestHandlerServiceProvider.php
+++ b/app/Ownership/OwnershipRequestHandlerServiceProvider.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Http\Ownership\GetOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Ownership\OwnershipStatusGuard;
 use CultuurNet\UDB3\Http\Ownership\RejectOwnershipRequestHandler;
 use CultuurNet\UDB3\Http\Ownership\RequestOwnershipRequestHandler;
+use CultuurNet\UDB3\Http\Ownership\SearchOwnershipRequestHandler;
 use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
 use CultuurNet\UDB3\User\CurrentUser;
 use Ramsey\Uuid\UuidFactory;
@@ -22,6 +23,7 @@ final class OwnershipRequestHandlerServiceProvider extends AbstractServiceProvid
         return [
             RequestOwnershipRequestHandler::class,
             GetOwnershipRequestHandler::class,
+            SearchOwnershipRequestHandler::class,
             ApproveOwnershipRequestHandler::class,
             RejectOwnershipRequestHandler::class,
             DeleteOwnershipRequestHandler::class,
@@ -47,6 +49,14 @@ final class OwnershipRequestHandlerServiceProvider extends AbstractServiceProvid
         $container->addShared(
             GetOwnershipRequestHandler::class,
             fn () => new GetOwnershipRequestHandler(
+                $container->get(OwnershipServiceProvider::OWNERSHIP_JSONLD_REPOSITORY)
+            )
+        );
+
+        $container->addShared(
+            SearchOwnershipRequestHandler::class,
+            fn () => new SearchOwnershipRequestHandler(
+                $container->get(OwnershipSearchRepository::class),
                 $container->get(OwnershipServiceProvider::OWNERSHIP_JSONLD_REPOSITORY)
             )
         );

--- a/features/ownership/search.feature
+++ b/features/ownership/search.feature
@@ -1,0 +1,29 @@
+Feature: Test searching ownerships
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I send and accept "application/json"
+
+  Scenario: Searching ownership of an organizer
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    When I send a GET request to '/ownerships/?itemId=%{organizerId}'
+    Then the response status should be 200
+    And the JSON response at "0/ownerId" should be "auth0|631748dba64ea78e3983b201"
+    And the JSON response at "0/state" should be "requested"
+    And the JSON response at "1/ownerId" should be "auth0|631748dba64ea78e3983b202"
+    And the JSON response at "1/state" should be "requested"
+    And the JSON response at "2/ownerId" should be "auth0|631748dba64ea78e3983b203"
+    And the JSON response at "2/state" should be "requested"
+
+  Scenario: No ownerships found
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    When I send a GET request to '/ownerships/?itemId=%{organizerId}'
+    Then the response status should be 200
+    And the JSON response should be:
+    """
+    []
+    """

--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -281,6 +281,11 @@ final class ApiProblem extends Exception
         );
     }
 
+    public static function queryParameterMissing(string $parameterName): self
+    {
+        return self::urlNotFound('Query parameter ' . $parameterName . ' is missing.');
+    }
+
     public static function resourceNotFound(string $resourceType, string $resourceId): self
     {
         return self::urlNotFound('The ' . $resourceType . ' with id "' . $resourceId . '" was not found.');

--- a/src/Http/Ownership/SearchOwnershipRequestHandler.php
+++ b/src/Http/Ownership/SearchOwnershipRequestHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Ownership;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\Response\JsonLdResponse;
+use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use Fig\Http\Message\StatusCodeInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class SearchOwnershipRequestHandler implements RequestHandlerInterface
+{
+    private OwnershipSearchRepository $ownershipSearchRepository;
+    private DocumentRepository $ownershipRepository;
+
+    public function __construct(
+        OwnershipSearchRepository $ownershipSearchRepository,
+        DocumentRepository $ownershipRepository
+    ) {
+        $this->ownershipSearchRepository = $ownershipSearchRepository;
+        $this->ownershipRepository = $ownershipRepository;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $itemId = $request->getQueryParams()['itemId'] ?? '';
+
+        if (empty($itemId)) {
+            throw ApiProblem::queryParameterMissing('itemId');
+        }
+
+        $ownerships = [];
+        $ownershipCollection = $this->ownershipSearchRepository->getByItemId($itemId);
+        foreach ($ownershipCollection as $ownership) {
+            $ownerships[] = $this->ownershipRepository->fetch($ownership->getId())->getAssocBody();
+        }
+
+        return new JsonLdResponse(
+            $ownerships,
+            StatusCodeInterface::STATUS_OK
+        );
+    }
+}

--- a/tests/Http/Ownership/SearchOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/SearchOwnershipRequestHandlerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Ownership;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
+use CultuurNet\UDB3\Ownership\Repositories\OwnershipItemCollection;
+use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
+use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SearchOwnershipRequestHandlerTest extends TestCase
+{
+    use AssertApiProblemTrait;
+
+    private InMemoryDocumentRepository $ownershipRepository;
+
+    /** @var InMemoryDocumentRepository|MockObject */
+    private $ownershipSearchRepository;
+
+    private SearchOwnershipRequestHandler $getOwnershipRequestHandler;
+
+    protected function setUp(): void
+    {
+        $this->ownershipSearchRepository = $this->createMock(OwnershipSearchRepository::class);
+
+        $this->ownershipRepository = new InMemoryDocumentRepository();
+
+        $this->getOwnershipRequestHandler = new SearchOwnershipRequestHandler(
+            $this->ownershipSearchRepository,
+            $this->ownershipRepository
+        );
+
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_searching_ownerships(): void
+    {
+        $getOwnershipRequest = (new Psr7RequestBuilder())
+            ->withUriFromString('?itemId=9e68dafc-01d8-4c1c-9612-599c918b981d')
+            ->build('GET');
+
+        $ownershipCollection = new OwnershipItemCollection(
+            new OwnershipItem(
+                'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+                '9e68dafc-01d8-4c1c-9612-599c918b981d',
+                'organizer',
+                'auth0|63e22626e39a8ca1264bd29a'
+            ),
+            new OwnershipItem(
+                '5c7dd3bb-fa44-4c84-b499-303ecc01cba1',
+                '9e68dafc-01d8-4c1c-9612-599c918b981d',
+                'organizer',
+                'auth0|63e22626e39a8ca1264bd29b'
+            )
+        );
+
+        $jsonDocuments = [];
+        /** @var OwnershipItem $ownership */
+        foreach ($ownershipCollection as $ownership) {
+            $jsonDocument = new JsonDocument(
+                $ownership->getId(),
+                Json::encode([
+                    'id' => $ownership->getId(),
+                    'itemId' => $ownership->getItemId(),
+                    'ownerId' => $ownership->getOwnerId(),
+                    'ownerType' => $ownership->getItemType(),
+                    'status' => 'approved',
+                ])
+            );
+            $jsonDocuments[] = $jsonDocument->getAssocBody();
+            $this->ownershipRepository->save($jsonDocument);
+        }
+
+        $this->ownershipSearchRepository->expects($this->once())
+            ->method('getByItemId')
+            ->with('9e68dafc-01d8-4c1c-9612-599c918b981d')
+            ->willReturn($ownershipCollection);
+
+        $response = $this->getOwnershipRequestHandler->handle($getOwnershipRequest);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(
+            Json::encode($jsonDocuments),
+            $response->getBody()->getContents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_empty_collection_when_no_ownerships_found(): void
+    {
+        $getOwnershipRequest = (new Psr7RequestBuilder())
+            ->withUriFromString('?itemId=9e68dafc-01d8-4c1c-9612-599c918b981d')
+            ->build('GET');
+
+        $this->ownershipSearchRepository->expects($this->once())
+            ->method('getByItemId')
+            ->with('9e68dafc-01d8-4c1c-9612-599c918b981d')
+            ->willReturn(new OwnershipItemCollection());
+
+        $response = $this->getOwnershipRequestHandler->handle($getOwnershipRequest);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(
+            '[]',
+            $response->getBody()->getContents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_an_api_problem_on_missing_item_id(): void
+    {
+        $getOwnershipRequest = (new Psr7RequestBuilder())
+            ->build('GET');
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::queryParameterMissing('itemId'),
+            fn () => $this->getOwnershipRequestHandler->handle($getOwnershipRequest)
+        );
+    }
+}


### PR DESCRIPTION
### Added
- Implemented endpoint `GET /ownerships/?itemId={itemId}` to search ownerships based on the item id

---
Ticket: https://jira.uitdatabank.be/browse/III-6071
