### PR TITLE
III-6075 Create role with permission to update event

### DIFF
--- a/features/ownership/permission.feature
+++ b/features/ownership/permission.feature
@@ -11,7 +11,7 @@ Feature: Test permissions based on ownership
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
-        """
+    """
     And I send a PUT request to "/organizers/%{organizerId}/name/nl"
     And the response status should be "403"
     And I request ownership for "40fadfd3-c4a6-4936-b1fe-20542ac56610" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
@@ -21,7 +21,7 @@ Feature: Test permissions based on ownership
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
-        """
+    """
     And I send a PUT request to "/organizers/%{organizerId}/name/nl"
     Then the response status should be "204"
 
@@ -33,7 +33,7 @@ Feature: Test permissions based on ownership
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
-        """
+    """
     And I send a PUT request to "/organizers/%{organizerId}/name/nl"
     And the response status should be "204"
     And I am authorized as JWT provider v1 user "centraal_beheerder"
@@ -42,6 +42,52 @@ Feature: Test permissions based on ownership
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
-        """
+    """
     And I send a PUT request to "/organizers/%{organizerId}/name/nl"
+    Then the response status should be "403"
+
+  Scenario: Approving the ownership of an organizer gives permission on the event associated with the organizer
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I create a minimal place and save the "id" as "placeId"
+    And I create an event from "events/event-with-organizer.json" and save the "id" as "eventId"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+    """
+    And I send a PUT request to "/events/%{eventId}/name/nl"
+    And the response status should be "403"
+    And I request ownership for "40fadfd3-c4a6-4936-b1fe-20542ac56610" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    When I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I approve the ownership with ownershipId "%{ownershipId}"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+    """
+    And I send a PUT request to "/events/%{eventId}/name/nl"
+    Then the response status should be "204"
+
+  Scenario: Deleting the ownership of an organizer removes permission on the event associated with the organizer
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I create a minimal place and save the "id" as "placeId"
+    And I create an event from "events/event-with-organizer.json" and save the "id" as "eventId"
+    And I request ownership for "40fadfd3-c4a6-4936-b1fe-20542ac56610" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I approve the ownership with ownershipId "%{ownershipId}"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+    """
+    And I send a PUT request to "/events/%{eventId}/name/nl"
+    And the response status should be "204"
+    When I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I delete the ownership with ownershipId "%{ownershipId}"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+    """
+    And I send a PUT request to "/events/%{eventId}/name/nl"
     Then the response status should be "403"

--- a/src/Ownership/Readmodels/OwnershipPermissionProjector.php
+++ b/src/Ownership/Readmodels/OwnershipPermissionProjector.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
 use CultuurNet\UDB3\Ownership\Events\OwnershipDeleted;
-use CultuurNet\UDB3\Ownership\Ownership;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
 use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
 use CultuurNet\UDB3\Role\Commands\AddConstraint;

--- a/src/Ownership/Readmodels/OwnershipPermissionProjector.php
+++ b/src/Ownership/Readmodels/OwnershipPermissionProjector.php
@@ -11,6 +11,8 @@ use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
 use CultuurNet\UDB3\Ownership\Events\OwnershipDeleted;
+use CultuurNet\UDB3\Ownership\Ownership;
+use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
 use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
 use CultuurNet\UDB3\Role\Commands\AddConstraint;
 use CultuurNet\UDB3\Role\Commands\AddPermission;
@@ -61,14 +63,26 @@ final class OwnershipPermissionProjector implements EventListener
     {
         $ownershipItem = $this->ownershipSearchRepository->getById($ownershipApproved->getId());
 
-        $roleId = new UUID($this->uuidFactory->uuid4()->toString());
+        $this->createOrganizationRole($ownershipItem);
+        $this->createEventRole($ownershipItem);
+    }
 
