### PR TITLE
III-6236 Change structure table duplicate places

### DIFF
--- a/app/Console/Command/ProcessDuplicatePlaces.php
+++ b/app/Console/Command/ProcessDuplicatePlaces.php
@@ -214,6 +214,7 @@ final class ProcessDuplicatePlaces extends AbstractCommand
                 $this->eventBus->publish(
                     new DomainEventStream([(new DomainMessageBuilder())->create($placeProjected)])
                 );
+                $this->duplicatePlaceRepository->markAsProcessed($placeToReIndex);
             }
         }
     }

--- a/app/Console/Command/ProcessDuplicatePlaces.php
+++ b/app/Console/Command/ProcessDuplicatePlaces.php
@@ -159,9 +159,8 @@ final class ProcessDuplicatePlaces extends AbstractCommand
                     if (!$dryRun) {
                         try {
                             $this->commandBus->dispatch($command);
-                        }
-                        catch (\Exception $e) {
-                            $output->writeln('<error>'. $e->getMessage(). '</error>');
+                        } catch (\Exception $e) {
+                            $output->writeln('<error>' . $e->getMessage() . '</error>');
                             $this->logger->error($e->getMessage());
                         }
                     }

--- a/app/Console/Command/ProcessDuplicatePlaces.php
+++ b/app/Console/Command/ProcessDuplicatePlaces.php
@@ -95,7 +95,7 @@ final class ProcessDuplicatePlaces extends AbstractCommand
         $onlyRunClusterId = $input->getOption(self::ONLY_RUN_CLUSTER_ID);
 
         if ($onlyRunClusterId) {
-            $clusterIds = [(int)$onlyRunClusterId];
+            $clusterIds = [$onlyRunClusterId];
         } else {
             $clusterIds = $this->duplicatePlaceRepository->getClusterIds();
         }

--- a/app/Console/Command/ProcessDuplicatePlaces.php
+++ b/app/Console/Command/ProcessDuplicatePlaces.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Place\Canonical\DuplicatePlaceRepository;
 use CultuurNet\UDB3\Place\Canonical\Exception\MuseumPassNotUniqueInCluster;
 use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
 use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -38,6 +39,8 @@ final class ProcessDuplicatePlaces extends AbstractCommand
 
     private Connection $connection;
 
+    private LoggerInterface $logger;
+
     public function __construct(
         CommandBus $commandBus,
         DuplicatePlaceRepository $duplicatePlaceRepository,
@@ -45,7 +48,8 @@ final class ProcessDuplicatePlaces extends AbstractCommand
         EventBus $eventBus,
         DocumentEventFactory $placeEventFactory,
         EventRelationsRepository $eventRelationsRepository,
-        Connection $connection
+        Connection $connection,
+        LoggerInterface $logger
     ) {
         $this->duplicatePlaceRepository = $duplicatePlaceRepository;
         $this->canonicalService = $canonicalService;
@@ -53,6 +57,7 @@ final class ProcessDuplicatePlaces extends AbstractCommand
         $this->placeEventFactory = $placeEventFactory;
         $this->eventRelationsRepository = $eventRelationsRepository;
         $this->connection = $connection;
+        $this->logger = $logger;
 
         parent::__construct($commandBus);
     }
@@ -152,7 +157,13 @@ final class ProcessDuplicatePlaces extends AbstractCommand
                 foreach ($commands as $command) {
                     $output->writeln('Dispatching UpdateLocation for event with id ' . $command->getItemId());
                     if (!$dryRun) {
-                        $this->commandBus->dispatch($command);
+                        try {
+                            $this->commandBus->dispatch($command);
+                        }
+                        catch (\Exception $e) {
+                            $output->writeln('<error>'. $e->getMessage(). '</error>');
+                            $this->logger->error($e->getMessage());
+                        }
                     }
                 }
             }

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -254,7 +254,11 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
                 $container->get(EventBus::class),
                 $container->get('place_jsonld_projected_event_factory'),
                 $container->get(EventRelationsRepository::class),
-                $container->get('dbal_connection')
+                $container->get('dbal_connection'),
+                LoggerFactory::create(
+                    $container,
+                    LoggerName::forService('duplicate-place', 'duplicate.places')
+                )
             )
         );
 

