### PR TITLE
III-6068 newsletter api

### DIFF
--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -142,6 +142,7 @@ use CultuurNet\UDB3\Http\Productions\SearchProductionsRequestHandler;
 use CultuurNet\UDB3\Http\Productions\SkipEventsRequestHandler;
 use CultuurNet\UDB3\Http\Productions\SuggestProductionRequestHandler;
 use CultuurNet\UDB3\Http\Proxy\ProxyRequestHandler;
+use CultuurNet\UDB3\Mailinglist\SubscribeUserToMailinglistRequestHandler;
 use CultuurNet\UDB3\UiTPASService\Controller\AddCardSystemToEventRequestHandler;
 use CultuurNet\UDB3\UiTPASService\Controller\DeleteCardSystemFromEventRequestHandler;
 use CultuurNet\UDB3\UiTPASService\Controller\GetCardSystemsFromEventRequestHandler;
@@ -219,6 +220,8 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
                 $this->bindUiTPASLabels($router);
 
                 $this->bindUiTPASOrganizers($router);
+
+                $this->bindMailinglist($router);
 
                 // Proxy GET requests to /events, /places, /offers and /organizers to SAPI3.
                 $router->get('/events/', ProxyRequestHandler::class);
@@ -579,5 +582,10 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
         $router->group('uitpas/organizers', function (RouteGroup $routeGroup): void {
             $routeGroup->get('{organizerId}/card-systems/', GetCardSystemsFromOrganizerRequestHandler::class);
         });
+    }
+
+    private function bindMailinglist(Router $router): void
+    {
+        $router->put('mailinglist/{email}/{mailingListId}/', SubscribeUserToMailinglistRequestHandler::class);
     }
 }

