### PR TITLE
III-6181 Movies with empty description

### DIFF
--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -51,7 +51,7 @@ use CultuurNet\UDB3\Kinepolis\Client\AuthenticatedKinepolisClient;
 use CultuurNet\UDB3\Kinepolis\KinepolisService;
 use CultuurNet\UDB3\Kinepolis\Mapping\MovieMappingRepository;
 use CultuurNet\UDB3\Kinepolis\Parser\KinepolisDateParser;
-use CultuurNet\UDB3\Kinepolis\Parser\KinepolisParser;
+use CultuurNet\UDB3\Kinepolis\Parser\KinepolisMovieParser;
 use CultuurNet\UDB3\Kinepolis\Parser\KinepolisPriceParser;
 use CultuurNet\UDB3\Kinepolis\Trailer\YoutubeTrailerRepository;
 use CultuurNet\UDB3\Offer\OfferType;
@@ -433,7 +433,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
                         $container->get('config')['kinepolis']['authentication']['key'],
                         $container->get('config')['kinepolis']['authentication']['secret'],
                     ),
-                    new KinepolisParser(
+                    new KinepolisMovieParser(
                         $container->get('config')['kinepolis']['terms'],
                         $container->get('config')['kinepolis']['theaters'],
                         new KinepolisDateParser()

--- a/src/Kinepolis/KinepolisService.php
+++ b/src/Kinepolis/KinepolisService.php
@@ -191,12 +191,14 @@ final class KinepolisService
             $this->logger->info('Event with id ' . $eventId . ' updated');
         }
 
-        $updateDescription = new UpdateDescription(
-            $eventId,
-            new LegacyLanguage('nl'),
-            Description::fromUdb3ModelDescription($parsedMovie->getDescription())
-        );
-        $commands[] = $updateDescription;
+        if ($parsedMovie->getDescription() !== null) {
+            $updateDescription = new UpdateDescription(
+                $eventId,
+                new LegacyLanguage('nl'),
+                Description::fromUdb3ModelDescription($parsedMovie->getDescription())
+            );
+            $commands[] = $updateDescription;
+        }
 
         $updatePriceInfo = new UpdatePriceInfo(
             $eventId,

--- a/src/Kinepolis/KinepolisService.php
+++ b/src/Kinepolis/KinepolisService.php
@@ -19,7 +19,7 @@ use CultuurNet\UDB3\Event\Productions\GroupEventsAsProduction;
 use CultuurNet\UDB3\Event\Productions\ProductionRepository;
 use CultuurNet\UDB3\Kinepolis\Client\KinepolisClient;
 use CultuurNet\UDB3\Kinepolis\Mapping\MappingRepository;
-use CultuurNet\UDB3\Kinepolis\Parser\Parser;
+use CultuurNet\UDB3\Kinepolis\Parser\MovieParser;
 use CultuurNet\UDB3\Kinepolis\Parser\PriceParser;
 use CultuurNet\UDB3\Kinepolis\Trailer\TrailerRepository;
 use CultuurNet\UDB3\Kinepolis\ValueObject\ParsedMovie;
@@ -44,7 +44,7 @@ final class KinepolisService
 
     private KinepolisClient $client;
 
-    private Parser $parser;
+    private MovieParser $movieParser;
 
     private PriceParser $priceParser;
 
@@ -64,7 +64,7 @@ final class KinepolisService
         CommandBus $commandBus,
         Repository $aggregateRepository,
         KinepolisClient $client,
-        Parser $parser,
+        MovieParser $movieParser,
         PriceParser $priceParser,
         MappingRepository $movieMappingRepository,
         ImageUploaderInterface $imageUploader,
@@ -76,7 +76,7 @@ final class KinepolisService
         $this->commandBus = $commandBus;
         $this->aggregateRepository = $aggregateRepository;
         $this->client = $client;
-        $this->parser = $parser;
+        $this->movieParser = $movieParser;
         $this->priceParser = $priceParser;
         $this->movieMappingRepository = $movieMappingRepository;
         $this->imageUploader = $imageUploader;
@@ -141,7 +141,7 @@ final class KinepolisService
                 return;
             }
             try {
-                $parsedMovies = $this->parser->getParsedMovies($movieDetail, $parsedPrices);
+                $parsedMovies = $this->movieParser->getParsedMovies($movieDetail, $parsedPrices);
             } catch (Exception $exception) {
                 $this->logger->error('Problem with parsing movie with id ' . $mid . ': ' . $exception->getMessage());
                 return;

--- a/src/Kinepolis/Parser/KinepolisMovieParser.php
+++ b/src/Kinepolis/Parser/KinepolisMovieParser.php
@@ -15,7 +15,7 @@ use CultuurNet\UDB3\Model\ValueObject\Price\PriceInfo;
 use CultuurNet\UDB3\Model\ValueObject\Text\Description;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 
-final class KinepolisParser implements Parser
+final class KinepolisMovieParser implements MovieParser
 {
     public const LONG_MOVIE_MINIMUM_LENGTH = 135;
     private array $termsMapper;

--- a/src/Kinepolis/Parser/KinepolisMovieParser.php
+++ b/src/Kinepolis/Parser/KinepolisMovieParser.php
@@ -69,11 +69,10 @@ final class KinepolisMovieParser implements MovieParser
                 $calendar = count($subEvents) === 1 ?
                     new SingleSubEventCalendar(...$subEvents) :
                     new MultipleSubEventsCalendar(new SubEvents(...$subEvents));
-                $parsedMovies[] = new ParsedMovie(
+                $parsedMovie = new ParsedMovie(
                     $this->generateMovieId($mid, $theatreId, $is3D),
                     new Title($title),
                     new LocationId($this->getLocationId($theatreId)),
-                    empty($description) ? null : new Description($description),
                     (new EventThemeResolver())->byId($themeId),
                     $calendar,
                     new PriceInfo(
@@ -82,6 +81,10 @@ final class KinepolisMovieParser implements MovieParser
                     ),
                     $poster
                 );
+                if (!empty($description)) {
+                    $parsedMovie = $parsedMovie->withDescription(new Description($description));
+                }
+                $parsedMovies[] = $parsedMovie;
             }
         }
         return $parsedMovies;

--- a/src/Kinepolis/Parser/KinepolisMovieParser.php
+++ b/src/Kinepolis/Parser/KinepolisMovieParser.php
@@ -73,7 +73,7 @@ final class KinepolisMovieParser implements MovieParser
                     $this->generateMovieId($mid, $theatreId, $is3D),
                     new Title($title),
                     new LocationId($this->getLocationId($theatreId)),
-                    new Description($description),
+                    empty($description) ? null : new Description($description),
                     (new EventThemeResolver())->byId($themeId),
                     $calendar,
                     new PriceInfo(

--- a/src/Kinepolis/Parser/MovieParser.php
+++ b/src/Kinepolis/Parser/MovieParser.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Kinepolis\Parser;
 use CultuurNet\UDB3\Kinepolis\ValueObject\ParsedMovie;
 use CultuurNet\UDB3\Kinepolis\ValueObject\ParsedPriceForATheater;
 
-interface Parser
+interface MovieParser
 {
     /**
      * @param ParsedPriceForATheater[] $parsedPrices

--- a/src/Kinepolis/ValueObject/ParsedMovie.php
+++ b/src/Kinepolis/ValueObject/ParsedMovie.php
@@ -19,7 +19,7 @@ final class ParsedMovie
 
     private LocationId $locationId;
 
-    private Description $description;
+    private ?Description $description;
 
     private Theme $theme;
 
@@ -33,7 +33,7 @@ final class ParsedMovie
         string $externalId,
         Title $title,
         LocationId $locationId,
-        Description $description,
+        ?Description $description,
         Theme $theme,
         Calendar $calendar,
         PriceInfo $priceInfo,
@@ -64,7 +64,7 @@ final class ParsedMovie
         return $this->locationId;
     }
 
-    public function getDescription(): Description
+    public function getDescription(): ?Description
     {
         return $this->description;
     }

--- a/src/Kinepolis/ValueObject/ParsedMovie.php
+++ b/src/Kinepolis/ValueObject/ParsedMovie.php
@@ -19,8 +19,6 @@ final class ParsedMovie
 
     private LocationId $locationId;
 
-    private ?Description $description;
-
     private Theme $theme;
 
     private Calendar $calendar;
@@ -29,11 +27,12 @@ final class ParsedMovie
 
     private string $imageUrl;
 
+    private ?Description $description = null;
+
     public function __construct(
         string $externalId,
         Title $title,
         LocationId $locationId,
-        ?Description $description,
         Theme $theme,
         Calendar $calendar,
         PriceInfo $priceInfo,
@@ -42,7 +41,6 @@ final class ParsedMovie
         $this->externalId = $externalId;
         $this->locationId = $locationId;
         $this->title = $title;
-        $this->description = $description;
         $this->theme = $theme;
         $this->calendar = $calendar;
         $this->priceInfo = $priceInfo;
@@ -64,11 +62,6 @@ final class ParsedMovie
         return $this->locationId;
     }
 
-    public function getDescription(): ?Description
-    {
-        return $this->description;
-    }
-
     public function getTheme(): Theme
     {
         return $this->theme;
@@ -87,5 +80,17 @@ final class ParsedMovie
     public function getImageUrl(): string
     {
         return $this->imageUrl;
+    }
+
+    public function getDescription(): ?Description
+    {
+        return $this->description;
+    }
+
+    public function withDescription(Description $description): self
+    {
+        $c = clone $this;
+        $c->description = $description;
+        return $c;
     }
 }

--- a/tests/Kinepolis/KinepolisServiceTest.php
+++ b/tests/Kinepolis/KinepolisServiceTest.php
@@ -22,7 +22,7 @@ use CultuurNet\UDB3\Event\Productions\ProductionRepository;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Kinepolis\Client\KinepolisClient;
 use CultuurNet\UDB3\Kinepolis\Mapping\MappingRepository;
-use CultuurNet\UDB3\Kinepolis\Parser\Parser;
+use CultuurNet\UDB3\Kinepolis\Parser\MovieParser;
 use CultuurNet\UDB3\Kinepolis\Parser\PriceParser;
 use CultuurNet\UDB3\Kinepolis\Trailer\TrailerRepository;
 use CultuurNet\UDB3\Kinepolis\ValueObject\ParsedMovie;
@@ -74,9 +74,9 @@ final class KinepolisServiceTest extends TestCase
     private $client;
 
     /**
-     * @var Parser|MockObject
+     * @var MovieParser|MockObject
      */
-    private $parser;
+    private $movieParser;
 
     /**
      * @var PriceParser|MockObject
@@ -117,7 +117,7 @@ final class KinepolisServiceTest extends TestCase
         $this->commandBus = new TraceableCommandBus();
         $this->repository = $this->createMock(EventRepository::class);
         $this->client = $this->createMock(KinepolisClient::class);
-        $this->parser = $this->createMock(Parser::class);
+        $this->movieParser = $this->createMock(MovieParser::class);
         $this->priceParser = $this->createMock(PriceParser::class);
         $this->mappingRepository = $this->createMock(MappingRepository::class);
         $this->imageUploader = $this->createMock(ImageUploaderInterface::class);
@@ -129,7 +129,7 @@ final class KinepolisServiceTest extends TestCase
             $this->commandBus,
             $this->repository,
             $this->client,
-            $this->parser,
+            $this->movieParser,
             $this->priceParser,
             $this->mappingRepository,
             $this->imageUploader,
@@ -232,7 +232,7 @@ final class KinepolisServiceTest extends TestCase
             ->expects($this->once())
             ->method('getMovieDetail');
 
-        $this->parser
+        $this->movieParser
             ->expects($this->once())
             ->method('getParsedMovies')
             ->willReturn(
@@ -412,7 +412,7 @@ final class KinepolisServiceTest extends TestCase
             ->expects($this->once())
             ->method('getMovieDetail');
 
-        $this->parser
+        $this->movieParser
             ->expects($this->once())
             ->method('getParsedMovies')
             ->willReturn(

--- a/tests/Kinepolis/KinepolisServiceTest.php
+++ b/tests/Kinepolis/KinepolisServiceTest.php
@@ -241,7 +241,6 @@ final class KinepolisServiceTest extends TestCase
                         $this->movieId,
                         new Title('Discovery Day'),
                         new LocationId('a77c8b8e-41e5-44cf-9407-f809ebb48744'),
-                        null,
                         (new EventThemeResolver())->byId('1.7.4.0.0'),
                         new MultipleSubEventsCalendar(
                             new SubEvents(
@@ -415,11 +414,10 @@ final class KinepolisServiceTest extends TestCase
             ->method('getParsedMovies')
             ->willReturn(
                 [
-                    new ParsedMovie(
+                    (new ParsedMovie(
                         $this->movieId,
                         new Title('Het Smelt'),
                         new LocationId('a77c8b8e-41e5-44cf-9407-f809ebb48744'),
-                        new Description('Eva groeit samen met twee jongens op in het kleine dorp Bovenmeer.'),
                         (new EventThemeResolver())->byId('1.7.4.0.0'),
                         new MultipleSubEventsCalendar(
                             new SubEvents(
@@ -467,7 +465,7 @@ final class KinepolisServiceTest extends TestCase
                             )
                         ),
                         '/MovieService/cdn.kinepolis.be/images/BE/65459BAD-CA99-4711-A97B-E049A5FA94E2/HO00010201/0000024162/Het_Smelt.jpg'
-                    ),
+                    ))->withDescription(new Description('Eva groeit samen met twee jongens op in het kleine dorp Bovenmeer.'), ),
                 ]
             );
 
@@ -595,11 +593,10 @@ final class KinepolisServiceTest extends TestCase
             ->method('getParsedMovies')
             ->willReturn(
                 [
-                    new ParsedMovie(
+                    (new ParsedMovie(
                         $this->movieId,
                         new Title('Het Smelt'),
                         new LocationId('a77c8b8e-41e5-44cf-9407-f809ebb48744'),
-                        new Description('Eva groeit samen met twee jongens op in het kleine dorp Bovenmeer.'),
                         (new EventThemeResolver())->byId('1.7.4.0.0'),
                         new MultipleSubEventsCalendar(
                             new SubEvents(
@@ -647,7 +644,7 @@ final class KinepolisServiceTest extends TestCase
                             )
                         ),
                         '/MovieService/cdn.kinepolis.be/images/BE/65459BAD-CA99-4711-A97B-E049A5FA94E2/HO00010201/0000024162/Het_Smelt.jpg'
-                    ),
+                    ))->withDescription(new Description('Eva groeit samen met twee jongens op in het kleine dorp Bovenmeer.'), ),
                 ]
             );
 

--- a/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
+++ b/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
@@ -28,9 +28,9 @@ use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
 
-final class KinepolisParserTest extends TestCase
+final class KinepolisMovieParserTest extends TestCase
 {
-    private KinepolisParser $parser;
+    private KinepolisMovieParser $parser;
 
     public function setUp(): void
     {
@@ -73,7 +73,7 @@ final class KinepolisParserTest extends TestCase
                     ],
                 ],
             ], );
-        $this->parser = new KinepolisParser(
+        $this->parser = new KinepolisMovieParser(
             [
                 616 => '1.7.2.0.0', // Actie | Actie en avontuur
                 986 => '1.7.3.0.0', // Actiekomedie

--- a/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
+++ b/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
@@ -93,17 +93,16 @@ final class KinepolisMovieParserTest extends TestCase
      */
     public function it_will_return_an_array_of_parse_movies(): void
     {
+        $description = 'Het epische gevecht gaat verder! In het Monsterverse van Legendary Pictures' .
+            ' volgt na de sensationele krachtmeting van “Godzilla vs. Kong” nu een geheel nieuw avontuur ' .
+            'waarin de machtige Kong en de angstaanjagende Godzilla het opnemen tegen elkaar.';
+
         $this->assertEquals(
             [
-                new ParsedMovie(
+                (new ParsedMovie(
                     'Kinepolis:tDECAm32696',
                     new Title('Godzilla x Kong: The New Empire'),
                     new LocationId('cbf8ddad-9aa7-4add-9133-228a752a87a5'),
-                    new Description(
-                        'Het epische gevecht gaat verder! In het Monsterverse van Legendary Pictures' .
-                        ' volgt na de sensationele krachtmeting van “Godzilla vs. Kong” nu een geheel nieuw avontuur ' .
-                        'waarin de machtige Kong en de angstaanjagende Godzilla het opnemen tegen elkaar.'
-                    ),
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
@@ -139,16 +138,11 @@ final class KinepolisMovieParserTest extends TestCase
                         )
                     ),
                     '/MovieService/cdn.kinepolis.be/images/BE/65459BAD-CA99-4711-A97B-E049A5FA94D2/HO00010201/0000024163/Godzilla_x_Kong:_The_New_Empire.jpg'
-                ),
-                new ParsedMovie(
+                ))->withDescription(new Description($description)),
+                (new ParsedMovie(
                     'Kinepolis:tKOOSTm32696',
                     new Title('Godzilla x Kong: The New Empire'),
                     new LocationId('b4ed748a-dfc4-432f-b242-ed1db62b76e2'),
-                    new Description(
-                        'Het epische gevecht gaat verder! In het Monsterverse van Legendary Pictures' .
-                        ' volgt na de sensationele krachtmeting van “Godzilla vs. Kong” nu een geheel nieuw avontuur ' .
-                        'waarin de machtige Kong en de angstaanjagende Godzilla het opnemen tegen elkaar.'
-                    ),
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
@@ -184,16 +178,11 @@ final class KinepolisMovieParserTest extends TestCase
                         )
                     ),
                     '/MovieService/cdn.kinepolis.be/images/BE/65459BAD-CA99-4711-A97B-E049A5FA94D2/HO00010201/0000024163/Godzilla_x_Kong:_The_New_Empire.jpg'
-                ),
-                new ParsedMovie(
+                ))->withDescription(new Description($description)),
+                (new ParsedMovie(
                     'Kinepolis:tKOOSTm32696v3D',
                     new Title('Godzilla x Kong: The New Empire 3D'),
                     new LocationId('b4ed748a-dfc4-432f-b242-ed1db62b76e2'),
-                    new Description(
-                        'Het epische gevecht gaat verder! In het Monsterverse van Legendary Pictures' .
-                        ' volgt na de sensationele krachtmeting van “Godzilla vs. Kong” nu een geheel nieuw avontuur ' .
-                        'waarin de machtige Kong en de angstaanjagende Godzilla het opnemen tegen elkaar.'
-                    ),
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
@@ -229,7 +218,7 @@ final class KinepolisMovieParserTest extends TestCase
                         )
                     ),
                     '/MovieService/cdn.kinepolis.be/images/BE/65459BAD-CA99-4711-A97B-E049A5FA94D2/HO00010201/0000024163/Godzilla_x_Kong:_The_New_Empire.jpg'
-                ),
+                ))->withDescription(new Description($description)),
             ],
             $this->parser->getParsedMovies(
                 Json::decodeAssociatively(file_get_contents(__DIR__ . '/../samples/KinepolisMovieDetailResponse.json')),
@@ -264,7 +253,6 @@ final class KinepolisMovieParserTest extends TestCase
                     'Kinepolis:tDECAm35033750',
                     new Title('Discovery Day'),
                     new LocationId('cbf8ddad-9aa7-4add-9133-228a752a87a5'),
-                    null,
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
@@ -305,7 +293,6 @@ final class KinepolisMovieParserTest extends TestCase
                     'Kinepolis:tKOOSTm35033750',
                     new Title('Discovery Day'),
                     new LocationId('b4ed748a-dfc4-432f-b242-ed1db62b76e2'),
-                    null,
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
@@ -346,7 +333,6 @@ final class KinepolisMovieParserTest extends TestCase
                     'Kinepolis:tKOOSTm35033750v3D',
                     new Title('Discovery Day 3D'),
                     new LocationId('b4ed748a-dfc4-432f-b242-ed1db62b76e2'),
-                    null,
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(

--- a/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
+++ b/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
@@ -252,4 +252,157 @@ final class KinepolisMovieParserTest extends TestCase
             )
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_will_handle_an_empty_description(): void
+    {
+        $this->assertEquals(
+            [
+                new ParsedMovie(
+                    'Kinepolis:tDECAm35033750',
+                    new Title('Discovery Day'),
+                    new LocationId('cbf8ddad-9aa7-4add-9133-228a752a87a5'),
+                    null,
+                    (new EventThemeResolver())->byId('1.7.2.0.0'),
+                    new SingleSubEventCalendar(new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:00:00+00:00')
+                        ),
+                        new Status(StatusType::Available()),
+                        new BookingAvailability(BookingAvailabilityType::Available())
+                    )),
+                    new PriceInfo(
+                        new Tariff(
+                            new TranslatedTariffName(
+                                new Language('nl'),
+                                new TariffName('Basistarief')
+                            ),
+                            new Money(1100, new Currency('EUR'))
+                        ),
+                        new Tariffs(
+                            new Tariff(
+                                new TranslatedTariffName(
+                                    new Language('nl'),
+                                    new TariffName('Kinepolis Student Card')
+                                ),
+                                new Money(900, new Currency('EUR'))
+                            ),
+                            new Tariff(
+                                new TranslatedTariffName(
+                                    new Language('nl'),
+                                    new TariffName('Kortingstarief')
+                                ),
+                                new Money(1000, new Currency('EUR'))
+                            )
+                        )
+                    ),
+                    '/MovieService/cdn.kinepolis.be/images/BE/65459BAD-CA99-4711-A97B-E049A5FA94D2/HO00010201/0000024163/Discovery_Day.jpg'
+                ),
+                new ParsedMovie(
+                    'Kinepolis:tKOOSTm35033750',
+                    new Title('Discovery Day'),
+                    new LocationId('b4ed748a-dfc4-432f-b242-ed1db62b76e2'),
+                    null,
+                    (new EventThemeResolver())->byId('1.7.2.0.0'),
+                    new SingleSubEventCalendar(new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:30:00+00:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T22:30:00+00:00')
+                        ),
+                        new Status(StatusType::Available()),
+                        new BookingAvailability(BookingAvailabilityType::Available())
+                    )),
+                    new PriceInfo(
+                        new Tariff(
+                            new TranslatedTariffName(
+                                new Language('nl'),
+                                new TariffName('Basistarief')
+                            ),
+                            new Money(1000, new Currency('EUR'))
+                        ),
+                        new Tariffs(
+                            new Tariff(
+                                new TranslatedTariffName(
+                                    new Language('nl'),
+                                    new TariffName('Kinepolis Student Card')
+                                ),
+                                new Money(800, new Currency('EUR'))
+                            ),
+                            new Tariff(
+                                new TranslatedTariffName(
+                                    new Language('nl'),
+                                    new TariffName('Kortingstarief')
+                                ),
+                                new Money(900, new Currency('EUR'))
+                            )
+                        )
+                    ),
+                    '/MovieService/cdn.kinepolis.be/images/BE/65459BAD-CA99-4711-A97B-E049A5FA94D2/HO00010201/0000024163/Discovery_Day.jpg'
+                ),
+                new ParsedMovie(
+                    'Kinepolis:tKOOSTm35033750v3D',
+                    new Title('Discovery Day 3D'),
+                    new LocationId('b4ed748a-dfc4-432f-b242-ed1db62b76e2'),
+                    null,
+                    (new EventThemeResolver())->byId('1.7.2.0.0'),
+                    new SingleSubEventCalendar(new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T17:45:00+00:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:45:00+00:00')
+                        ),
+                        new Status(StatusType::Available()),
+                        new BookingAvailability(BookingAvailabilityType::Available())
+                    )),
+                    new PriceInfo(
+                        new Tariff(
+                            new TranslatedTariffName(
+                                new Language('nl'),
+                                new TariffName('Basistarief')
+                            ),
+                            new Money(1200, new Currency('EUR'))
+                        ),
+                        new Tariffs(
+                            new Tariff(
+                                new TranslatedTariffName(
+                                    new Language('nl'),
+                                    new TariffName('Kinepolis Student Card')
+                                ),
+                                new Money(1000, new Currency('EUR'))
+                            ),
+                            new Tariff(
+                                new TranslatedTariffName(
+                                    new Language('nl'),
+                                    new TariffName('Kortingstarief')
+                                ),
+                                new Money(1100, new Currency('EUR'))
+                            )
+                        )
+                    ),
+                    '/MovieService/cdn.kinepolis.be/images/BE/65459BAD-CA99-4711-A97B-E049A5FA94D2/HO00010201/0000024163/Discovery_Day.jpg'
+                ),
+            ],
+            $this->parser->getParsedMovies(
+                Json::decodeAssociatively(file_get_contents(__DIR__ . '/../samples/KinepolisMovieDetailResponseWithEmptyDescription.json')),
+                [
+                    'KOOST' => new ParsedPriceForATheater(
+                        1000,
+                        900,
+                        800,
+                        250,
+                        200
+                    ),
+                    'DECA' => new ParsedPriceForATheater(
+                        1100,
+                        1000,
+                        900,
+                        300,
+                        250
+                    ),
+                ]
+            )
+        );
+    }
 }