--- a/app/Migrations/Version20240718143512.php
+++ b/app/Migrations/Version20240718143512.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240718143512 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('duplicate_places');
+
+        $table->changeColumn(
+            'cluster_id',
+            [
+                'type' => Type::getType(Types::STRING),
+                'length' => 40, //SHA1 length
+            ]
+        );
+
+        $table->addColumn('created_date', Types::DATETIME_IMMUTABLE);
+
+        $table->addColumn(
+            'processed',
+            Types::BOOLEAN,
+            ['default' => false]
+        )
+        ->setNotnull(true);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('duplicate_places');
+
+        $table->dropColumn('created_date');
+        $table->dropColumn('processed');
+
+        $table->changeColumn(
+            'cluster_id',
+            [
+                'type' => Type::getType(Types::BIGINT),
+                'length' => 40, //SHA1 length
+            ]
+        );
+    }
+}

--- a/src/Place/Canonical/CanonicalService.php
+++ b/src/Place/Canonical/CanonicalService.php
@@ -36,7 +36,7 @@ class CanonicalService
         $this->placeRepository = $placeRepository;
     }
 
-    public function getCanonical(int $clusterId): string
+    public function getCanonical(string $clusterId): string
     {
         $placeIds = $this->duplicatePlaceRepository->getPlacesInCluster($clusterId);
 

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -17,17 +17,16 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
 
     public function getClusterIds(): array
     {
-        $result = $this->connection->createQueryBuilder()
+        return $this->connection->createQueryBuilder()
             ->select('DISTINCT cluster_id')
             ->from('duplicate_places')
+            ->where('processed = 0')
             ->orderBy('cluster_id')
             ->execute()
             ->fetchFirstColumn();
-
-        return array_map('intval', $result);
     }
 
-    public function getPlacesInCluster(int $clusterId): array
+    public function getPlacesInCluster(string $clusterId): array
     {
         return $this->connection->createQueryBuilder()
             ->select('place_uuid')
@@ -38,7 +37,7 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
             ->fetchFirstColumn();
     }
 
-    public function setCanonicalOnCluster(int $clusterId, string $canonical): void
+    public function setCanonicalOnCluster(string $clusterId, string $canonical): void
     {
         $this->connection->createQueryBuilder()
             ->update('duplicate_places')

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -81,9 +81,9 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
     public function markAsProcessed(string $placeId): void
     {
         $this->connection->createQueryBuilder()
-            ->update('duplicate_places', 'dp')
-            ->set('dp.processed', '1')
-            ->where('dp.place_uuid = :place_uuid')
+            ->update('duplicate_places')
+            ->set('processed', '1')
+            ->where('place_uuid = :place_uuid')
             ->setParameter(':place_uuid', $placeId)
             ->execute();
     }

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -77,4 +77,14 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
 
         return count($duplicates) > 0 ? $duplicates : null;
     }
+
+    public function markAsProcessed(string $placeId): void
+    {
+        $this->connection->createQueryBuilder()
+            ->update('duplicate_places', 'dp')
+            ->set('dp.processed', '1')
+            ->where('dp.place_uuid = :place_uuid')
+            ->setParameter(':place_uuid', $placeId)
+            ->execute();
+    }
 }

--- a/src/Place/Canonical/DuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DuplicatePlaceRepository.php
@@ -22,5 +22,5 @@ interface DuplicatePlaceRepository
 
     public function getDuplicatesOfPlace(string $placeId): ?array;
 
-    public function markAsProcessed(string $placeId) : void;
+    public function markAsProcessed(string $placeId): void;
 }

--- a/src/Place/Canonical/DuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DuplicatePlaceRepository.php
@@ -21,4 +21,6 @@ interface DuplicatePlaceRepository
     public function getCanonicalOfPlace(string $placeId): ?string;
 
     public function getDuplicatesOfPlace(string $placeId): ?array;
+
+    public function markAsProcessed(string $placeId) : void;
 }

