### PR TITLE
Make the ApiProblem for Rdf Creation more clear

### DIFF
--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -546,7 +546,7 @@ final class ApiProblem extends Exception
     public static function invalidJsonDataForRdfCreation(string $detail): self
     {
         return self::create(
-            'https://api.publiq.be/probs/body/invalid-json-data',
+            'https://api.publiq.be/probs/body/invalid-json-data-for-rdf-creation',
             'Invalid JSON data for RDF creation',
             StatusCodeInterface::STATUS_BAD_REQUEST,
             $detail

--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -543,7 +543,7 @@ final class ApiProblem extends Exception
         );
     }
 
-    public static function invalidJsonData(string $detail): self
+    public static function invalidJsonDataForRdfCreation(string $detail): self
     {
         return self::create(
             'https://api.publiq.be/probs/body/invalid-json-data',

--- a/src/RDF/JsonDataCouldNotBeConverted.php
+++ b/src/RDF/JsonDataCouldNotBeConverted.php
@@ -17,6 +17,6 @@ final class JsonDataCouldNotBeConverted extends Exception implements ConvertsToA
 
     public function toApiProblem(): ApiProblem
     {
-        return ApiProblem::invalidJsonData($this->message);
+        return ApiProblem::invalidJsonDataForRdfCreation($this->message);
     }
 }


### PR DESCRIPTION
### Changed
I changed the ApiProblem::invalidJsonData method name to more clearly reflect this does not contain generic invalid json errors, but is specific for the RDF creation.
