### PR TITLE
III-6226 events deleted by SystemUser

### DIFF
--- a/app/Console/Command/DeletePlace.php
+++ b/app/Console/Command/DeletePlace.php
@@ -83,7 +83,7 @@ class DeletePlace extends AbstractCommand
             $this->placeDocumentRepository->fetch($placeUuid);
             $this->placeDocumentRepository->fetch($canonicalUuid);
         } catch (DocumentDoesNotExist $e) {
-            $output->writeln($placeUuid . ' & ' . $canonicalUuid . ' should both be valid Place Uuids.');
+            $output->writeln($e->getMessage());
             return 0;
         }
 

--- a/app/Console/Command/DeletePlace.php
+++ b/app/Console/Command/DeletePlace.php
@@ -9,6 +9,8 @@ use CultuurNet\UDB3\Event\Commands\UpdateLocation;
 use CultuurNet\UDB3\Event\ReadModel\Relations\EventRelationsRepository;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Offer\Commands\DeleteOffer;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -26,12 +28,16 @@ class DeletePlace extends AbstractCommand
 
     private EventRelationsRepository $eventRelationsRepository;
 
+    private DocumentRepository $placeDocumentRepository;
+
     public function __construct(
         CommandBus $commandBus,
-        EventRelationsRepository $eventRelationsRepository
+        EventRelationsRepository $eventRelationsRepository,
+        DocumentRepository $placeDocumentRepository
     ) {
         parent::__construct($commandBus);
         $this->eventRelationsRepository = $eventRelationsRepository;
+        $this->placeDocumentRepository = $placeDocumentRepository;
     }
 
     public function configure(): void

--- a/app/Console/Command/DeletePlace.php
+++ b/app/Console/Command/DeletePlace.php
@@ -79,6 +79,14 @@ class DeletePlace extends AbstractCommand
             return 0;
         }
 
+        try {
+            $this->placeDocumentRepository->fetch($placeUuid);
+            $this->placeDocumentRepository->fetch($canonicalUuid);
+        } catch (DocumentDoesNotExist $e) {
+            $output->writeln($placeUuid . ' & ' . $canonicalUuid . ' should both be valid Place Uuids.');
+            return 0;
+        }
+
         if (!$this->askConfirmation($input, $output)) {
             return 0;
         }

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -415,6 +415,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
             fn () => new DeletePlace(
                 $container->get('event_command_bus'),
                 $container->get(EventRelationsRepository::class),
+                $container->get('place_jsonld_repository'),
             )
         );
 


### PR DESCRIPTION
### Changed

- `Console/Command/DeletePlace`: Added a `PlaceDocumentRepository` to the `constructor`
- `Console/Command/DeletePlace`: Check if `placeUuid` & `canonicalUuid` are indeed Places

### Fixed

- `Events` should no longer be deleted by the `DeletePlace` CLI-Command.

---
Ticket: https://jira.publiq.be/browse/III-6226