--- a/app/Mailinglist/MailinglistServiceProvider.php
+++ b/app/Mailinglist/MailinglistServiceProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailinglist;
+
+use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use CultuurNet\UDB3\Error\LoggerFactory;
+use CultuurNet\UDB3\Error\LoggerName;
+use CultuurNet\UDB3\Mailinglist\Client\MailingJetClient;
+use CultuurNet\UDB3\Mailinglist\Client\MailinglistClient;
+
+final class MailinglistServiceProvider extends AbstractServiceProvider
+{
+    protected function getProvidedServiceNames(): array
+    {
+        return [
+            MailinglistClient::class,
+            SubscribeUserToMailinglistRequestHandler::class,
+        ];
+    }
+
+    public function register(): void
+    {
+        $container = $this->getContainer();
+
+        $container->addShared(
+            MailinglistClient::class,
+            function () use ($container) {
+                return new MailingJetClient(
+                    $container->get('config')['mailjet']['apiKey'] ?? '',
+                    $container->get('config')['mailjet']['apiSecret'] ?? ''
+                );
+            }
+        );
+
+        $container->addShared(
+            SubscribeUserToMailinglistRequestHandler::class,
+            function () use ($container) {
+                return new SubscribeUserToMailinglistRequestHandler(
+                    $container->get(MailinglistClient::class),
+                    LoggerFactory::create($container, LoggerName::forWeb())
+                );
+            }
+        );
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -31,6 +31,7 @@ use CultuurNet\UDB3\Export\ExportServiceProvider;
 use CultuurNet\UDB3\Geocoding\GeocodingServiceProvider;
 use CultuurNet\UDB3\Jobs\JobsServiceProvider;
 use CultuurNet\UDB3\Labels\LabelServiceProvider;
+use CultuurNet\UDB3\Mailinglist\MailinglistServiceProvider;
 use CultuurNet\UDB3\Media\ImageStorageProvider;
 use CultuurNet\UDB3\Media\MediaImportServiceProvider;
 use CultuurNet\UDB3\Media\MediaServiceProvider;
@@ -215,6 +216,9 @@ $container->addServiceProvider(new OrganizerRdfServiceProvider());
 $container->addServiceProvider(new OwnershipServiceProvider());
 $container->addServiceProvider(new OwnershipCommandHandlerProvider());
 $container->addServiceProvider(new OwnershipRequestHandlerServiceProvider());
+
+/** Mailinglist */
+$container->addServiceProvider(new MailinglistServiceProvider());
 
 if (isset($container->get('config')['bookable_event']['dummy_place_ids'])) {
     LocationId::setDummyPlaceForEducationIds($container->get('config')['bookable_event']['dummy_place_ids']);

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     "league/route": "^5.1",
     "league/uri": "^6.3",
     "league/uri-components": "^2.4",
+    "mailjet/mailjet-apiv3-php": "^1.6",
     "mathiasverraes/money": "^v1.3.0",
     "monolog/monolog": "~1.11",
     "opis/json-schema": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12432e0499ab7b7ac9269b3c446c705c",
+    "content-hash": "9268bd178ddde2291ad6c889f90b1a95",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -3477,6 +3477,66 @@
                 }
             ],
             "time": "2020-05-30T13:11:16+00:00"
+        },
+        {
+            "name": "mailjet/mailjet-apiv3-php",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mailjet/mailjet-apiv3-php.git",
+                "reference": "10250914355c72ba17290ed2d16729e6ea5fb51a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mailjet/mailjet-apiv3-php/zipball/10250914355c72ba17290ed2d16729e6ea5fb51a",
+                "reference": "10250914355c72ba17290ed2d16729e6ea5fb51a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^7.4.4",
+                "php": "^7.2|^8.0",
+                "psr/http-client": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.4",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpcompatibility/php-compatibility": "*",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8|^9",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mailjet": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mailjet",
+                    "email": "dev@mailjet.com",
+                    "homepage": "https://dev.mailjet.com"
+                }
+            ],
+            "description": "PHP wrapper for the Mailjet API",
+            "homepage": "https://github.com/mailjet/mailjet-apiv3-php/",
+            "keywords": [
+                "Mailjet",
+                "api",
+                "email",
+                "php",
+                "v3"
+            ],
+            "support": {
+                "issues": "https://github.com/mailjet/mailjet-apiv3-php/issues",
+                "source": "https://github.com/mailjet/mailjet-apiv3-php/tree/v1.6.0"
+            },
+            "time": "2023-08-10T15:11:31+00:00"
         },
         {
             "name": "markbaker/complex",
@@ -11541,5 +11601,5 @@
         "ext-xmlreader": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/features/mailinglist/put.feature
+++ b/features/mailinglist/put.feature
@@ -1,0 +1,13 @@
+Feature: Test the UDB3 labels API
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I send and accept "application/json"
+
+  Scenario: Subscribe to newsletter
+    When I create a random name of 10 characters
+    And I send a PUT request to "mailinglist/%{name}@test.be/1746977"
+    Then the response status should be "200"
+    And the JSON response at "status" should be "ok"

--- a/src/Http/InvokableRequestHandlerContainer.php
+++ b/src/Http/InvokableRequestHandlerContainer.php
@@ -34,6 +34,6 @@ final class InvokableRequestHandlerContainer implements ContainerInterface
 
     public function has($id): bool
     {
-        return (bool) $this->container->has($id);
+        return $this->container->has($id);
     }
 }

--- a/src/Mailinglist/Client/MailingJetClient.php
+++ b/src/Mailinglist/Client/MailingJetClient.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailinglist\Client;
+
+use Mailjet\Client;
+use Mailjet\Resources;
+
+class MailingJetClient implements MailinglistClient
+{
+    private Client $client;
+
+    public function __construct(string $apiKey, string $apiSecret)
+    {
+        $this->client = new Client(
+            $apiKey,
+            $apiSecret
+        );
+    }
+
+    public function subscribe(string $email, string $mailingListId): void
+    {
+        $mailjetResponse = $this->client->post(
+            Resources::$ContactslistManagecontact,
+            [
+                'id' => $mailingListId,
+                'body' => [
+                    'Email' => $email,
+                    'Action' => 'addnoforce',
+                ],
+            ]
+        );
+
+        if (!$mailjetResponse->success()) {
+            throw new MailinglistSubscriptionFailed($mailjetResponse->getReasonPhrase());
+        }
+    }
+}

--- a/src/Mailinglist/Client/MailinglistClient.php
+++ b/src/Mailinglist/Client/MailinglistClient.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailinglist\Client;
+
+interface MailinglistClient
+{
+    public function subscribe(string $email, string $mailingListId): void;
+}

--- a/src/Mailinglist/Client/MailinglistSubscriptionFailed.php
+++ b/src/Mailinglist/Client/MailinglistSubscriptionFailed.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailinglist\Client;
+
+class MailinglistSubscriptionFailed extends \DomainException
+{
+}