--- a/src/Place/Canonical/DuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DuplicatePlaceRepository.php
@@ -7,16 +7,16 @@ namespace CultuurNet\UDB3\Place\Canonical;
 interface DuplicatePlaceRepository
 {
     /**
-     * @return int[]
+     * @return string[]
      */
     public function getClusterIds(): array;
 
     /**
      * @return string[]
      */
-    public function getPlacesInCluster(int $clusterId): array;
+    public function getPlacesInCluster(string $clusterId): array;
 
-    public function setCanonicalOnCluster(int $clusterId, string $canonical): void;
+    public function setCanonicalOnCluster(string $clusterId, string $canonical): void;
 
     public function getCanonicalOfPlace(string $placeId): ?string;
 

--- a/src/Place/Canonical/Exception/MuseumPassNotUniqueInCluster.php
+++ b/src/Place/Canonical/Exception/MuseumPassNotUniqueInCluster.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Place\Canonical\Exception;
 
 class MuseumPassNotUniqueInCluster extends \Exception
 {
-    public function __construct(int $clusterId, int $amount)
+    public function __construct(string $clusterId, int $amount)
     {
         parent::__construct(sprintf('Cluster %s contains %d MuseumPass places', $clusterId, $amount));
     }

--- a/tests/Place/Canonical/CanonicalServiceTest.php
+++ b/tests/Place/Canonical/CanonicalServiceTest.php
@@ -219,7 +219,7 @@ class CanonicalServiceTest extends TestCase
      */
     public function it_will_return_the_MPM_place(): void
     {
-        $canonicalId = $this->canonicalService->getCanonical(1);
+        $canonicalId = $this->canonicalService->getCanonical('1');
 
         $this->assertEquals(
             $this->museumPassPlaceId,
@@ -232,7 +232,7 @@ class CanonicalServiceTest extends TestCase
      */
     public function it_will_get_the_place_with_most_events(): void
     {
-        $canonicalId = $this->canonicalService->getCanonical(3);
+        $canonicalId = $this->canonicalService->getCanonical('3');
 
         $this->assertEquals(
             $this->mostEventsPlaceId,
@@ -248,7 +248,7 @@ class CanonicalServiceTest extends TestCase
         $this->expectException(MuseumPassNotUniqueInCluster::class);
         $this->expectExceptionMessage('Cluster 2 contains 2 MuseumPass places');
 
-        $this->canonicalService->getCanonical(2);
+        $this->canonicalService->getCanonical('2');
     }
 
     /**
@@ -256,7 +256,7 @@ class CanonicalServiceTest extends TestCase
      */
     public function it_will_get_the_oldest_place_if_equal_nr_of_events(): void
     {
-        $canonicalId = $this->canonicalService->getCanonical(4);
+        $canonicalId = $this->canonicalService->getCanonical('4');
 
         $this->assertEquals(
             $this->oldestPlaceId,

--- a/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
+++ b/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
@@ -83,7 +83,7 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
     {
         $clusterIds = $this->duplicatePlaceRepository->getClusterIds();
 
-        $this->assertEquals([self::CLUSTER_ID_1,self::CLUSTER_ID_2], $clusterIds);
+        $this->assertEquals([self::CLUSTER_ID_1, self::CLUSTER_ID_2], $clusterIds);
     }
 
     /**
@@ -191,6 +191,29 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
                 '4a355db3-c3f9-4acc-8093-61b333a3aefb',
             ],
             $this->duplicatePlaceRepository->getDuplicatesOfPlace('64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_mark_a_place_as_processed(): void
+    {
+        $placeId = '19ce6565-76be-425d-94d6-894f84dd2947';
+
+        $this->duplicatePlaceRepository->markAsProcessed($placeId);
+
+        $actualRows = $this->connection->createQueryBuilder()
+            ->select('*')
+            ->from('duplicate_places')
+            ->where('place_uuid = :place_uuid')
+            ->setParameter('place_uuid', $placeId)
+            ->execute()
+            ->fetchNumeric();
+
+        $this->assertEquals(
+            [self::CLUSTER_ID_1, $placeId, null, 1],
+            $actualRows
         );
     }
 }

--- a/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
+++ b/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
@@ -15,7 +15,7 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
 
     private const CLUSTER_ID_1 = '356a192b7913b04c54574d18c28d46e6395428ab';
     private const CLUSTER_ID_2 = 'da4b9237bacccdf19c0760cab7aec4a8359010b0';
-    const CLUSTER_ID_PROCESSED = 'ec2f96367578f9efb384a1113e625f3570aeeaa1';
+    public const CLUSTER_ID_PROCESSED = 'ec2f96367578f9efb384a1113e625f3570aeeaa1';
     private DBALDuplicatePlaceRepository $duplicatePlaceRepository;
 
     public function setUp(): void

--- a/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
+++ b/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
@@ -77,7 +77,7 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
      */
     public function it_can_return_placeIds(): void
     {
-        $clusterIds = $this->duplicatePlaceRepository->getPlacesInCluster(1);
+        $clusterIds = $this->duplicatePlaceRepository->getPlacesInCluster('1');
 
         $this->assertEquals(
             [
@@ -94,8 +94,8 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
      */
     public function it_can_set_the_canonical_of_a_cluster(): void
     {
-        $this->duplicatePlaceRepository->setCanonicalOnCluster(1, '1accbcfb-3b22-4762-bc13-be0f67fd3116');
-        $this->duplicatePlaceRepository->setCanonicalOnCluster(2, '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster('1', '1accbcfb-3b22-4762-bc13-be0f67fd3116');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster('2', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
 
         $actualRows = $this->connection->createQueryBuilder()
             ->select('*')
@@ -120,8 +120,8 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
      */
     public function it_can_get_the_canonical_of_a_place(): void
     {
-        $this->duplicatePlaceRepository->setCanonicalOnCluster(1, '1accbcfb-3b22-4762-bc13-be0f67fd3116');
-        $this->duplicatePlaceRepository->setCanonicalOnCluster(2, '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster('1', '1accbcfb-3b22-4762-bc13-be0f67fd3116');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster('2', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
 
         $this->assertEquals(
             '1accbcfb-3b22-4762-bc13-be0f67fd3116',
@@ -151,8 +151,8 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
      */
     public function it_can_get_the_duplicates_of_a_place(): void
     {
-        $this->duplicatePlaceRepository->setCanonicalOnCluster(1, '1accbcfb-3b22-4762-bc13-be0f67fd3116');
-        $this->duplicatePlaceRepository->setCanonicalOnCluster(2, '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster('1', '1accbcfb-3b22-4762-bc13-be0f67fd3116');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster('2', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
 
         $this->assertNull(
             $this->duplicatePlaceRepository->getDuplicatesOfPlace('19ce6565-76be-425d-94d6-894f84dd2947')

--- a/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
+++ b/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
@@ -13,49 +13,63 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
 {
     use DBALTestConnectionTrait;
 
+    private const CLUSTER_ID_1 = '356a192b7913b04c54574d18c28d46e6395428ab';
+    private const CLUSTER_ID_2 = 'da4b9237bacccdf19c0760cab7aec4a8359010b0';
+    const CLUSTER_ID_PROCESSED = 'ec2f96367578f9efb384a1113e625f3570aeeaa1';
     private DBALDuplicatePlaceRepository $duplicatePlaceRepository;
 
     public function setUp(): void
     {
         $table = new Table('duplicate_places');
-        $table->addColumn('cluster_id', Types::BIGINT)->setNotnull(true);
+        $table->addColumn('cluster_id', Types::STRING)->setLength(40)->setNotnull(true);
         $table->addColumn('place_uuid', Types::GUID)->setLength(36)->setNotnull(true);
         $table->addColumn('canonical', Types::GUID)->setLength(36)->setNotnull(false)->setDefault(null);
+        $table->addColumn('processed', Types::BOOLEAN)->setDefault(0);
         $this->createTable($table);
 
         $this->getConnection()->insert(
             'duplicate_places',
             [
-                'cluster_id' => '1',
+                'cluster_id' => self::CLUSTER_ID_1,
                 'place_uuid' => '19ce6565-76be-425d-94d6-894f84dd2947',
             ]
         );
         $this->getConnection()->insert(
             'duplicate_places',
             [
-                'cluster_id' => '1',
+                'cluster_id' => self::CLUSTER_ID_1,
                 'place_uuid' => '1accbcfb-3b22-4762-bc13-be0f67fd3116',
             ]
         );
         $this->getConnection()->insert(
             'duplicate_places',
             [
-                'cluster_id' => '1',
+                'cluster_id' => self::CLUSTER_ID_1,
                 'place_uuid' => '526605d3-7cc4-4607-97a4-065896253f42',
             ]
         );
         $this->getConnection()->insert(
             'duplicate_places',
             [
-                'cluster_id' => '2',
+                'cluster_id' => self::CLUSTER_ID_2,
                 'place_uuid' => '4a355db3-c3f9-4acc-8093-61b333a3aefb',
             ]
         );
         $this->getConnection()->insert(
             'duplicate_places',
             [
-                'cluster_id' => '2',
+                'cluster_id' => self::CLUSTER_ID_2,
                 'place_uuid' => '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad',
+            ]
+        );
+
+        // It should skipp this cluster
+        $this->getConnection()->insert(
+            'duplicate_places',
+            [
+                'cluster_id' => self::CLUSTER_ID_PROCESSED,
+                'place_uuid' => 'e2ec9859-6e04-42e2-916c-9a914b34a120',
+                'processed' => 1,
             ]
         );
 
@@ -69,7 +83,7 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
     {
         $clusterIds = $this->duplicatePlaceRepository->getClusterIds();
 
-        $this->assertEquals([1,2], $clusterIds);
+        $this->assertEquals([self::CLUSTER_ID_1,self::CLUSTER_ID_2], $clusterIds);
     }
 
     /**
@@ -77,7 +91,7 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
      */
     public function it_can_return_placeIds(): void
     {
-        $clusterIds = $this->duplicatePlaceRepository->getPlacesInCluster('1');
+        $clusterIds = $this->duplicatePlaceRepository->getPlacesInCluster(self::CLUSTER_ID_1);
 
         $this->assertEquals(
             [
@@ -94,22 +108,23 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
      */
     public function it_can_set_the_canonical_of_a_cluster(): void
     {
-        $this->duplicatePlaceRepository->setCanonicalOnCluster('1', '1accbcfb-3b22-4762-bc13-be0f67fd3116');
-        $this->duplicatePlaceRepository->setCanonicalOnCluster('2', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster(self::CLUSTER_ID_1, '1accbcfb-3b22-4762-bc13-be0f67fd3116');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster(self::CLUSTER_ID_2, '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
 
         $actualRows = $this->connection->createQueryBuilder()
             ->select('*')
             ->from('duplicate_places')
+            ->where('processed = 0')
             ->execute()
             ->fetchAllNumeric();
 
         $this->assertEquals(
             [
-                ['1', '19ce6565-76be-425d-94d6-894f84dd2947', '1accbcfb-3b22-4762-bc13-be0f67fd3116'],
-                ['1', '1accbcfb-3b22-4762-bc13-be0f67fd3116', null],
-                ['1', '526605d3-7cc4-4607-97a4-065896253f42', '1accbcfb-3b22-4762-bc13-be0f67fd3116'],
-                ['2', '4a355db3-c3f9-4acc-8093-61b333a3aefb', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad'],
-                ['2', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad', null],
+                [self::CLUSTER_ID_1, '19ce6565-76be-425d-94d6-894f84dd2947', '1accbcfb-3b22-4762-bc13-be0f67fd3116', 0],
+                [self::CLUSTER_ID_1, '1accbcfb-3b22-4762-bc13-be0f67fd3116', null, 0],
+                [self::CLUSTER_ID_1, '526605d3-7cc4-4607-97a4-065896253f42', '1accbcfb-3b22-4762-bc13-be0f67fd3116', 0],
+                [self::CLUSTER_ID_2, '4a355db3-c3f9-4acc-8093-61b333a3aefb', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad', 0],
+                [self::CLUSTER_ID_2, '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad', null, 0],
             ],
             $actualRows
         );
@@ -120,8 +135,8 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
      */
     public function it_can_get_the_canonical_of_a_place(): void
     {
-        $this->duplicatePlaceRepository->setCanonicalOnCluster('1', '1accbcfb-3b22-4762-bc13-be0f67fd3116');
-        $this->duplicatePlaceRepository->setCanonicalOnCluster('2', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster(self::CLUSTER_ID_1, '1accbcfb-3b22-4762-bc13-be0f67fd3116');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster(self::CLUSTER_ID_2, '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
 
         $this->assertEquals(
             '1accbcfb-3b22-4762-bc13-be0f67fd3116',
@@ -151,8 +166,8 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
      */
     public function it_can_get_the_duplicates_of_a_place(): void
     {
-        $this->duplicatePlaceRepository->setCanonicalOnCluster('1', '1accbcfb-3b22-4762-bc13-be0f67fd3116');
-        $this->duplicatePlaceRepository->setCanonicalOnCluster('2', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster(self::CLUSTER_ID_1, '1accbcfb-3b22-4762-bc13-be0f67fd3116');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster(self::CLUSTER_ID_2, '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
 
         $this->assertNull(
             $this->duplicatePlaceRepository->getDuplicatesOfPlace('19ce6565-76be-425d-94d6-894f84dd2947')


### PR DESCRIPTION
In preparation for the data teams changes to duplicate places:

### Added
- Added a date field "created_date" to the duplicate_places table. The data team will fill this up.
- Added a boolean field "processed"  to the duplicate_places table.
- Make sure the duplicate places CLI script only processes new records with the new field processed = false
- Bonus feature: Added logging when a dispatch UpdateLocation fails and made sure it doesn't crash the entire script.
- Added extra test case related to "processed" flag.

### Changed
- Changed the "cluster_id" field to handle hashes in the duplicate_places table.

---
Ticket: https://jira.uitdatabank.be/browse/III-6236