### PR TITLE
III-5990 incorrect events in Production

### DIFF
--- a/app/Console/Command/BulkRemoveFromProduction.php
+++ b/app/Console/Command/BulkRemoveFromProduction.php
@@ -31,8 +31,8 @@ final class BulkRemoveFromProduction extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $command = new RemoveEventsFromProduction($input->getOption(
-            'eventId'),
+        $command = new RemoveEventsFromProduction(
+            $input->getOption('eventId'),
             ProductionId::fromNative($input->getArgument('productionId'))
         );
         $this->commandBus->dispatch($command);

--- a/app/Console/Command/BulkRemoveFromProduction.php
+++ b/app/Console/Command/BulkRemoveFromProduction.php
@@ -33,6 +33,7 @@ final class BulkRemoveFromProduction extends AbstractCommand
     {
         $eventIds = $input->getOption('eventId');
         $productionId = $input->getArgument('productionId');
+
         $this->commandBus->dispatch(
             new RemoveEventsFromProduction(
                 $eventIds,

--- a/app/Console/Command/BulkRemoveFromProduction.php
+++ b/app/Console/Command/BulkRemoveFromProduction.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Console\Command;
+
+use Broadway\Domain\DomainEventStream;
+use Broadway\EventHandling\EventBus;
+use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Event\Productions\ProductionId;
+use CultuurNet\UDB3\Event\Productions\ProductionRepository;
+use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
+use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class BulkRemoveFromProduction extends Command
+{
+    private ProductionRepository $repository;
+
+    private EventBus $eventBus;
+
+    private DocumentEventFactory $eventFactory;
+
+    public function __construct(
+        ProductionRepository $repository,
+        EventBus $eventBus,
+        DocumentEventFactory $eventFactory
+    ) {
+        $this->repository = $repository;
+        $this->eventBus = $eventBus;
+        $this->eventFactory = $eventFactory;
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('event:bulk-remove-from-production')
+            ->setDescription('Bulk removes events from a production')
+            ->addArgument(
+                'productionId',
+                InputOption::VALUE_REQUIRED,
+                'The id of the production contains incorrect events.'
+            )
+            ->addOption(
+                'eventId',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'An array of eventIds to remove from the production.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $productionId = ProductionId::fromNative($input->getArgument('productionId'));
+        try {
+            $production = $this->repository->find($productionId);
+        } catch (EntityNotFoundException $exception) {
+            $output->writeln($exception->getMessage());
+            return 1;
+        }
+
+        $originalEventIds = $production->getEventIds();
+        $eventIdsToRemove = $input->getOption('eventId');
+
+        if (!empty(array_diff($eventIdsToRemove, $originalEventIds))) {
+            $output->writeln('The input contains events which are not part of the production with id ' . $productionId->toNative());
+            return 1;
+        }
+
+        foreach ($eventIdsToRemove as $eventIdToRemove) {
+            $this->repository->removeEvent($eventIdToRemove, $productionId);
+        }
+
+        $this->dispatchEventsProjectedToJsonLd(...$originalEventIds);
+
+        $domainMessages = [];
+        foreach ($originalEventIds as $originalEventId) {
+            $eventProjectedToJsonLd = $this->eventFactory->createEvent($originalEventId);
+            $domainMessages[] = (new DomainMessageBuilder())->create($eventProjectedToJsonLd);
+        }
+        $stream = new DomainEventStream($domainMessages);
+        $this->eventBus->publish($stream);
+
+        return 0;
+    }
+
+    private function dispatchEventsProjectedToJsonLd(string ...$eventIds): void
+    {
+        $domainMessages = [];
+        foreach ($eventIds as $eventId) {
+            $eventProjectedToJsonLd = $this->eventFactory->createEvent($eventId);
+            $domainMessages[] = (new DomainMessageBuilder())->create($eventProjectedToJsonLd);
+        }
+        $stream = new DomainEventStream($domainMessages);
+        $this->eventBus->publish($stream);
+    }
+}

--- a/app/Console/Command/BulkRemoveFromProduction.php
+++ b/app/Console/Command/BulkRemoveFromProduction.php
@@ -31,11 +31,12 @@ final class BulkRemoveFromProduction extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $command = new RemoveEventsFromProduction(
-            $input->getOption('eventId'),
-            ProductionId::fromNative($input->getArgument('productionId'))
+        $this->commandBus->dispatch(
+            new RemoveEventsFromProduction(
+                $input->getOption('eventId'),
+                ProductionId::fromNative($input->getArgument('productionId'))
+            )
         );
-        $this->commandBus->dispatch($command);
 
         return 0;
     }

--- a/app/Console/Command/BulkRemoveFromProduction.php
+++ b/app/Console/Command/BulkRemoveFromProduction.php
@@ -31,12 +31,16 @@ final class BulkRemoveFromProduction extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $eventIds = $input->getOption('eventId');
+        $productionId = $input->getArgument('productionId');
         $this->commandBus->dispatch(
             new RemoveEventsFromProduction(
-                $input->getOption('eventId'),
-                ProductionId::fromNative($input->getArgument('productionId'))
+                $eventIds,
+                ProductionId::fromNative($productionId)
             )
         );
+
+        $output->writeln(count($eventIds) . ' events were removed from production with id ' . $productionId);
 
         return 0;
     }

--- a/app/Console/Command/BulkRemoveFromProduction.php
+++ b/app/Console/Command/BulkRemoveFromProduction.php
@@ -4,37 +4,14 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Console\Command;
 
-use Broadway\Domain\DomainEventStream;
-use Broadway\EventHandling\EventBus;
-use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\Productions\ProductionId;
-use CultuurNet\UDB3\Event\Productions\ProductionRepository;
-use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
-use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
-use Symfony\Component\Console\Command\Command;
+use CultuurNet\UDB3\Event\Productions\RemoveEventsFromProduction;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class BulkRemoveFromProduction extends Command
+final class BulkRemoveFromProduction extends AbstractCommand
 {
-    private ProductionRepository $repository;
-
-    private EventBus $eventBus;
-
-    private DocumentEventFactory $eventFactory;
-
-    public function __construct(
-        ProductionRepository $repository,
-        EventBus $eventBus,
-        DocumentEventFactory $eventFactory
-    ) {
-        $this->repository = $repository;
-        $this->eventBus = $eventBus;
-        $this->eventFactory = $eventFactory;
-        parent::__construct();
-    }
-
     protected function configure(): void
     {
         $this->setName('event:bulk-remove-from-production')
@@ -55,46 +32,12 @@ final class BulkRemoveFromProduction extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $productionId = ProductionId::fromNative($input->getArgument('productionId'));
-        try {
-            $production = $this->repository->find($productionId);
-        } catch (EntityNotFoundException $exception) {
-            $output->writeln($exception->getMessage());
-            return 1;
-        }
 
-        $originalEventIds = $production->getEventIds();
         $eventIdsToRemove = $input->getOption('eventId');
 
-        if (!empty(array_diff($eventIdsToRemove, $originalEventIds))) {
-            $output->writeln('The input contains events which are not part of the production with id ' . $productionId->toNative());
-            return 1;
-        }
-
-        foreach ($eventIdsToRemove as $eventIdToRemove) {
-            $this->repository->removeEvent($eventIdToRemove, $productionId);
-        }
-
-        $this->dispatchEventsProjectedToJsonLd(...$originalEventIds);
-
-        $domainMessages = [];
-        foreach ($originalEventIds as $originalEventId) {
-            $eventProjectedToJsonLd = $this->eventFactory->createEvent($originalEventId);
-            $domainMessages[] = (new DomainMessageBuilder())->create($eventProjectedToJsonLd);
-        }
-        $stream = new DomainEventStream($domainMessages);
-        $this->eventBus->publish($stream);
+        $command = new RemoveEventsFromProduction($eventIdsToRemove, $productionId);
+        $this->commandBus->dispatch($command);
 
         return 0;
-    }
-
-    private function dispatchEventsProjectedToJsonLd(string ...$eventIds): void
-    {
-        $domainMessages = [];
-        foreach ($eventIds as $eventId) {
-            $eventProjectedToJsonLd = $this->eventFactory->createEvent($eventId);
-            $domainMessages[] = (new DomainMessageBuilder())->create($eventProjectedToJsonLd);
-        }
-        $stream = new DomainEventStream($domainMessages);
-        $this->eventBus->publish($stream);
     }
 }

--- a/app/Console/Command/BulkRemoveFromProduction.php
+++ b/app/Console/Command/BulkRemoveFromProduction.php
@@ -31,11 +31,10 @@ final class BulkRemoveFromProduction extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $productionId = ProductionId::fromNative($input->getArgument('productionId'));
-
-        $eventIdsToRemove = $input->getOption('eventId');
-
-        $command = new RemoveEventsFromProduction($eventIdsToRemove, $productionId);
+        $command = new RemoveEventsFromProduction($input->getOption(
+            'eventId'),
+            ProductionId::fromNative($input->getArgument('productionId'))
+        );
         $this->commandBus->dispatch($command);
 
         return 0;

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Console;
 
 use Broadway\EventHandling\EventBus;
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
+use CultuurNet\UDB3\Console\Command\BulkRemoveFromProduction;
 use CultuurNet\UDB3\Console\Command\ChangeOfferOwner;
 use CultuurNet\UDB3\Console\Command\ChangeOfferOwnerInBulk;
 use CultuurNet\UDB3\Console\Command\ChangeOrganizerOwner;
@@ -47,6 +48,8 @@ use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
+use CultuurNet\UDB3\Event\EventJSONLDServiceProvider;
+use CultuurNet\UDB3\Event\Productions\DBALProductionRepository;
 use CultuurNet\UDB3\Event\Productions\ProductionRepository;
 use CultuurNet\UDB3\Event\ReadModel\Relations\EventRelationsRepository;
 use CultuurNet\UDB3\Kinepolis\Client\AuthenticatedKinepolisClient;
@@ -82,6 +85,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         'console.fire-projected-to-jsonld-for-relations',
         'console.fire-projected-to-jsonld',
         'console.place:process-duplicates',
+        'console.event:bulk-remove-from-production',
         'console.event:reindex-offers-with-popularity',
         'console.place:reindex-offers-with-popularity',
         'console.event:reindex-events-with-recommendations',
@@ -253,6 +257,15 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
                 $container->get('place_jsonld_projected_event_factory'),
                 $container->get(EventRelationsRepository::class),
                 $container->get('dbal_connection')
+            )
+        );
+
+        $container->addShared(
+            'console.event:bulk-remove-from-production',
+            fn () => new BulkRemoveFromProduction(
+                new DBALProductionRepository($container->get('dbal_connection')),
+                $container->get(EventBus::class),
+                $container->get(EventJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY)
             )
         );
 

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -48,8 +48,6 @@ use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
-use CultuurNet\UDB3\Event\EventJSONLDServiceProvider;
-use CultuurNet\UDB3\Event\Productions\DBALProductionRepository;
 use CultuurNet\UDB3\Event\Productions\ProductionRepository;
 use CultuurNet\UDB3\Event\ReadModel\Relations\EventRelationsRepository;
 use CultuurNet\UDB3\Kinepolis\Client\AuthenticatedKinepolisClient;
@@ -262,11 +260,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
 
         $container->addShared(
             'console.event:bulk-remove-from-production',
-            fn () => new BulkRemoveFromProduction(
-                new DBALProductionRepository($container->get('dbal_connection')),
-                $container->get(EventBus::class),
-                $container->get(EventJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY)
-            )
+            fn () => new BulkRemoveFromProduction($container->get('event_command_bus'))
         );
 
         $container->addShared(

--- a/app/Event/EventCommandHandlerProvider.php
+++ b/app/Event/EventCommandHandlerProvider.php
@@ -98,7 +98,8 @@ final class EventCommandHandlerProvider extends AbstractServiceProvider
             function () use ($container): CopyEventHandler {
                 return new CopyEventHandler(
                     $container->get('event_repository'),
-                    $container->get(ProductionRepository::class)
+                    $container->get(ProductionRepository::class),
+                    $container->get('config')['copy_production'] ?? true
                 );
             }
         );

--- a/src/Event/CommandHandlers/CopyEventHandler.php
+++ b/src/Event/CommandHandlers/CopyEventHandler.php
@@ -17,12 +17,16 @@ final class CopyEventHandler implements CommandHandler
     private EventRepository $eventRepository;
     private ProductionRepository $productionRepository;
 
+    private bool $copyProduction;
+
     public function __construct(
         EventRepository $eventRepository,
-        ProductionRepository $productionRepository
+        ProductionRepository $productionRepository,
+        bool $copyProduction
     ) {
         $this->eventRepository = $eventRepository;
         $this->productionRepository = $productionRepository;
+        $this->copyProduction = $copyProduction;
     }
 
     public function handle($command): void
@@ -42,11 +46,13 @@ final class CopyEventHandler implements CommandHandler
 
         // Add the new event to the same production as the original one.
         // This is not done as part of Event::copy() because productions are not event-sourced.
-        try {
-            $production = $this->productionRepository->findProductionForEventId($originalEventId);
-            $this->productionRepository->addEvent($newEventId, $production);
-        } catch (EntityNotFoundException $e) {
-            return;
+        if ($this->copyProduction) {
+            try {
+                $production = $this->productionRepository->findProductionForEventId($originalEventId);
+                $this->productionRepository->addEvent($newEventId, $production);
+            } catch (EntityNotFoundException $e) {
+                return;
+            }
         }
     }
 }

--- a/src/Event/Productions/BroadcastingProductionRepository.php
+++ b/src/Event/Productions/BroadcastingProductionRepository.php
@@ -56,6 +56,14 @@ final class BroadcastingProductionRepository implements ProductionRepository
         $this->dispatchEventsProjectedToJsonLd($eventId, ...$otherEventIds);
     }
 
