### PR TITLE
III-6186 calsum update to 4.0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "cakephp/chronos": "^1.3",
     "chrisboulton/php-resque": "dev-compat-1-2 as 1.2",
     "commerceguys/intl": "^0.7",
-    "cultuurnet/calendar-summary-v3": "^4.0.7",
+    "cultuurnet/calendar-summary-v3": "^4.0.8",
     "cultuurnet/cdb": "~2.2.0",
     "cultuurnet/culturefeed-php": "dev-master",
     "cultuurnet/udb3-api-guard": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3d47f540fc744e72664403797165107",
+    "content-hash": "c56d5ac010b261674dfa4f722c559b97",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -775,16 +775,16 @@
         },
         {
             "name": "cultuurnet/calendar-summary-v3",
-            "version": "v4.0.7",
+            "version": "v4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/calendar-summary-v3.git",
-                "reference": "03c7c20f6d71ed525c1108c92f79bf04b08bea17"
+                "reference": "ce1c52c9b2311d6d0ec5144c226513adb21a5bf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/03c7c20f6d71ed525c1108c92f79bf04b08bea17",
-                "reference": "03c7c20f6d71ed525c1108c92f79bf04b08bea17",
+                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/ce1c52c9b2311d6d0ec5144c226513adb21a5bf6",
+                "reference": "ce1c52c9b2311d6d0ec5144c226513adb21a5bf6",
                 "shasum": ""
             },
             "require": {
@@ -819,9 +819,9 @@
             "description": "Library to convert cultuurnet dates to a readable summary",
             "support": {
                 "issues": "https://github.com/cultuurnet/calendar-summary-v3/issues",
-                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.7"
+                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.8"
             },
-            "time": "2024-06-05T09:20:49+00:00"
+            "time": "2024-06-25T09:36:12+00:00"
         },
         {
             "name": "cultuurnet/cdb",


### PR DESCRIPTION
### Fixed

`Composer.json`: updated `calendar-summary-v3` to `4.0.8` 

---
Ticket: https://jira.uitdatabank.be/browse/III-6186
