### PR TITLE
III-5990 change name for readability

### DIFF
--- a/app/Event/EventCommandHandlerProvider.php
+++ b/app/Event/EventCommandHandlerProvider.php
@@ -99,7 +99,7 @@ final class EventCommandHandlerProvider extends AbstractServiceProvider
                 return new CopyEventHandler(
                     $container->get('event_repository'),
                     $container->get(ProductionRepository::class),
-                    $container->get('config')['copy_production'] ?? true
+                    $container->get('config')['add_copied_event_to_parent_production'] ?? true
                 );
             }
         );


### PR DESCRIPTION
### Changed

- Changed the name of `copy_production` to `add_copied_event_to_parent_production` to improve readability

### Related PR

- https://github.com/cultuurnet/appconfig/pull/733

---
Ticket: https://jira.publiq.be/browse/III-5990