-        $this->commandBus->dispatch(
-            new CreateRole(
-                $roleId,
-                $this->createRoleName($ownershipItem->getId())
-            )
+    protected function applyOwnershipDeleted(OwnershipDeleted $ownershipDeleted): void
+    {
+        $roles = $this->roleSearchRepository->search(
+            $this->createRoleName($ownershipDeleted->getId())
         );
+
+        foreach ($roles->getMember() as $role) {
+            $this->commandBus->dispatch(
+                new DeleteRole(new UUID($role['uuid']))
+            );
+        }
+    }
+
+    private function createOrganizationRole(OwnershipItem $ownershipItem): void
+    {
+        $roleId = $this->createRole($ownershipItem);
 
         $this->commandBus->dispatch(
             new AddConstraint(
@@ -83,6 +97,37 @@ final class OwnershipPermissionProjector implements EventListener
                 Permission::organisatiesBewerken()
             )
         );
+    }
+
+    private function createEventRole(OwnershipItem $ownershipItem): void
+    {
+        $roleId = $this->createRole($ownershipItem);
+
+        $this->commandBus->dispatch(
+            new AddConstraint(
+                $roleId,
+                new Query('organizer.id:' . $ownershipItem->getItemId())
+            )
+        );
+
+        $this->commandBus->dispatch(
+            new AddPermission(
+                $roleId,
+                Permission::aanbodBewerken()
+            )
+        );
+    }
+
+    private function createRole(OwnershipItem $ownershipItem): UUID
+    {
+        $roleId = new UUID($this->uuidFactory->uuid4()->toString());
+
+        $this->commandBus->dispatch(
+            new CreateRole(
+                $roleId,
+                $this->createRoleName($ownershipItem->getId())
+            )
+        );
 
         $this->commandBus->dispatch(
             new AddUser(
@@ -90,19 +135,8 @@ final class OwnershipPermissionProjector implements EventListener
                 $ownershipItem->getOwnerId()
             )
         );
-    }
 
-    protected function applyOwnershipDeleted(OwnershipDeleted $ownershipDeleted): void
-    {
-        $roles = $this->roleSearchRepository->search(
-            $this->createRoleName($ownershipDeleted->getId())
-        );
-
-        foreach ($roles->getMember() as $role) {
-            $this->commandBus->dispatch(
-                new DeleteRole(new UUID($role['uuid']))
-            );
-        }
+        return $roleId;
     }
 
     private function createRoleName(string $ownershipId): string

--- a/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
+++ b/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
@@ -97,7 +97,8 @@ class OwnershipPermissionProjectorTest extends TestCase
             ->method('uuid4')
             ->willReturnCallback(
                 function () use ($organizationRoleId, $eventRoleId) {
-                    static $count = 0; $count++;
+                    static $count = 0;
+                    $count++;
                     return $count === 1 ? $organizationRoleId : $eventRoleId;
                 }
             );

--- a/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
+++ b/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
@@ -91,30 +91,52 @@ class OwnershipPermissionProjectorTest extends TestCase
                 )
             );
 
-        $roleId = new UUID('8d17cffe-6f28-459c-8627-1f6345f8b296');
-        $this->uuidFactory->expects($this->once())
+        $organizationRoleId = new UUID('8d17cffe-6f28-459c-8627-1f6345f8b296');
+        $eventRoleId = new UUID('e8f8e2bc-2666-47f3-9290-ae3e7229a2c1');
+        $this->uuidFactory->expects($this->exactly(2))
             ->method('uuid4')
-            ->willReturn(\Ramsey\Uuid\Uuid::fromString($roleId->toString()));
+            ->willReturnCallback(
+                function () use ($organizationRoleId, $eventRoleId) {
+                    static $count = 0; $count++;
+                    return $count === 1 ? $organizationRoleId : $eventRoleId;
+                }
+            );
 
         $this->ownershipPermissionProjector->handle($domainMessage);
 
         $this->assertEquals(
             [
                 new CreateRole(
-                    $roleId,
+                    $organizationRoleId,
                     'Ownership ' . $ownershipId
                 ),
+                new AddUser(
+                    $organizationRoleId,
+                    'auth0|63e22626e39a8ca1264bd29b'
+                ),
                 new AddConstraint(
-                    $roleId,
+                    $organizationRoleId,
                     new Query('id:9e68dafc-01d8-4c1c-9612-599c918b981d')
                 ),
                 new AddPermission(
-                    $roleId,
+                    $organizationRoleId,
                     Permission::organisatiesBewerken()
                 ),
+                new CreateRole(
+                    $eventRoleId,
+                    'Ownership ' . $ownershipId
+                ),
                 new AddUser(
-                    $roleId,
+                    $eventRoleId,
                     'auth0|63e22626e39a8ca1264bd29b'
+                ),
+                new AddConstraint(
+                    $eventRoleId,
+                    new Query('organizer.id:9e68dafc-01d8-4c1c-9612-599c918b981d')
+                ),
+                new AddPermission(
+                    $eventRoleId,
+                    Permission::aanbodBewerken()
                 ),
             ],
             $this->commandBus->getRecordedCommands()


### PR DESCRIPTION
### Changed
- Updated the ownership permission projector to also create a role that allows updating events from the organizer.

### Note
- There is still an issue when a normal user approves an ownership because creating roles is not allowed by a normal user, this can only be done by a user with the permission `gebruikersBeheren`

---
Ticket: https://jira.uitdatabank.be/browse/III-6075
