### PR TITLE
III-6124 Include completness in canonical, when multiple museum places

### DIFF
--- a/src/Place/Canonical/CanonicalService.php
+++ b/src/Place/Canonical/CanonicalService.php
@@ -45,7 +45,7 @@ class CanonicalService
             return $placesWithMuseumpas[array_key_first($placesWithMuseumpas)];
         }
         if (count($placesWithMuseumpas) > 1) {
-            throw new MuseumPassNotUniqueInCluster($clusterId, count($placesWithMuseumpas));
+            return $this->getPlaceWithHighestCompleteness($placesWithMuseumpas);
         }
 
         $placesWithMostEvents = $this->getPlacesWithMostEvents($placeIds);
@@ -93,5 +93,24 @@ class CanonicalService
 
         asort($placesByCreationDate);
         return array_key_first($placesByCreationDate);
+    }
+
+    private function getPlaceWithHighestCompleteness(array $placeIds): string
+    {
+        $maxCompleteness = -1;
+        $placeWithMaxCompleteness = '';
+
+        foreach ($placeIds as $placeId) {
+            $jsonDocument = $this->placeRepository->fetch($placeId);
+            $body = $jsonDocument->getBody();
+            $completeness = $body->completeness;
+
+            if ($completeness > $maxCompleteness) {
+                $maxCompleteness = $completeness;
+                $placeWithMaxCompleteness = $placeId;
+            }
+        }
+
+        return $placeWithMaxCompleteness;
     }
 }

--- a/src/Place/Canonical/CanonicalService.php
+++ b/src/Place/Canonical/CanonicalService.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Place\Canonical;
 use CultuurNet\UDB3\Event\ReadModel\Relations\EventRelationsRepository;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
-use CultuurNet\UDB3\Place\Canonical\Exception\MuseumPassNotUniqueInCluster;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 
 class CanonicalService

--- a/tests/Place/Canonical/CanonicalServiceTest.php
+++ b/tests/Place/Canonical/CanonicalServiceTest.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\DBALTestConnectionTrait;
 use CultuurNet\UDB3\Event\ReadModel\Relations\Doctrine\DBALEventRelationsRepository;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\Doctrine\DBALReadRepository;
-use CultuurNet\UDB3\Place\Canonical\Exception\MuseumPassNotUniqueInCluster;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use Doctrine\DBAL\Schema\Table;
@@ -130,7 +129,7 @@ class CanonicalServiceTest extends TestCase
             [
                 'labelName' => 'museumPASSmusees',
                 'relationType' => 'Place',
-                'relationId'=> $this->museumPassPlaceId,
+                'relationId' => $this->museumPassPlaceId,
                 'imported' => '0',
             ]
         );
@@ -140,7 +139,7 @@ class CanonicalServiceTest extends TestCase
             [
                 'labelName' => 'museumPASSmusees',
                 'relationType' => 'Place',
-                'relationId'=> $anotherMuseumPassPlaceId,
+                'relationId' => $anotherMuseumPassPlaceId,
                 'imported' => '0',
             ]
         );
@@ -156,7 +155,7 @@ class CanonicalServiceTest extends TestCase
             [
                 'event' => 'cb11d320-17dc-41f8-831a-8b9d8208ea80',
                 'organizer' => 'eb89d990-8f5b-46be-a548-c87a300a54c8',
-                'place'=> $this->museumPassPlaceId,
+                'place' => $this->museumPassPlaceId,
             ]
         );
         $this->getConnection()->insert(
@@ -164,7 +163,7 @@ class CanonicalServiceTest extends TestCase
             [
                 'event' => '86e4540d-eed2-4cc5-8e08-a9f684deb03f',
                 'organizer' => 'eb89d990-8f5b-46be-a548-c87a300a54c8',
-                'place'=> $this->museumPassPlaceId,
+                'place' => $this->museumPassPlaceId,
             ]
         );
         $this->getConnection()->insert(
@@ -172,7 +171,7 @@ class CanonicalServiceTest extends TestCase
             [
                 'event' => 'bf1ba6c5-6d02-4c08-ab62-84ce8aa214a0',
                 'organizer' => 'eb89d990-8f5b-46be-a548-c87a300a54c8',
-                'place'=> $this->mostEventsPlaceId,
+                'place' => $this->mostEventsPlaceId,
             ]
         );
 

--- a/tests/Place/Canonical/CanonicalServiceTest.php
+++ b/tests/Place/Canonical/CanonicalServiceTest.php
@@ -200,6 +200,18 @@ class CanonicalServiceTest extends TestCase
         );
         $documentRepository->save($oldestJsonDocument);
 
+        $oldestJsonDocument = new JsonDocument(
+            $anotherMuseumPassPlaceId,
+            Json::encode(['@id' => $anotherMuseumPassPlaceId, 'completeness' => 40])
+        );
+        $documentRepository->save($oldestJsonDocument);
+
+        $oldestJsonDocument = new JsonDocument(
+            $this->museumPassPlaceId,
+            Json::encode(['@id' => $this->museumPassPlaceId, 'completeness' => 80])
+        );
+        $documentRepository->save($oldestJsonDocument);
+
         $this->canonicalService = new CanonicalService(
             'museumPASSmusees',
             new DBALDuplicatePlaceRepository($this->getConnection()),
@@ -243,12 +255,14 @@ class CanonicalServiceTest extends TestCase
     /**
      * @test
      */
-    public function it_will_throw_an_exception_when_cluster_contains_2_MPM_places(): void
+    public function it_will_return_the_place_with_the_highest_completeness_when_cluster_contains_2_MPM_places(): void
     {
-        $this->expectException(MuseumPassNotUniqueInCluster::class);
-        $this->expectExceptionMessage('Cluster 2 contains 2 MuseumPass places');
+        $canonicalId = $this->canonicalService->getCanonical(2);
 
-        $this->canonicalService->getCanonical(2);
+        $this->assertEquals(
+            $this->museumPassPlaceId,
+            $canonicalId
+        );
     }
 
     /**


### PR DESCRIPTION
### Changed
Currently when we calculate a canonical for the duplicate places clusters, we skip clusters with multiple MuseumPass places.
Now that we have the "completeness" inside the backend of UiTdatabank, it can be very useful to use that and to make sure we use data rich places as a canonical.
So we are going to take the place with the highest completeness in these cases and select it as canonical.

Comes with a test :-)

---
Ticket: https://jira.uitdatabank.be/browse/III-6124 