--- a/tests/Kinepolis/samples/KinepolisMovieDetailResponseWithEmptyDescription.json
+++ b/tests/Kinepolis/samples/KinepolisMovieDetailResponseWithEmptyDescription.json
@@ -1,0 +1,509 @@
+{
+  "mid": 35033750,
+  "muuid": 35033750,
+  "dates": {
+    "2024-04-10": [
+      {
+        "prid": "1006122676",
+        "tid": "KKOR",
+        "screen": 4,
+        "time": "18:15:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          82
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1006122695",
+        "tid": "KKOR",
+        "screen": 9,
+        "time": "12:45:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1006122696",
+        "tid": "KKOR",
+        "screen": 9,
+        "time": "14:45:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1006122698",
+        "tid": "KKOR",
+        "screen": 9,
+        "time": "20:00:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1006122699",
+        "tid": "KKOR",
+        "screen": 9,
+        "time": "22:45:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1007106129",
+        "tid": "SL",
+        "screen": 1,
+        "time": "19:50:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          824
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1007106130",
+        "tid": "SL",
+        "screen": 1,
+        "time": "22:40:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          824
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1007106160",
+        "tid": "SL",
+        "screen": 2,
+        "time": "16:30:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          82
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1007106287",
+        "tid": "SL",
+        "screen": 7,
+        "time": "11:00:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1007106288",
+        "tid": "SL",
+        "screen": 7,
+        "time": "13:50:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      }
+    ],
+    "2024-04-11": [
+      {
+        "prid": "1006122781",
+        "tid": "KKOR",
+        "screen": 4,
+        "time": "16:45:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          82
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1006122884",
+        "tid": "KKOR",
+        "screen": 9,
+        "time": "10:45:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1006122885",
+        "tid": "KKOR",
+        "screen": 9,
+        "time": "13:45:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1006122887",
+        "tid": "KKOR",
+        "screen": 9,
+        "time": "20:00:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1006122888",
+        "tid": "KKOR",
+        "screen": 9,
+        "time": "22:45:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1007106134",
+        "tid": "SL",
+        "screen": 1,
+        "time": "19:50:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          824
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1007106135",
+        "tid": "SL",
+        "screen": 1,
+        "time": "22:40:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          824
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1007106165",
+        "tid": "SL",
+        "screen": 2,
+        "time": "16:30:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          82
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1007106291",
+        "tid": "SL",
+        "screen": 7,
+        "time": "11:00:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      },
+      {
+        "prid": "1007106292",
+        "tid": "SL",
+        "screen": 7,
+        "time": "13:50:00",
+        "variant": "HO00010201",
+        "saleable": 1,
+        "soldout": 0,
+        "time_saleable": null,
+        "version": [
+          61
+        ],
+        "sub": [
+          72
+        ],
+        "format": [
+          85
+        ],
+        "language": "NL"
+      }
+    ]
+  },
+  "presale": true,
+  "coming": true,
+  "active": true,
+  "spokenLanguage": {
+    "code": "OV",
+    "name": "Originele Versie",
+    "id": "1"
+  },
+  "variants": {
+    "HO00010201": {
+      "title": "Discovery Day",
+      "poster": "\/MovieService\/cdn.kinepolis.be\/images\/BE\/65459BAD-CA99-4711-A97B-E049A5FA94D2\/HO00010201\/0000024163\/Discovery_Day",
+      "hq_poster": "\/MovieService\/cdn.kinepolis.be\/images\/BE\/65459BAD-CA99-4711-A97B-E049A5FA94D2\/HO00010201\/0000024163\/Discovery_Day"
+    },
+    "HO00010442": {
+      "title": "Discovery Day",
+      "poster": "\/MovieService\/cdn.kinepolis.be\/images\/BE\/65459BAD-CA99-4711-A97B-E049A5FA94D2\/HO00010442\/0000024161\/Discovery_Day",
+      "hq_poster": "\/MovieService\/cdn.kinepolis.be\/images\/BE\/65459BAD-CA99-4711-A97B-E049A5FA94D2\/HO00010442\/0000024161\/Discovery_Day"
+    }
+  },
+  "poster": "\/MovieService\/cdn.kinepolis.be\/images\/BE\/65459BAD-CA99-4711-A97B-E049A5FA94D2\/HO00010201\/0000024163\/Discovery_Day.jpg",
+  "hq_poster": "\/MovieService\/cdn.kinepolis.be\/images\/BE\/65459BAD-CA99-4711-A97B-E049A5FA94D2\/HO00010201\/0000024163\/Discovery_Day.jpg",
+  "title": "Discovery Day",
+  "order": 35,
+  "rating": [
+    110,
+    19946,
+    19949
+  ],
+  "category": null,
+  "audience": null,
+  "genre": [
+    25,
+    214,
+    616
+  ],
+  "country": [
+    5227
+  ],
+  "actors": [
+    69776,
+    70003,
+    70060,
+    97048,
+    99047,
+    99048,
+    99049,
+    99050,
+    99051
+  ],
+  "directors": [
+    71030
+  ],
+  "length": 115,
+  "release_date": "2024-04-03",
+  "imdb": "0",
+  "score": "6.5",
+  "stills": [
+    "\/MovieService\/cdn.kinepolis.be\/images\/BE\/65459BAD-CA99-4711-A97B-E049A5FA94D2\/HO00010201\/0000024163\/Discovery_Day.jpg",
+    "\/MovieService\/cdn.kinepolis.be\/images\/BE\/386E7CF0-8904-4D23-B644-ECCFA8E912CA\/HO00010201\/0000024357\/Discovery_Day.jpg",
+    "\/MovieService\/cdn.kinepolis.be\/images\/BE\/51277512-4CEC-4DDB-B8F1-30D60F7EE274\/HO00010201\/0000024358\/Discovery_Day.jpg",
+    "\/MovieService\/cdn.kinepolis.be\/images\/BE\/51277512-4CEC-4DDB-B8F1-30D60F7EE274\/HO00010201\/0000024359\/Discovery_Day.jpg",
+    "\/MovieService\/cdn.kinepolis.be\/images\/BE\/51277512-4CEC-4DDB-B8F1-30D60F7EE274\/HO00010201\/0000024360\/Discovery_Day.jpg"
+  ],
+  "trailers": [
+    {
+      "image": "\/MovieService\/cdn.kinepolis.be\/images\/BE\/65459BAD-CA99-4711-A97B-E049A5FA94D2\/HO00010201\/0000024163\/Discovery_Day.jpg",
+      "360p": [
+        {
+          "filename": "deMU1xuO.m3u8",
+          "uri": "public:\/\/MovieService\/cdn.jwplayer.com\/manifests\/deMU1xuO.m3u8",
+          "filemime": "video\/stream"
+        },
+        {
+          "filename": "deMU1xuO.m3u8",
+          "uri": "public:\/\/MovieService\/cdn.jwplayer.com\/manifests\/deMU1xuO.m3u8",
+          "filemime": "video\/mp4"
+        }
+      ],
+      "400p": [
+        {
+          "filename": "deMU1xuO.m3u8",
+          "uri": "public:\/\/MovieService\/cdn.jwplayer.com\/manifests\/deMU1xuO.m3u8",
+          "filemime": "video\/stream"
+        },
+        {
+          "filename": "deMU1xuO.m3u8",
+          "uri": "public:\/\/MovieService\/cdn.jwplayer.com\/manifests\/deMU1xuO.m3u8",
+          "filemime": "video\/mp4"
+        }
+      ]
+    }
+  ],
+  "desc": "",
+  "user_reviews": null,
+  "critic_reviews": null,
+  "event": false,
+  "event_title": null,
+  "modified": 1712311687
+}


### PR DESCRIPTION
### Changed

- Refactoring: Renamed `Parser` to `MovieParser` to better differentiate between the different Parsers.
- `ParsedMovie`: Make `Description` nullable
- `KinepolisMovieParser`: handle Empty Description
- `KinepolisService`: do not dispatch a `UpdateDescription` when `Description` is `null`

- `KinepolisMovieParserTest`:  Added test for `ParsedMovie` with empty Description
- `KinepolisServiceTest`: Added test for `ParsedMovie` with empty Description

### Fixed

- The `KinepolisService` now handles movies with an empty description

---
Ticket: https://jira.publiq.be/browse/III-6181
