### PR TITLE
III-6074 Create organizer role based on ownership

### DIFF
--- a/app/EventBus/EventBusServiceProvider.php
+++ b/app/EventBus/EventBusServiceProvider.php
@@ -22,6 +22,7 @@ use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataProjector;
 use CultuurNet\UDB3\Organizer\OrganizerJSONLDServiceProvider;
 use CultuurNet\UDB3\Organizer\OrganizerPermissionServiceProvider;
 use CultuurNet\UDB3\Ownership\Readmodels\OwnershipLDProjector;
+use CultuurNet\UDB3\Ownership\Readmodels\OwnershipPermissionProjector;
 use CultuurNet\UDB3\Ownership\Readmodels\OwnershipSearchProjector;
 use CultuurNet\UDB3\Place\PlaceJSONLDServiceProvider;
 use CultuurNet\UDB3\Place\ReadModel\History\HistoryProjector as PlaceHistoryProjector;
@@ -82,6 +83,7 @@ final class EventBusServiceProvider extends AbstractServiceProvider
                             AutoApproveForUiTIDv1ApiKeysProcessManager::class,
                             OwnershipLDProjector::class,
                             OwnershipSearchProjector::class,
+                            OwnershipPermissionProjector::class,
                         ];
 
                         $initialSubscribersCount = count($subscribers);

--- a/app/Ownership/OwnershipServiceProvider.php
+++ b/app/Ownership/OwnershipServiceProvider.php
@@ -9,9 +9,11 @@ use CultuurNet\UDB3\AggregateType;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Ownership\Readmodels\OwnershipLDProjector;
+use CultuurNet\UDB3\Ownership\Readmodels\OwnershipPermissionProjector;
 use CultuurNet\UDB3\Ownership\Readmodels\OwnershipSearchProjector;
 use CultuurNet\UDB3\Ownership\Repositories\Search\DBALOwnershipSearchRepository;
 use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
+use Ramsey\Uuid\UuidFactory;
 
 final class OwnershipServiceProvider extends AbstractServiceProvider
 {
@@ -25,6 +27,7 @@ final class OwnershipServiceProvider extends AbstractServiceProvider
             OwnershipLDProjector::class,
             OwnershipSearchRepository::class,
             OwnershipSearchProjector::class,
+            OwnershipPermissionProjector::class,
         ];
     }
 
@@ -66,6 +69,16 @@ final class OwnershipServiceProvider extends AbstractServiceProvider
             OwnershipSearchProjector::class,
             fn () => new OwnershipSearchProjector(
                 $container->get(OwnershipSearchRepository::class)
+            )
+        );
+
+        $container->addShared(
+            OwnershipPermissionProjector::class,
+            fn () => new OwnershipPermissionProjector(
+                $container->get('event_command_bus'),
+                $container->get(OwnershipSearchRepository::class),
+                new UuidFactory(),
+                $container->get('role_search_v3_repository')
             )
         );
     }

--- a/features/ownership/permission.feature
+++ b/features/ownership/permission.feature
@@ -1,0 +1,47 @@
+Feature: Test permissions based on ownership
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I send and accept "application/json"
+
+  Scenario: Approving the ownership of an organizer gives permission on the organizer
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+        """
+    And I send a PUT request to "/organizers/%{organizerId}/name/nl"
+    And the response status should be "403"
+    And I request ownership for "40fadfd3-c4a6-4936-b1fe-20542ac56610" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    When I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I approve the ownership with ownershipId "%{ownershipId}"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+        """
+    And I send a PUT request to "/organizers/%{organizerId}/name/nl"
+    Then the response status should be "204"
+
+  Scenario: Deleting the ownership of an organizer removes permission on the organizer
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I request ownership for "40fadfd3-c4a6-4936-b1fe-20542ac56610" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    And I approve the ownership with ownershipId "%{ownershipId}"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+        """
+    And I send a PUT request to "/organizers/%{organizerId}/name/nl"
+    And the response status should be "204"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I delete the ownership with ownershipId "%{ownershipId}"
+    When I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+        """
+    And I send a PUT request to "/organizers/%{organizerId}/name/nl"
+    Then the response status should be "403"

