### PR TITLE
III-6131 Normalize saved searches

### DIFF
--- a/features/saved_searches/get.feature
+++ b/features/saved_searches/get.feature
@@ -17,3 +17,15 @@ Feature: Test the UDB3 saved searches API
     Then the response status should be "200"
     And the response body should be valid JSON
     And the JSON response at "/" should include "%{name}"
+
+  Scenario: get a saved search with a dirty query
+    Given I create a random name of 12 characters
+    And I set the JSON request payload to:
+    """
+      {"name":"%{name}","query":"address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00%2B00:00 TO 2015-07-31T21:59:59%2B00:00]"}
+    """
+    And I send a POST request to "/saved-searches/v3"
+    When I send a GET request to "/saved-searches/v3"
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response at "/" should include "address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]"

--- a/features/saved_searches/get.feature
+++ b/features/saved_searches/get.feature
@@ -13,6 +13,7 @@ Feature: Test the UDB3 saved searches API
       {"name":"%{name}","query":"Avondlessen"}
     """
     And I send a POST request to "/saved-searches/v3"
+    Then the response status should be "201"
     When I send a GET request to "/saved-searches/v3"
     Then the response status should be "200"
     And the response body should be valid JSON
@@ -25,6 +26,7 @@ Feature: Test the UDB3 saved searches API
       {"name":"%{name}","query":"address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00%2B00:00 TO 2015-07-31T21:59:59%2B00:00]"}
     """
     And I send a POST request to "/saved-searches/v3"
+    Then the response status should be "201"
     When I send a GET request to "/saved-searches/v3"
     Then the response status should be "200"
     And the response body should be valid JSON

--- a/src/SavedSearches/Properties/QueryString.php
+++ b/src/SavedSearches/Properties/QueryString.php
@@ -18,7 +18,7 @@ class QueryString
     {
         $value = $this->trim($value);
         $this->guardNotEmpty($value);
-        $this->setValue($value);
+        $this->setValue($this->clean($value));
     }
 
     public static function fromURLQueryString(string $queryString): QueryString
@@ -32,21 +32,15 @@ class QueryString
         return new QueryString($queryArray['q']);
     }
 
-    public function clean(): self
+    private function clean(string $value): string
     {
-        /* Bugfix https://jira.publiq.be/browse/III-6131
-        Why not always do this in the constructor?
-        It will give problems with newly entered faulty queries, they will be escaped twice (saving + loading), this could corrupt to query
-        Example: %2B -> change to + -> change to ""
-        */
-
-        $value = $this->value;
+        /* Bugfix https://jira.publiq.be/browse/III-6131 */
 
         // Use preg_replace_callback to apply stripslashes() only to the part between square brackets
         $value = preg_replace_callback('/\[([^]]+)\]/', function ($matches) {
             return '[' . stripslashes($matches[1]) . ']';
         }, $value);
 
-        return new QueryString(urldecode($value));
+        return str_replace('%2B', '+', $value);
     }
 }

--- a/src/SavedSearches/Properties/QueryString.php
+++ b/src/SavedSearches/Properties/QueryString.php
@@ -43,7 +43,7 @@ class QueryString
         $value = $this->value;
 
         // Use preg_replace_callback to apply stripslashes() only to the part between square brackets
-        $value = preg_replace_callback('/\[([^]]+)\]/', function($matches) {
+        $value = preg_replace_callback('/\[([^]]+)\]/', function ($matches) {
             return '[' . stripslashes($matches[1]) . ']';
         }, $value);
 

--- a/src/SavedSearches/Properties/QueryString.php
+++ b/src/SavedSearches/Properties/QueryString.php
@@ -31,4 +31,14 @@ class QueryString
 
         return new QueryString($queryArray['q']);
     }
+
+    public function clean(): self
+    {
+        /* Bugfix https://jira.publiq.be/browse/III-6131
+        Why not always do this in the constructor?
+        It will give problems with newly entered faulty queries, they will be escaped twice (saving + loading), this could corrupt to query
+        Example: %2B -> change to + -> change to ""
+        */
+        return new QueryString(urldecode(stripslashes($this->value)));
+    }
 }

--- a/src/SavedSearches/Properties/QueryString.php
+++ b/src/SavedSearches/Properties/QueryString.php
@@ -39,6 +39,14 @@ class QueryString
         It will give problems with newly entered faulty queries, they will be escaped twice (saving + loading), this could corrupt to query
         Example: %2B -> change to + -> change to ""
         */