+    /** @param string[] $eventIds */
+    public function removeEvents(array $eventIds, ProductionId $productionId): void
+    {
+        $this->repository->removeEvents($eventIds, $productionId);
+        $otherEventIds = $this->getEventIdsForProductionId($productionId);
+        $this->dispatchEventsProjectedToJsonLd(...$eventIds, ...$otherEventIds);
+    }
+
     public function moveEvents(ProductionId $from, Production $to): void
     {
         $this->repository->moveEvents($from, $to);

--- a/src/Event/Productions/BroadcastingProductionRepository.php
+++ b/src/Event/Productions/BroadcastingProductionRepository.php
@@ -12,20 +12,11 @@ use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
 
 final class BroadcastingProductionRepository implements ProductionRepository
 {
-    /**
-     * @var ProductionRepository
-     */
-    private $repository;
+    private ProductionRepository $repository;
 
-    /**
-     * @var EventBus
-     */
-    private $eventBus;
+    private EventBus $eventBus;
 
-    /**
-     * @var DocumentEventFactory
-     */
-    private $eventFactory;
+    private DocumentEventFactory $eventFactory;
 
     public function __construct(
         ProductionRepository $repository,

--- a/src/Event/Productions/DBALProductionRepository.php
+++ b/src/Event/Productions/DBALProductionRepository.php
@@ -77,6 +77,14 @@ class DBALProductionRepository extends AbstractDBALRepository implements Product
         );
     }
 
+    /** @param string[] $eventIds */
+    public function removeEvents(array $eventIds, ProductionId $productionId): void
+    {
+        foreach ($eventIds as $eventId) {
+            $this->removeEvent($eventId, $productionId);
+        }
+    }
+
     public function moveEvents(ProductionId $from, Production $to): void
     {
         $addedAt = Chronos::now();

--- a/src/Event/Productions/DBALProductionRepository.php
+++ b/src/Event/Productions/DBALProductionRepository.php
@@ -80,9 +80,15 @@ final class DBALProductionRepository extends AbstractDBALRepository implements P
     /** @param string[] $eventIds */
     public function removeEvents(array $eventIds, ProductionId $productionId): void
     {
-        foreach ($eventIds as $eventId) {
-            $this->removeEvent($eventId, $productionId);
-        }
+        (
+            $this->getConnection()->createQueryBuilder()
+            ->delete(
+                $this->getTableName()
+            )->where('event_id IN (:event_ids)')
+            ->andWhere('production_id = :production_id')
+            ->setParameter('event_ids', $eventIds, Connection::PARAM_STR_ARRAY)
+            ->setParameter('production_id', $productionId->toNative())
+        )->execute();
     }
 
     public function moveEvents(ProductionId $from, Production $to): void

--- a/src/Event/Productions/DBALProductionRepository.php
+++ b/src/Event/Productions/DBALProductionRepository.php
@@ -80,15 +80,15 @@ final class DBALProductionRepository extends AbstractDBALRepository implements P
     /** @param string[] $eventIds */
     public function removeEvents(array $eventIds, ProductionId $productionId): void
     {
-        (
-            $this->getConnection()->createQueryBuilder()
-            ->delete(
-                $this->getTableName()
-            )->where('event_id IN (:event_ids)')
+        $this->getConnection()->createQueryBuilder()
+            ->delete($this->getTableName())
+            ->where('event_id IN (:event_ids)')
             ->andWhere('production_id = :production_id')
             ->setParameter('event_ids', $eventIds, Connection::PARAM_STR_ARRAY)
-            ->setParameter('production_id', $productionId->toNative())
-        )->execute();
+            ->setParameter(
+                'production_id',
+                $productionId->toNative()
+            )->execute();
     }
 
     public function moveEvents(ProductionId $from, Production $to): void

--- a/src/Event/Productions/DBALProductionRepository.php
+++ b/src/Event/Productions/DBALProductionRepository.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 
-class DBALProductionRepository extends AbstractDBALRepository implements ProductionRepository
+final class DBALProductionRepository extends AbstractDBALRepository implements ProductionRepository
 {
     public const TABLE_NAME = 'productions';
 

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -78,6 +78,12 @@ class ProductionCommandHandler extends Udb3CommandHandler
         $this->productionRepository->removeEvent($command->getEventId(), $command->getProductionId());
     }
 
+    public function handleRemoveEventsFromProduction(RemoveEventsFromProduction $command): void
+    {
+        $this->assertEventsCanBeRemovedFromProduction($command->getEventIds(), $command->getProductionId());
+        $this->productionRepository->removeEvents($command->getEventIds(), $command->getProductionId());
+    }
+
     public function handleMergeProductions(MergeProductions $command): void
     {
         $toProduction = $this->productionRepository->find($command->getTo());
@@ -116,6 +122,14 @@ class ProductionCommandHandler extends Udb3CommandHandler
             throw EventCannotBeRemovedFromProduction::becauseItDoesNotExist($eventId);
         } catch (EntityNotFoundException $e) {
             throw EventCannotBeRemovedFromProduction::becauseProductionDoesNotExist($eventId, $productionId);
+        }
+    }
+
+    /** @param string[] $eventIds */
+    private function assertEventsCanBeRemovedFromProduction(array $eventIds, ProductionId $productionId): void
+    {
+        foreach ($eventIds as $eventId) {
+            $this->assertEventCanBeRemovedFromProduction($eventId, $productionId);
         }
     }
 }

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use Doctrine\DBAL\DBALException;
 
