### PR TITLE
III-6079 BUGFIX: moviefetcher publish

### DIFF
--- a/src/Kinepolis/KinepolisService.php
+++ b/src/Kinepolis/KinepolisService.php
@@ -10,6 +10,7 @@ use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Calendar\Calendar as LegacyCalendar;
 use CultuurNet\UDB3\Description;
 use CultuurNet\UDB3\Event\Commands\AddImage;
+use CultuurNet\UDB3\Event\Commands\Moderation\Publish;
 use CultuurNet\UDB3\Event\Commands\UpdateDescription;
 use CultuurNet\UDB3\Event\Event as EventAggregate;
 use CultuurNet\UDB3\Event\EventType;
@@ -152,6 +153,7 @@ final class KinepolisService
 
         if ($eventId === null) {
             $eventId = $this->createNewMovie($parsedMovie);
+            $commands[] = new Publish($eventId);
             $addImage = $this->uploadImage($token, $parsedMovie, $eventId);
             $commands[] = $addImage;
 

--- a/tests/Kinepolis/KinepolisServiceTest.php
+++ b/tests/Kinepolis/KinepolisServiceTest.php
@@ -7,9 +7,11 @@ namespace CultuurNet\UDB3\Kinepolis;
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use Broadway\Repository\Repository;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
+use Cake\Chronos\Chronos;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Description as LegacyDescription;
 use CultuurNet\UDB3\Event\Commands\AddImage;
+use CultuurNet\UDB3\Event\Commands\Moderation\Publish;
 use CultuurNet\UDB3\Event\Commands\UpdateDescription;
 use CultuurNet\UDB3\Event\EventRepository;
 use CultuurNet\UDB3\Event\EventThemeResolver;
@@ -193,6 +195,9 @@ final class KinepolisServiceTest extends TestCase
      */
     public function it_dispatches_commands_for_newly_created_movie(): void
     {
+        $now = Chronos::now();
+        Chronos::setTestNow($now);
+
         $this->client
             ->expects($this->once())
             ->method('getMovies')
@@ -303,6 +308,7 @@ final class KinepolisServiceTest extends TestCase
         $this->service->import();
         $this->assertEquals(
             [
+                new Publish($this->eventId),
                 new AddImage(
                     $this->eventId,
                     $imageId


### PR DESCRIPTION
### Changed

- `KinpelosService`:  Dispatch a `Publish`, when creating a new `Movie`

### Fixed

- New movies are no longer in `DRAFT`

---
Ticket: https://jira.publiq.be/browse/III-6079