-        return new QueryString(urldecode(stripslashes($this->value)));
+
+        $value = $this->value;
+
+        // Use preg_replace_callback to apply stripslashes() only to the part between square brackets
+        $value = preg_replace_callback('/\[([^]]+)\]/', function($matches) {
+            return '[' . stripslashes($matches[1]) . ']';
+        }, $value);
+
+        return new QueryString(urldecode($value));
     }
 }

--- a/src/SavedSearches/ReadModel/SavedSearch.php
+++ b/src/SavedSearches/ReadModel/SavedSearch.php
@@ -28,14 +28,11 @@ class SavedSearch implements \JsonSerializable
         return $this->userId;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $serializedSavedSearch = [
             'name' => $this->name,
-            'query' => $this->query->toString(),
+            'query' => $this->query->clean()->toString(),
         ];
 
         if ($this->id) {

--- a/src/SavedSearches/ReadModel/SavedSearch.php
+++ b/src/SavedSearches/ReadModel/SavedSearch.php
@@ -32,7 +32,7 @@ class SavedSearch implements \JsonSerializable
     {
         $serializedSavedSearch = [
             'name' => $this->name,
-            'query' => $this->query->clean()->toString(),
+            'query' => $this->query->toString(),
         ];
 
         if ($this->id) {

--- a/tests/SavedSearches/Properties/QueryStringTest.php
+++ b/tests/SavedSearches/Properties/QueryStringTest.php
@@ -31,4 +31,27 @@ class QueryStringTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         QueryString::fromURLQueryString($invalidUrlQueryString);
     }
+
+
+    /**
+     * @test
+     * @dataProvider dataproviderBrokenQueries
+     */
+    public function it_cleans_broken_queries(string $brokenQuery, string $fixedQuery): void
+    {
+        $this->assertEquals($fixedQuery, (new QueryString($brokenQuery))->clean()->toString());
+    }
+
+    public function dataproviderBrokenQueries(): array
+    {
+        return [
+            ['\:', ':'],
+            ['%2B', '+'],
+            ['Hello%20World%21', 'Hello World!'],
+            [
+                'address.\*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22\:00\:00%2B00\:00 TO 2015-07-31T21\:59\:59%2B00\:00]',
+                'address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]',
+            ],
+        ];
+    }
 }

--- a/tests/SavedSearches/Properties/QueryStringTest.php
+++ b/tests/SavedSearches/Properties/QueryStringTest.php
@@ -45,12 +45,12 @@ class QueryStringTest extends TestCase
     public function dataproviderBrokenQueries(): array
     {
         return [
-            ['\:', ':'],
+            ['test\*[\:test\:]', 'test\*[:test:]'],
             ['%2B', '+'],
             ['Hello%20World%21', 'Hello World!'],
             [
                 'address.\*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22\:00\:00%2B00\:00 TO 2015-07-31T21\:59\:59%2B00\:00]',
-                'address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]',
+                'address.\*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]',
             ],
         ];
     }

--- a/tests/SavedSearches/Properties/QueryStringTest.php
+++ b/tests/SavedSearches/Properties/QueryStringTest.php
@@ -39,7 +39,7 @@ class QueryStringTest extends TestCase
      */
     public function it_cleans_broken_queries(string $brokenQuery, string $fixedQuery): void
     {
-        $this->assertEquals($fixedQuery, (new QueryString($brokenQuery))->clean()->toString());
+        $this->assertEquals($fixedQuery, (new QueryString($brokenQuery))->toString());
     }
 
     public function dataproviderBrokenQueries(): array
@@ -47,11 +47,14 @@ class QueryStringTest extends TestCase
         return [
             ['test\*[\:test\:]', 'test\*[:test:]'],
             ['%2B', '+'],
-            ['Hello%20World%21', 'Hello World!'],
             [
                 'address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22\:00\:00%2B00\:00 TO 2015-07-31T21\:59\:59%2B00\:00]',
                 'address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]',
             ],
+            ['name.\*:wijndegustatie% AND address.\*.addressLocality:lede', 'name.\*:wijndegustatie% AND address.\*.addressLocality:lede'],
+            ['address.\*.postalCode:3090 AND (dateRange:[2018-08-31T22\:00\:00%2B00\:00 TO 2018-10-31T22\:59\:59%2B00\:00] AND (dateRange:[2018-08-31T22\:00\:00%2B00\:00 TO 2018-10-31T22\:59\:59%2B00\:00] AND !(calendarType:permanent)))', 'address.\*.postalCode:3090 AND (dateRange:[2018-08-31T22:00:00+00:00 TO 2018-10-31T22:59:59+00:00] AND (dateRange:[2018-08-31T22:00:00+00:00 TO 2018-10-31T22:59:59+00:00] AND !(calendarType:permanent)))'],
+            ['address.\*.addressLocality:Zandhoven AND dateRange:[2016-10-31T23\:00\:00%2B00\:00 TO 2016-12-31T22\:59\:59%2B00\:00]', 'address.\*.addressLocality:Zandhoven AND dateRange:[2016-10-31T23:00:00+00:00 TO 2016-12-31T22:59:59+00:00]'],
+            ['address.\*.addressLocality:sint-martens-latem AND dateRange:[2015-11-10T23\:00\:00%2B00\:00 TO *]', 'address.\*.addressLocality:sint-martens-latem AND dateRange:[2015-11-10T23:00:00+00:00 TO *]'],
         ];
     }
 }