-class ProductionCommandHandler extends Udb3CommandHandler
+final class ProductionCommandHandler extends Udb3CommandHandler
 {
     private ProductionRepository $productionRepository;
 

--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -19,6 +19,9 @@ interface ProductionRepository
 
     public function removeEvent(string $eventId, ProductionId $productionId): void;
 
+    /** @param string[] $eventIds */
+    public function removeEvents(array $eventIds, ProductionId $productionId): void;
+
     public function moveEvents(ProductionId $from, Production $to): void;
 
     public function renameProduction(ProductionId $productionId, string $name): void;

--- a/src/Event/Productions/RemoveEventsFromProduction.php
+++ b/src/Event/Productions/RemoveEventsFromProduction.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Productions;
+
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\AuthorizableCommand;
+
+final class RemoveEventsFromProduction implements AuthorizableCommand
+{
+    /**
+     * @var string[]
+     */
+    private array $eventIds;
+
+    private ProductionId $productionId;
+
+    /**
+     * @param string[] $eventIds
+     */
+    public function __construct(
+        array $eventIds,
+        ProductionId $productionId
+    ) {
+        $this->eventIds = $eventIds;
+        $this->productionId = $productionId;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getEventIds(): array
+    {
+        return $this->eventIds;
+    }
+
+    public function getProductionId(): ProductionId
+    {
+        return $this->productionId;
+    }
+
+    public function getItemId(): string
+    {
+        return $this->getProductionId()->toNative();
+    }
+
+    public function getPermission(): Permission
+    {
+        return Permission::productiesAanmaken();
+    }
+}

--- a/tests/Event/CommandHandlers/CopyEventHandlerTest.php
+++ b/tests/Event/CommandHandlers/CopyEventHandlerTest.php
@@ -32,11 +32,22 @@ class CopyEventHandlerTest extends TestCase
     private MockObject $productionRepository;
     private CopyEventHandler $copyEventHandler;
 
+    private CopyEventHandler $disabledCopyEventHandler;
+
     protected function setUp(): void
     {
         $this->eventRepository = $this->createMock(EventRepository::class);
         $this->productionRepository = $this->createMock(ProductionRepository::class);
-        $this->copyEventHandler = new CopyEventHandler($this->eventRepository, $this->productionRepository);
+        $this->copyEventHandler = new CopyEventHandler(
+            $this->eventRepository,
+            $this->productionRepository,
+            true
+        );
+        $this->disabledCopyEventHandler = new CopyEventHandler(
+            $this->eventRepository,
+            $this->productionRepository,
+            false
+        );
     }
 
     /**
@@ -178,6 +189,72 @@ class CopyEventHandlerTest extends TestCase
             ->with($newEventId, $production);
 
         $this->copyEventHandler->handle($command);
+
+        $this->assertEquals($expectedEvents, $actualEvents);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_add_the_new_event_to_the_same_production_if_disabled(): void
+    {
+        $originalEventId = '83a12220-9459-4fc8-b1ed-71b3d1668e65';
+        $newEventId = '5b9158c6-47ec-4f98-8d9e-edafc89870bc';
+        $newCalendar = new PermanentCalendar(new OpeningHours());
+
+        $command = new CopyEvent($originalEventId, $newEventId, $newCalendar);
+
+        $originalEvent = Event::create(
+            $originalEventId,
+            new Language('nl'),
+            new Title('Mock event'),
+            new EventType('0.0.0.0.1', 'Mock type'),
+            new LocationId('8aa2d316-0f5a-495d-9832-46fc22eeaa89'),
+            new Calendar(
+                CalendarType::SINGLE(),
+                null,
+                null,
+                [
+                    new Timestamp(
+                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2022-01-01T12:00:00+01:00'),
+                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2022-01-02T12:00:00+01:00')
+                    ),
+                ]
+            )
+        );
+
+        // Fake a save to the event store.
+        // Otherwise there are uncommitted events on the original event, and it will refuse to copy itself.
+        $originalEvent->getUncommittedEvents();
+
+        $this->eventRepository->expects($this->once())
+            ->method('load')
+            ->with($originalEventId)
+            ->willReturn($originalEvent);
+
+        $expectedEvents = [
+            new EventCopied($newEventId, $originalEventId, Calendar::fromUdb3ModelCalendar($newCalendar)),
+        ];
+        $actualEvents = [];
+
+        $this->eventRepository->expects($this->once())
+            ->method('save')
+            ->willReturnCallback(
+                function (Event $newEvent) use (&$actualEvents): void {
+                    $actualEvents = array_map(
+                        fn (DomainMessage $domainMessage) => $domainMessage->getPayload(),
+                        $newEvent->getUncommittedEvents()->getIterator()->getArrayCopy()
+                    );
+                }
+            );
+
+        $this->productionRepository->expects($this->never())
+            ->method('findProductionForEventId');
+
+        $this->productionRepository->expects($this->never())
+            ->method('addEvent');
+
+        $this->disabledCopyEventHandler->handle($command);
 
         $this->assertEquals($expectedEvents, $actualEvents);
     }

--- a/tests/Event/CommandHandlers/CopyEventHandlerTest.php
+++ b/tests/Event/CommandHandlers/CopyEventHandlerTest.php
@@ -26,7 +26,7 @@ use DateTimeImmutable;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class CopyEventHandlerTest extends TestCase
+final class CopyEventHandlerTest extends TestCase
 {
     private MockObject $eventRepository;
     private MockObject $productionRepository;

--- a/tests/Event/Productions/BroadcastingProductionRepositoryTest.php
+++ b/tests/Event/Productions/BroadcastingProductionRepositoryTest.php
@@ -12,22 +12,16 @@ use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class BroadcastingProductionRepositoryTest extends TestCase
+final class BroadcastingProductionRepositoryTest extends TestCase
 {
     /**
      * @var ProductionRepository|MockObject
      */
     private $decoratee;
 
-    /**
-     * @var TraceableEventBus
-     */
-    private $eventBus;
+    private TraceableEventBus $eventBus;
 
-    /**
-     * @var BroadcastingProductionRepository
-     */
-    private $repository;
+    private BroadcastingProductionRepository $repository;
 
     protected function setUp(): void
     {

--- a/tests/Event/Productions/BroadcastingProductionRepositoryTest.php
+++ b/tests/Event/Productions/BroadcastingProductionRepositoryTest.php
@@ -187,6 +187,66 @@ class BroadcastingProductionRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_should_broadcast_event_projected_to_jsonld_for_events_in_a_production_when_multiple_events_are_removed(): void
+    {
+        $removeEventIds = [
+            'bf1668d0-ce82-4e38-b284-2947f12850d6',
+            'fc779e8a-614b-4a88-bcde-ab0825aa1443',
+            '24187ed9-ae8f-41d3-88d4-09cf67608669',
+        ];
+
+        $productionId = ProductionId::fromNative('599fc3af-0023-4c59-a0ab-05c9ad7f54cc');
+        $productionAfterRemoval = new Production(
+            $productionId,
+            'mock production',
+            [
+                'd6a65aa8-d871-4a3e-a7ef-81926ad62371',
+                'a40ca8ff-cdae-406c-9124-f5874ef8056a',
+            ]
+        );
+
+        $this->decoratee->expects($this->once())
+            ->method('removeEvents')
+            ->with($removeEventIds, $productionId);
+
+        $this->decoratee->expects($this->once())
+            ->method('find')
+            ->with($productionId)
+            ->willReturn($productionAfterRemoval);
+
+        $this->repository->removeEvents($removeEventIds, $productionId);
+
+        $expected = [
+            new EventProjectedToJSONLD(
+                'bf1668d0-ce82-4e38-b284-2947f12850d6',
+                'https://io.uitdatabank.be/events/bf1668d0-ce82-4e38-b284-2947f12850d6'
+            ),
+            new EventProjectedToJSONLD(
+                'fc779e8a-614b-4a88-bcde-ab0825aa1443',
+                'https://io.uitdatabank.be/events/fc779e8a-614b-4a88-bcde-ab0825aa1443'
+            ),
+            new EventProjectedToJSONLD(
+                '24187ed9-ae8f-41d3-88d4-09cf67608669',
+                'https://io.uitdatabank.be/events/24187ed9-ae8f-41d3-88d4-09cf67608669'
+            ),
+            new EventProjectedToJSONLD(
+                'd6a65aa8-d871-4a3e-a7ef-81926ad62371',
+                'https://io.uitdatabank.be/events/d6a65aa8-d871-4a3e-a7ef-81926ad62371'
+            ),
+            new EventProjectedToJSONLD(
+                'a40ca8ff-cdae-406c-9124-f5874ef8056a',
+                'https://io.uitdatabank.be/events/a40ca8ff-cdae-406c-9124-f5874ef8056a'
+            ),
+        ];
+
+        $actual = $this->eventBus->getEvents();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_broadcast_event_projected_to_jsonld_for_events_in_a_production_when_events_get_moved(): void
     {
         $productionIdFrom = ProductionId::fromNative('bf1668d0-ce82-4e38-b284-2947f12850d6');

--- a/tests/Event/Productions/DBALProductionRepositoryTest.php
+++ b/tests/Event/Productions/DBALProductionRepositoryTest.php
@@ -11,14 +11,11 @@ use Doctrine\DBAL\DBALException;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class DBALProductionRepositoryTest extends TestCase
+final class DBALProductionRepositoryTest extends TestCase
 {
     use DBALTestConnectionTrait;
 
-    /**
-     * @var DBALProductionRepository
-     */
-    private $repository;
+    private DBALProductionRepository $repository;
 
     protected function setUp(): void
     {

--- a/tests/Event/Productions/DBALProductionRepositoryTest.php
+++ b/tests/Event/Productions/DBALProductionRepositoryTest.php
@@ -85,6 +85,33 @@ class DBALProductionRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_can_remove_multiple_events_from_a_production(): void
+    {
+        $production = Production::createEmpty('foo');
+        $eventsToRemove = [
+            Uuid::uuid4()->toString(),
+            Uuid::uuid4()->toString(),
+        ];
+        $eventToKeep = Uuid::uuid4()->toString();
+
+        $production = $production->addEvent($eventsToRemove[0]);
+        $production = $production->addEvent($eventToKeep);
+        $production = $production->addEvent($eventsToRemove[1]);
+
+        $this->repository->add($production);
+
+        $this->repository->removeEvents($eventsToRemove, $production->getProductionId());
+
+        $persistedProduction = $this->repository->find($production->getProductionId());
+        $this->assertTrue($persistedProduction->containsEvent($eventToKeep));
+        foreach ($eventsToRemove as $removedEvent) {
+            $this->assertFalse($persistedProduction->containsEvent($removedEvent));
+        }
+    }
+
+    /**
+     * @test
+     */
     public function a_production_without_events_no_longer_exists(): void
     {
         $production = $this->givenThereIsAProduction();

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -14,19 +14,13 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class ProductionCommandHandlerTest extends TestCase
+final class ProductionCommandHandlerTest extends TestCase
 {
     use DBALTestConnectionTrait;
 
-    /**
-     * @var DBALProductionRepository
-     */
-    private $productionRepository;
+    private DBALProductionRepository $productionRepository;
 
-    /**
-     * @var ProductionCommandHandler
-     */
-    private $commandHandler;
+    private ProductionCommandHandler $commandHandler;
 
     /**
      * @var SkippedSimilarEventsRepository|MockObject


### PR DESCRIPTION
### Added

- `BulkRemoveFromProduction`: CLI-Command, to bulk remove Events from a production, without overloading the queues.
- `RemoveEventsFromProduction`: Command to remove multiple Events from a production.

### Changed

- `ConsoleServiceProvider`: Registered `BulkRemoveFromProduction`
- `CopyEventHandler`: Make it optional to add a copied event to the same production as the original.
- `EventCommandHandlerProvider`: `Updated constructor` of `CopyEventHandler`
- `ProductionCommandHandler`: added handle for `RemoveEventsFromProduction`
- `ProductionRepository` & implementations `DBALProductionRepository` & `BroadcastingProductionRepository` added `removeEvents()`

### Fixed

- When a production has many incorrect events, we can now bulk remove those events without overloading the queues.
Also to see if it investigate if it will diminish the incorrect events, adding a copied Event to the same production as the original has been made optional.
- Improved Codestyle for several files

### Related PR

- https://github.com/cultuurnet/appconfig/pull/719

---
Ticket: https://jira.publiq.be/browse/III-5990
