### PR TITLE
III-6175 migrate moviedata

### DIFF
--- a/app/Console/Command/ImportMovieIdsFromCsv.php
+++ b/app/Console/Command/ImportMovieIdsFromCsv.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Console\Command;
+
+use CultuurNet\UDB3\Kinepolis\MovieMappingRepository;
+use League\Csv\Reader;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ImportMovieIdsFromCsv extends Command
+{
+    private const CSV_FILE = 'csv_file';
+    private MovieMappingRepository $mappingRepository;
+
+    public function __construct(MovieMappingRepository $mappingRepository)
+    {
+        parent::__construct();
+        $this->mappingRepository = $mappingRepository;
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('movies:migrate')
+            ->setDescription('Migrates the movieIds from the legacy application to UDB3 via a CSV')
+            ->addArgument(
+                self::CSV_FILE,
+                InputArgument::REQUIRED,
+                'Full path to the csv file to import.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $csvReader = Reader::createFromPath(
+            $input->getArgument(self::CSV_FILE)
+        );
+
+        $records = $csvReader->getRecords();
+        $output->writeln('Starting import.');
+        foreach ($records as $record) {
+            $this->mappingRepository->create($record[0], $record[1]);
+        }
+
+        $output->writeln('Finished import.');
+
+        return 0;
+    }
+}

--- a/app/Console/Command/ImportMovieIdsFromCsv.php
+++ b/app/Console/Command/ImportMovieIdsFromCsv.php
@@ -23,8 +23,7 @@ final class ImportMovieIdsFromCsv extends Command
     public function __construct(
         MovieMappingRepository $mappingRepository,
         DocumentRepository $eventDocumentRepository
-    )
-    {
+    ) {
         parent::__construct();
         $this->mappingRepository = $mappingRepository;
         $this->eventDocumentRepository = $eventDocumentRepository;
@@ -52,7 +51,7 @@ final class ImportMovieIdsFromCsv extends Command
         foreach ($records as $record) {
             try {
                 $this->eventDocumentRepository->fetch($record[0]);
-            } catch (DocumentDoesNotExist $documentDoesNotExist){
+            } catch (DocumentDoesNotExist $documentDoesNotExist) {
                 $output->writeln('Did not found event with id: ' . $record[0]);
                 return 1;
             }

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -414,7 +414,10 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
 
         $container->addShared(
             'console.movies:migrate',
-            fn () => new ImportMovieIdsFromCsv(new MovieMappingRepository($container->get(('dbal_connection'))), )
+            fn () => new ImportMovieIdsFromCsv(
+                new MovieMappingRepository($container->get(('dbal_connection'))),
+                $container->get('event_jsonld_repository')
+            )
         );
 
         $container->addShared(

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -24,6 +24,7 @@ use CultuurNet\UDB3\Console\Command\FireProjectedToJSONLDForRelationsCommand;
 use CultuurNet\UDB3\Console\Command\GeocodeEventCommand;
 use CultuurNet\UDB3\Console\Command\GeocodeOrganizerCommand;
 use CultuurNet\UDB3\Console\Command\GeocodePlaceCommand;
+use CultuurNet\UDB3\Console\Command\ImportMovieIdsFromCsv;
 use CultuurNet\UDB3\Console\Command\ImportOfferAutoClassificationLabels;
 use CultuurNet\UDB3\Console\Command\IncludeLabel;
 use CultuurNet\UDB3\Console\Command\ProcessDuplicatePlaces;
@@ -100,6 +101,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         'console.organizer:convert-educational-description',
         'console.execute-command-from-csv',
         'console.movies:fetch',
+        'console.movies:migrate',
     ];
 
     protected function getProvidedServiceNames(): array
@@ -408,6 +410,11 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         $container->addShared(
             'console.execute-command-from-csv',
             fn () => new ExecuteCommandFromCsv()
+        );
+
+        $container->addShared(
+            'console.movies:migrate',
+            fn () => new ImportMovieIdsFromCsv(new MovieMappingRepository($container->get(('dbal_connection'))), )
         );
 
         $container->addShared(


### PR DESCRIPTION
### Added

- `ImportMovieIdsFromCsv`: `Command` to import movieIds from the legacy application via a `csv`.

### Changed

- `ConsoleServiceProvider`: Register new Command `ImportMovieIdsFromCsv`

---
Ticket: https://jira.publiq.be/browse/III-6175