--- a/src/Mailinglist/SubscribeUserToMailinglistRequestHandler.php
+++ b/src/Mailinglist/SubscribeUserToMailinglistRequestHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailinglist;
+
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\JsonResponse;
+use CultuurNet\UDB3\Mailinglist\Client\MailinglistClient;
+use CultuurNet\UDB3\Mailinglist\Client\MailinglistSubscriptionFailed;
+use Fig\Http\Message\StatusCodeInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+
+class SubscribeUserToMailinglistRequestHandler implements RequestHandlerInterface
+{
+    private MailinglistClient $client;
+    private LoggerInterface $logger;
+
+    public function __construct(MailinglistClient $client, LoggerInterface $logger)
+    {
+        $this->client = $client;
+        $this->logger = $logger;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $email = (new RouteParameters($request))->get('email');
+        $mailingListId = (new RouteParameters($request))->get('mailingListId');
+
+        try {
+            $this->client->subscribe($email, $mailingListId);
+        } catch (MailinglistSubscriptionFailed $e) {
+            $this->logger->error('Failed to subscribe to newsletter: ' . $e->getMessage());
+            return new JsonResponse(['status' => $e->getMessage()], StatusCodeInterface::STATUS_BAD_REQUEST);
+        }
+
+        return new JsonResponse(['status' => 'ok']);
+    }
+}

--- a/tests/Mailinglist/SubscribeUserToMailinglistRequestHandlerTest.php
+++ b/tests/Mailinglist/SubscribeUserToMailinglistRequestHandlerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailinglist;
+
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Http\Response\JsonResponse;
+use CultuurNet\UDB3\Mailinglist\Client\MailinglistClient;
+use CultuurNet\UDB3\Mailinglist\Client\MailinglistSubscriptionFailed;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+
+class SubscribeUserToMailinglistRequestHandlerTest extends TestCase
+{
+    private SubscribeUserToMailinglistRequestHandler $handler;
+
+    /**
+     * @var MockObject|LoggerInterface
+     */
+    private $mailinglistClient;
+
+    /**
+     * @var MockObject|LoggerInterface
+     */
+    private $logger;
+    private ServerRequestInterface $request;
+
+    protected function setUp(): void
+    {
+        $this->mailinglistClient = $this->createMock(MailinglistClient::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->handler = new SubscribeUserToMailinglistRequestHandler(
+            $this->mailinglistClient,
+            $this->logger
+        );
+
+        $email = urlencode('test@publiq.be');
+        $mailingListId = '1';
+
+        $this->request = (new Psr7RequestBuilder())
+            ->withUriFromString('/mailinglist/{$email}/{$mailingListId}')
+            ->withRouteParameter('email', $email)
+            ->withRouteParameter('mailingListId', $mailingListId)
+            ->build('PUT');
+    }
+
+    public function testHandleSuccess(): void
+    {
+        $this->mailinglistClient->expects($this->once())
+            ->method('subscribe')
+            ->with('test@publiq.be', 1);
+
+        $response = $this->handler->handle($this->request);
+
+        $this->assertEquals(['status' => 'ok'], json_decode($response->getBody()->getContents(), true));
+    }
+
+    public function testHandleFailure(): void
+    {
+        $errorMessage = 'Failed to subscribe';
+
+        $this->mailinglistClient->expects($this->once())
+            ->method('subscribe')
+            ->with('test@publiq.be', 1)
+            ->willThrowException(new MailinglistSubscriptionFailed($errorMessage));
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with("Failed to subscribe to newsletter: $errorMessage");
+
+        $response = $this->handler->handle($this->request);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(['status' => $errorMessage], json_decode($response->getBody()->getContents(), true));
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
### Added
I added a new endpoint to subscribe to a newsletter, removing the need for the current mail-microservice.
Contains a unit test and a feature test to prove it works.

I also tested it on the acc env of mailjet and saw the new contacts in the export.

It will also need a change in the frontend variable ["newsletterApiUrl"](https://github.com/cultuurnet/udb3-frontend/blob/main/src/hooks/api/newsletter.ts#L7C3-L7C101) (Thanks to @simon-debruijn)

Related to the config changes in https://github.com/cultuurnet/appconfig/pull/588

---
Ticket: https://jira.uitdatabank.be/browse/III-6068 