--- a/src/Ownership/Readmodels/OwnershipPermissionProjector.php
+++ b/src/Ownership/Readmodels/OwnershipPermissionProjector.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\Readmodels;
+
+use Broadway\CommandHandling\CommandBus;
+use Broadway\Domain\DomainMessage;
+use Broadway\EventHandling\EventListener;
+use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
+use CultuurNet\UDB3\Ownership\Events\OwnershipDeleted;
+use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
+use CultuurNet\UDB3\Role\Commands\AddConstraint;
+use CultuurNet\UDB3\Role\Commands\AddPermission;
+use CultuurNet\UDB3\Role\Commands\AddUser;
+use CultuurNet\UDB3\Role\Commands\CreateRole;
+use CultuurNet\UDB3\Role\Commands\DeleteRole;
+use CultuurNet\UDB3\Role\ReadModel\Search\RepositoryInterface;
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Role\ValueObjects\Query;
+use Ramsey\Uuid\UuidFactoryInterface;
+
+final class OwnershipPermissionProjector implements EventListener
+{
+    use DelegateEventHandlingToSpecificMethodTrait {
+        DelegateEventHandlingToSpecificMethodTrait::handle as handleMethodSpecificEvents;
+    }
+
+    private CommandBus $commandBus;
+    private OwnershipSearchRepository $ownershipSearchRepository;
+    private UuidFactoryInterface $uuidFactory;
+    private RepositoryInterface $roleSearchRepository;
+
+    public function __construct(
+        CommandBus $commandBus,
+        OwnershipSearchRepository $ownershipSearchRepository,
+        UuidFactoryInterface $uuidFactory,
+        RepositoryInterface $roleSearchRepository
+    ) {
+        $this->commandBus = $commandBus;
+        $this->ownershipSearchRepository = $ownershipSearchRepository;
+        $this->uuidFactory = $uuidFactory;
+        $this->roleSearchRepository = $roleSearchRepository;
+    }
+
+    public function handle(DomainMessage $domainMessage): void
+    {
+        $event = $domainMessage->getPayload();
+
+        $handleMethod = $this->getHandleMethodName($event);
+        if (!$handleMethod) {
+            return;
+        }
+
+        $this->{$handleMethod}($event, $domainMessage);
+    }
+
+    protected function applyOwnershipApproved(OwnershipApproved $ownershipApproved): void
+    {
+        $ownershipItem = $this->ownershipSearchRepository->getById($ownershipApproved->getId());
+
+        $roleId = new UUID($this->uuidFactory->uuid4()->toString());
+
+        $this->commandBus->dispatch(
+            new CreateRole(
+                $roleId,
+                $this->createRoleName($ownershipItem->getId())
+            )
+        );
+
+        $this->commandBus->dispatch(
+            new AddConstraint(
+                $roleId,
+                new Query('id:' . $ownershipItem->getItemId())
+            )
+        );
+
+        $this->commandBus->dispatch(
+            new AddPermission(
+                $roleId,
+                Permission::organisatiesBewerken()
+            )
+        );
+
+        $this->commandBus->dispatch(
+            new AddUser(
+                $roleId,
+                $ownershipItem->getOwnerId()
+            )
+        );
+    }
+
+    protected function applyOwnershipDeleted(OwnershipDeleted $ownershipDeleted): void
+    {
+        $roles = $this->roleSearchRepository->search(
+            $this->createRoleName($ownershipDeleted->getId())
+        );
+
+        foreach ($roles->getMember() as $role) {
+            $this->commandBus->dispatch(
+                new DeleteRole(new UUID($role['uuid']))
+            );
+        }
+    }
+
+    private function createRoleName(string $ownershipId): string
+    {
+        return 'Ownership ' . $ownershipId;
+    }
+}

