### PR TITLE
III-6079 BUGFIX: link movie to production

### DIFF
--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -45,6 +45,7 @@ use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
+use CultuurNet\UDB3\Event\Productions\ProductionRepository;
 use CultuurNet\UDB3\Event\ReadModel\Relations\EventRelationsRepository;
 use CultuurNet\UDB3\Kinepolis\Client\AuthenticatedKinepolisClient;
 use CultuurNet\UDB3\Kinepolis\KinepolisService;
@@ -447,6 +448,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
                         new Version4Generator(),
                         $container->get('config')['kinepolis']['trailers']['enabled'],
                     ),
+                    $container->get(ProductionRepository::class),
                     LoggerFactory::create(
                         $container,
                         LoggerName::forService('fetching-movies', 'kinepolis')

--- a/src/Kinepolis/KinepolisService.php
+++ b/src/Kinepolis/KinepolisService.php
@@ -165,7 +165,7 @@ final class KinepolisService
             $addImage = $this->uploadImage($token, $parsedMovie, $eventId);
             $commands[] = $addImage;
 
-            $productionId = $this->linkToProduction($parsedMovie->getTitle()->toString());
+            $productionId = $this->searchForProduction($parsedMovie->getTitle()->toString());
             $addEventToProduction =  new AddEventToProduction($eventId, $productionId);
             $commands[] = $addEventToProduction;
 
@@ -241,7 +241,7 @@ final class KinepolisService
         return new AddImage($eventId, $imageId);
     }
 
-    private function linkToProduction(string $title): ProductionId
+    private function searchForProduction(string $title): ProductionId
     {
         $productions = $this->productionRepository->search($title, 0, 1);
         if (count($productions) > 0) {

--- a/src/Kinepolis/KinepolisService.php
+++ b/src/Kinepolis/KinepolisService.php
@@ -245,7 +245,7 @@ final class KinepolisService
     {
         $productions = $this->productionRepository->search($title, 0, 1);
         if (count($productions) > 0) {
-           return $productions[0]->getProductionId();
+            return $productions[0]->getProductionId();
         }
 
         return (Production::createEmpty($title))->getProductionId();

--- a/tests/Kinepolis/KinepolisServiceTest.php
+++ b/tests/Kinepolis/KinepolisServiceTest.php
@@ -312,7 +312,7 @@ final class KinepolisServiceTest extends TestCase
             ->with('Het Smelt', 0, 1)
             ->willReturn(
                 [
-                    new Production($productionId, 'Het Smelt', [])
+                    new Production($productionId, 'Het Smelt', []),
                 ]
             );
 


### PR DESCRIPTION
### Changed

-  `KinepolisService`: newly created movies are linked to a `production`, if no matching `production` is found, a new one is created for the movie.

### Fixed

- Movies are no correctly linked to a production.

---
Ticket: https://jira.publiq.be/browse/III-6079