--- a/tests/SavedSearches/Properties/QueryStringTest.php
+++ b/tests/SavedSearches/Properties/QueryStringTest.php
@@ -49,8 +49,8 @@ class QueryStringTest extends TestCase
             ['%2B', '+'],
             ['Hello%20World%21', 'Hello World!'],
             [
-                'address.\*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22\:00\:00%2B00\:00 TO 2015-07-31T21\:59\:59%2B00\:00]',
-                'address.\*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]',
+                'address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22\:00\:00%2B00\:00 TO 2015-07-31T21\:59\:59%2B00\:00]',
+                'address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]',
             ],
         ];
     }

--- a/tests/SavedSearches/ReadModel/SavedSearchTest.php
+++ b/tests/SavedSearches/ReadModel/SavedSearchTest.php
@@ -43,7 +43,7 @@ class SavedSearchTest extends TestCase
         $jsonEncoded = Json::encode($savedSearch);
 
         $this->assertEquals(
-            '{"name":"In Leuven","query":"address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]","id":"101"}',
+            '{"name":"In Leuven","query":"address.\*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]","id":"101"}',
             $jsonEncoded
         );
     }

--- a/tests/SavedSearches/ReadModel/SavedSearchTest.php
+++ b/tests/SavedSearches/ReadModel/SavedSearchTest.php
@@ -32,6 +32,25 @@ class SavedSearchTest extends TestCase
     /**
      * @test
      */
+    public function it_serializes_and_cleans_dirty_queries(): void
+    {
+        $savedSearch = new SavedSearch(
+            'In Leuven',
+            new QueryString('address.\*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22\:00\:00%2B00\:00 TO 2015-07-31T21\:59\:59%2B00\:00]'),
+            '101'
+        );
+
+        $jsonEncoded = Json::encode($savedSearch);
+
+        $this->assertEquals(
+            '{"name":"In Leuven","query":"address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]","id":"101"}',
+            $jsonEncoded
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_does_not_serialize_an_empty_id_property(): void
     {
         $savedSearch = new SavedSearch(

--- a/tests/SavedSearches/ReadModel/SavedSearchTest.php
+++ b/tests/SavedSearches/ReadModel/SavedSearchTest.php
@@ -36,14 +36,14 @@ class SavedSearchTest extends TestCase
     {
         $savedSearch = new SavedSearch(
             'In Leuven',
-            new QueryString('address.\*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22\:00\:00%2B00\:00 TO 2015-07-31T21\:59\:59%2B00\:00]'),
+            new QueryString('address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22\:00\:00%2B00\:00 TO 2015-07-31T21\:59\:59%2B00\:00]'),
             '101'
         );
 
         $jsonEncoded = Json::encode($savedSearch);
 
         $this->assertEquals(
-            '{"name":"In Leuven","query":"address.\*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]","id":"101"}',
+            '{"name":"In Leuven","query":"address.*.addressLocality:Scherpenheuvel-Zichem AND dateRange:[2015-05-31T22:00:00+00:00 TO 2015-07-31T21:59:59+00:00]","id":"101"}',
             $jsonEncoded
         );
     }


### PR DESCRIPTION
### Fixed
It was possible to enter faulty saved queries, that the system could not read.
This code cleans them up.
It does NOT change anything in the database, it just makes sure the GET request returns correctly formatted queries.

Includes unit tests and a feature test.

---
Ticket: https://jira.uitdatabank.be/browse/III-6131