--- a/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
+++ b/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\Readmodels;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use Broadway\Domain\DateTime;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
+use CultuurNet\UDB3\Ownership\Events\OwnershipDeleted;
+use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
+use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
+use CultuurNet\UDB3\RecordedOn;
+use CultuurNet\UDB3\Role\Commands\AddConstraint;
+use CultuurNet\UDB3\Role\Commands\AddPermission;
+use CultuurNet\UDB3\Role\Commands\AddUser;
+use CultuurNet\UDB3\Role\Commands\CreateRole;
+use CultuurNet\UDB3\Role\Commands\DeleteRole;
+use CultuurNet\UDB3\Role\ReadModel\Search\RepositoryInterface;
+use CultuurNet\UDB3\Role\ReadModel\Search\Results;
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Role\ValueObjects\Query;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\UuidFactory;
+
+class OwnershipPermissionProjectorTest extends TestCase
+{
+    private TraceableCommandBus $commandBus;
+
+    /** @var OwnershipSearchRepository&MockObject */
+    private $ownershipSearchRepository;
+
+    /** @var UuidFactory&MockObject */
+    private $uuidFactory;
+
+    /** @var RepositoryInterface&MockObject */
+    private $roleSearchRepository;
+
+    private OwnershipPermissionProjector $ownershipPermissionProjector;
+
+    protected function setUp(): void
+    {
+        $this->commandBus = new TraceableCommandBus();
+        $this->commandBus->record();
+
+        $this->ownershipSearchRepository = $this->createMock(OwnershipSearchRepository::class);
+
+        $this->uuidFactory = $this->createMock(UuidFactory::class);
+
+        $this->roleSearchRepository = $this->createMock(RepositoryInterface::class);
+
+        $this->ownershipPermissionProjector = new OwnershipPermissionProjector(
+            $this->commandBus,
+            $this->ownershipSearchRepository,
+            $this->uuidFactory,
+            $this->roleSearchRepository
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_ownership_approved(): void
+    {
+        $ownershipId = 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e';
+        $recordedOn = RecordedOn::fromBroadwayDateTime(DateTime::fromString('2024-02-19T14:15:16Z'));
+
+        $ownershipRequested = new OwnershipApproved($ownershipId);
+
+        $domainMessage = new DomainMessage(
+            $ownershipId,
+            0,
+            new Metadata(),
+            $ownershipRequested,
+            $recordedOn->toBroadwayDateTime()
+        );
+
+        $this->ownershipSearchRepository->expects($this->once())
+            ->method('getById')
+            ->with($ownershipId)
+            ->willReturn(
+                new OwnershipItem(
+                    $ownershipId,
+                    '9e68dafc-01d8-4c1c-9612-599c918b981d',
+                    'organizer',
+                    'auth0|63e22626e39a8ca1264bd29b'
+                )
+            );
+
+        $roleId = new UUID('8d17cffe-6f28-459c-8627-1f6345f8b296');
+        $this->uuidFactory->expects($this->once())
+            ->method('uuid4')
+            ->willReturn(\Ramsey\Uuid\Uuid::fromString($roleId->toString()));
+
+        $this->ownershipPermissionProjector->handle($domainMessage);
+
+        $this->assertEquals(
+            [
+                new CreateRole(
+                    $roleId,
+                    'Ownership ' . $ownershipId
+                ),
+                new AddConstraint(
+                    $roleId,
+                    new Query('id:9e68dafc-01d8-4c1c-9612-599c918b981d')
+                ),
+                new AddPermission(
+                    $roleId,
+                    Permission::organisatiesBewerken()
+                ),
+                new AddUser(
+                    $roleId,
+                    'auth0|63e22626e39a8ca1264bd29b'
+                ),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_ownership_deleted(): void
+    {
+        $ownershipId = 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e';
+        $recordedOn = RecordedOn::fromBroadwayDateTime(DateTime::fromString('2024-02-19T14:15:16Z'));
+
+        $ownershipRequested = new OwnershipDeleted($ownershipId);
+
+        $domainMessage = new DomainMessage(
+            $ownershipId,
+            0,
+            new Metadata(),
+            $ownershipRequested,
+            $recordedOn->toBroadwayDateTime()
+        );
+
+        $roleId = '8d17cffe-6f28-459c-8627-1f6345f8b296';
+        $this->roleSearchRepository->expects($this->once())
+            ->method('search')
+            ->with('Ownership ' . $ownershipId)
+            ->willReturn(
+                new Results(
+                    1,
+                    [
+                        [
+                            'uuid' => $roleId,
+                            'name' => 'Ownership ' . $ownershipId,
+                        ],
+                    ],
+                    1
+                )
+            );
+
+        $this->ownershipPermissionProjector->handle($domainMessage);
+
+        $this->assertEquals(
+            [
+                new DeleteRole(new UUID($roleId)),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+}


### PR DESCRIPTION
### Added
- Added a projector that handles ownership approval and deletion. When an ownership is approved a role to update the organizers is created. When the ownership is deleted the associated role is also deleted.

---
Ticket: https://jira.uitdatabank.be/browse/III-6074
