### PR TITLE
III-6075 Avoid permission on places

### DIFF
--- a/features/ownership/permission.feature
+++ b/features/ownership/permission.feature
@@ -92,7 +92,7 @@ Feature: Test permissions based on ownership
     And I send a PUT request to "/events/%{eventId}/name/nl"
     Then the response status should be "403"
 
-  Scenario: Approving the ownership of an organizer gives permission no permission on the place associated with the organizer
+  Scenario: Approving the ownership of an organizer doesn't give permission on the place associated with the organizer
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I keep the value of the JSON response at "url" as "organizerUrl"
     And I create a place from "places/place-with-organizer.json" and save the "id" as "placeId"

--- a/features/ownership/permission.feature
+++ b/features/ownership/permission.feature
@@ -91,3 +91,25 @@ Feature: Test permissions based on ownership
     """
     And I send a PUT request to "/events/%{eventId}/name/nl"
     Then the response status should be "403"
+
+  Scenario: Approving the ownership of an organizer gives permission no permission on the place associated with the organizer
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I keep the value of the JSON response at "url" as "organizerUrl"
+    And I create a place from "places/place-with-organizer.json" and save the "id" as "placeId"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+    """
+    And I send a PUT request to "/places/%{placeId}/name/nl"
+    And the response status should be "403"
+    And I request ownership for "40fadfd3-c4a6-4936-b1fe-20542ac56610" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    When I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I approve the ownership with ownershipId "%{ownershipId}"
+    And I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+    """
+    And I send a PUT request to "/places/%{placeId}/name/nl"
+    Then the response status should be "403"

--- a/src/Ownership/Readmodels/OwnershipPermissionProjector.php
+++ b/src/Ownership/Readmodels/OwnershipPermissionProjector.php
@@ -113,7 +113,7 @@ final class OwnershipPermissionProjector implements EventListener
         $this->commandBus->dispatch(
             new AddConstraint(
                 $roleId,
-                new Query('organizer.id:' . $ownershipItem->getItemId())
+                new Query('organizer.id:' . $ownershipItem->getItemId() . ' AND _type:event')
             )
         );
 

--- a/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
+++ b/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
@@ -133,7 +133,7 @@ class OwnershipPermissionProjectorTest extends TestCase
                 ),
                 new AddConstraint(
                     $eventRoleId,
-                    new Query('organizer.id:9e68dafc-01d8-4c1c-9612-599c918b981d')
+                    new Query('organizer.id:9e68dafc-01d8-4c1c-9612-599c918b981d AND _type:event')
                 ),
                 new AddPermission(
                     $eventRoleId,


### PR DESCRIPTION
### Fixed
- Avoid permission on places associated with an organizer with approved ownership by adding the `_type:event` advanced query

---
Ticket: https://jira.uitdatabank.be/browse/III-6075
