### PR TITLE
III-6079 Remove unneeded index.

### DIFF
--- a/app/Migrations/Version20240402125210.php
+++ b/app/Migrations/Version20240402125210.php
@@ -18,7 +18,6 @@ final class Version20240402125210 extends AbstractMigration
         $table->addColumn('movie_id', Types::STRING)->setNotnull(true);
 
         $table->setPrimaryKey(['event_id']);
-        $table->addIndex(['movie_id']);
         $table->addUniqueIndex(['movie_id', 'event_id']);
     }
 


### PR DESCRIPTION
### Removed

- `Migrations/kinepolis_movie_mapping`: Removed unneeded `index` on column `movie_id`, that I overlooked in a previous PR.

---
Ticket: https://jira.uitdatabank.be/browse/III-6079
