### PR TITLE
III-6239 tariff name trimmed

### DIFF
--- a/features/event/price-info.feature
+++ b/features/event/price-info.feature
@@ -231,6 +231,74 @@ Feature: Test event priceInfo property
     }
     """
 
+  Scenario: Try updating an event without a duplicate tariff in different spacing
+    When I set the JSON request payload to:
+    """
+    [
+      {
+       "category": "base",
+       "name": {
+         "nl": "Basistarief",
+         "fr": "Tarif de base",
+         "en": "Base tariff",
+         "de": "Basisrate"
+       },
+       "price": 10,
+       "priceCurrency": "EUR"
+      },
+      {
+       "category": "tariff",
+       "name": {
+         "nl": "Korting",
+         "fr": "Reduction",
+         "en": "Reduction",
+         "de": "Rabatt"
+       },
+       "price": 5,
+       "priceCurrency": "EUR"
+       },
+       {
+       "category": "tariff",
+       "name": {
+         "nl": "Korting ",
+         "fr": "Reduction ",
+         "en": "Reduction ",
+         "de": "Rabatt "
+       },
+       "price": 3,
+       "priceCurrency": "EUR"
+      }
+    ]
+    """
+    And I send a PUT request to "%{eventUrl}/priceInfo"
+    Then the response status should be "400"
+    Then the JSON response should be:
+    """
+    {
+      "schemaErrors": [
+        {
+          "error": "Tariff name \"Korting\" must be unique.",
+          "jsonPointer": "/priceInfo/2/name/nl"
+        },
+        {
+          "error": "Tariff name \"Reduction\" must be unique.",
+          "jsonPointer": "/priceInfo/2/name/fr"
+        },
+        {
+          "error": "Tariff name \"Reduction\" must be unique.",
+          "jsonPointer": "/priceInfo/2/name/en"
+        },
+        {
+          "error": "Tariff name \"Rabatt\" must be unique.",
+          "jsonPointer": "/priceInfo/2/name/de"
+        }
+      ],
+      "status": 400,
+      "title": "Invalid body data",
+      "type": "https://api.publiq.be/probs/body/invalid-data"
+    }
+    """
+
   Scenario: Try creating an event duplicate tariff names
     Given I set the JSON request payload from "events/price-info/event-with-duplicate-tariff-names.json"
     When I send a POST request to "/events/"

--- a/features/event/price-info.feature
+++ b/features/event/price-info.feature
@@ -231,7 +231,7 @@ Feature: Test event priceInfo property
     }
     """
 
-  Scenario: Try updating an event without a duplicate tariff in different spacing
+  Scenario: Try updating an event with a tariff that only differs in spacing
     When I set the JSON request payload to:
     """
     [

--- a/features/place/price-info.feature
+++ b/features/place/price-info.feature
@@ -206,6 +206,53 @@ Feature: Test place priceInfo property
     }
     """
 
+  Scenario: Try Updating a place price with duplicate with different spacing
+    When I set the JSON request payload to:
+    """
+    [
+      {
+       "category": "base",
+       "name": {
+         "nl": "Basistarief"
+       },
+       "price": 10,
+       "priceCurrency": "EUR"
+      },
+      {
+       "category": "tariff",
+       "name": {
+         "nl": "Early Birds"
+       },
+       "price": 10,
+       "priceCurrency": "EUR"
+      },
+      {
+       "category": "tariff",
+       "name": {
+         "nl": "Early Birds "
+       },
+       "price": 5,
+       "priceCurrency": "EUR"
+      }
+    ]
+    """
+    And I send a PUT request to "%{placeUrl}/priceInfo"
+    Then the response status should be "400"
+    And the JSON response should be:
+    """
+    {
+      "schemaErrors": [
+        {
+          "error": "Tariff name \"Early Birds\" must be unique.",
+          "jsonPointer": "/priceInfo/2/name/nl"
+        }
+      ],
+      "status": 400,
+      "title": "Invalid body data",
+      "type": "https://api.publiq.be/probs/body/invalid-data"
+    }
+    """
+
   Scenario: Try updating a place price as a string
     When I set the JSON request payload to:
     """

--- a/src/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParser.php
+++ b/src/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParser.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Offer;
 
-use _HumbugBox113887eee2b6\___PHPSTORM_HELPERS\this;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;

--- a/src/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParser.php
+++ b/src/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParser.php
@@ -42,7 +42,7 @@ class PriceInfoDuplicateNameValidatingRequestBodyParser implements RequestBodyPa
         $errors = [];
         $nameMatrix = [];
 
-        $priceInfos = $this->trimTariffName($priceInfos); //$this->trimArrayValues($priceInfos);
+        $priceInfos = $this->trimTariffName($priceInfos);
 
         foreach ($priceInfos as $index => $priceInfo) {
             foreach ($priceInfo['name'] as $language => $name) {

--- a/src/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParser.php
+++ b/src/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParser.php
@@ -42,7 +42,7 @@ class PriceInfoDuplicateNameValidatingRequestBodyParser implements RequestBodyPa
         $errors = [];
         $nameMatrix = [];
 
-        $priceInfos = $this->trimArrayValues($priceInfos);
+        $priceInfos = $this->trimTariffName($priceInfos); //$this->trimArrayValues($priceInfos);
 
         foreach ($priceInfos as $index => $priceInfo) {
             foreach ($priceInfo['name'] as $language => $name) {
@@ -59,15 +59,15 @@ class PriceInfoDuplicateNameValidatingRequestBodyParser implements RequestBodyPa
         return $errors;
     }
 
-    private function trimArrayValues(array $array): array
+    private function trimTariffName(array $priceInfos): array
     {
-        foreach ($array as $key => $value) {
-            if (is_array($value)) {
-                $array[$key] = $this->trimArrayValues($value);
-            } else {
-                $array[$key] = is_string($value) ? trim($value) : $value;
+        foreach ($priceInfos as $key => $tariff) {
+            if (array_key_exists('name', $tariff)) {
+                foreach ($tariff['name'] as $language => $name) {
+                    $priceInfos[$key]['name'][$language] = trim($priceInfos[$key]['name'][$language]);
+                }
             }
         }
-        return $array;
+        return $priceInfos;
     }
 }

--- a/src/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParser.php
+++ b/src/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Offer;
 
+use _HumbugBox113887eee2b6\___PHPSTORM_HELPERS\this;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
@@ -42,6 +43,8 @@ class PriceInfoDuplicateNameValidatingRequestBodyParser implements RequestBodyPa
         $errors = [];
         $nameMatrix = [];
 
+       $priceInfos = $this->trimArrayValues($priceInfos);
+
         foreach ($priceInfos as $index => $priceInfo) {
             foreach ($priceInfo['name'] as $language => $name) {
                 if (isset($nameMatrix[$language]) && in_array($name, $nameMatrix[$language], true)) {
@@ -55,5 +58,17 @@ class PriceInfoDuplicateNameValidatingRequestBodyParser implements RequestBodyPa
         }
 
         return $errors;
+    }
+
+    private function trimArrayValues(array $array): array
+    {
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $array[$key] = $this->trimArrayValues($value);
+            } else {
+                $array[$key] = is_string($value) ? trim($value) : $value;
+            }
+        }
+        return $array;
     }
 }

--- a/src/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParser.php
+++ b/src/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParser.php
@@ -43,7 +43,7 @@ class PriceInfoDuplicateNameValidatingRequestBodyParser implements RequestBodyPa
         $errors = [];
         $nameMatrix = [];
 
-       $priceInfos = $this->trimArrayValues($priceInfos);
+        $priceInfos = $this->trimArrayValues($priceInfos);
 
         foreach ($priceInfos as $index => $priceInfo) {
             foreach ($priceInfo['name'] as $language => $name) {

--- a/tests/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParserTest.php
+++ b/tests/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParserTest.php
@@ -180,8 +180,8 @@ final class PriceInfoDuplicateNameValidatingRequestBodyParserTest extends TestCa
         );
     }
 
-    private function arrayAsObject(array $priceInfoArry): object
+    private function arrayAsObject(array $priceInfoArray): object
     {
-        return Json::decode(Json::encode($priceInfoArry));
+        return Json::decode(Json::encode($priceInfoArray));
     }
 }

--- a/tests/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParserTest.php
+++ b/tests/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParserTest.php
@@ -102,9 +102,9 @@ final class PriceInfoDuplicateNameValidatingRequestBodyParserTest extends TestCa
                         'nl' => 'Studenten',
                         ],
                     'price' => 10,
-                    ],
                 ],
-            ];
+            ],
+        ];
 
         $request = $this->requestBuilder
             ->build('POST')

--- a/tests/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParserTest.php
+++ b/tests/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParserTest.php
@@ -117,4 +117,65 @@ final class PriceInfoDuplicateNameValidatingRequestBodyParserTest extends TestCa
             fn () => $this->priceInfoDuplicateNameValidatingRequestBodyParser->parse($request)
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_throws_on_same_names_with_different_spacing(): void
+    {
+        $priceInfo = (object) [
+            'priceInfo' => (object) [
+                (object)[
+                    'category' => 'tariff',
+                    'name' => (object) [
+                        'nl' => 'Studenten',
+                    ],
+                    'price' => 10,
+                    'priceCurrency' => 'EUR',
+                ],
+                (object)[
+                    'category' => 'base',
+                    'name' => (object) [
+                        'nl' => 'Basistarief',
+                    ],
+                    'price' => 50,
+                    'priceCurrency' => 'EUR',
+                ],
+                (object)[
+                    'category' => 'tariff',
+                    'name' => (object) [
+                        'nl' => 'Studenten ',
+                    ],
+                    'price' => 15,
+                    'priceCurrency' => 'EUR',
+                ],
+                (object)[
+                    'category' => 'tariff',
+                    'name' => (object) [
+                        'nl' => 'Leraren',
+                    ],
+                    'price' => 20,
+                ],
+                (object)[
+                    'category' => 'tariff',
+                    'name' => (object) [
+                        'nl' => 'Studenten   ',
+                    ],
+                    'price' => 30,
+                ],
+            ],
+        ];
+
+        $request = $this->requestBuilder
+            ->build('POST')
+            ->withParsedBody($priceInfo);
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidData(
+                new SchemaError('/priceInfo/2/name/nl', 'Tariff name "Studenten" must be unique.'),
+                new SchemaError('/priceInfo/4/name/nl', 'Tariff name "Studenten" must be unique.')
+            ),
+            fn () => $this->priceInfoDuplicateNameValidatingRequestBodyParser->parse($request)
+        );
+    }
 }

--- a/tests/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParserTest.php
+++ b/tests/Http/Offer/PriceInfoDuplicateNameValidatingRequestBodyParserTest.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Json;
 use PHPUnit\Framework\TestCase;
 
 final class PriceInfoDuplicateNameValidatingRequestBodyParserTest extends TestCase
@@ -62,42 +63,42 @@ final class PriceInfoDuplicateNameValidatingRequestBodyParserTest extends TestCa
      */
     public function it_throws_on_same_names(): void
     {
-        $priceInfo = (object) [
-            'priceInfo' => (object) [
-                (object)[
+        $priceInfo =  [
+            'priceInfo' =>  [
+                [
                     'category' => 'tariff',
-                    'name' => (object) [
+                    'name' =>  [
                         'nl' => 'Studenten',
                     ],
                     'price' => 10,
                     'priceCurrency' => 'EUR',
                 ],
-                (object)[
+                [
                     'category' => 'base',
-                    'name' => (object) [
+                    'name' =>  [
                         'nl' => 'Basistarief',
                         ],
                     'price' => 50,
                     'priceCurrency' => 'EUR',
                     ],
-                (object)[
+                [
                     'category' => 'tariff',
-                    'name' => (object) [
+                    'name' =>  [
                         'nl' => 'Studenten',
                         ],
                     'price' => 10,
                     'priceCurrency' => 'EUR',
                     ],
-                (object)[
+                [
                     'category' => 'tariff',
-                    'name' => (object) [
+                    'name' =>  [
                         'nl' => 'Leraren',
                     ],
                     'price' => 20,
                 ],
-                (object)[
+                [
                     'category' => 'tariff',
-                    'name' => (object) [
+                    'name' =>  [
                         'nl' => 'Studenten',
                         ],
                     'price' => 10,
@@ -107,7 +108,7 @@ final class PriceInfoDuplicateNameValidatingRequestBodyParserTest extends TestCa
 
         $request = $this->requestBuilder
             ->build('POST')
-            ->withParsedBody($priceInfo);
+            ->withParsedBody($this->arrayAsObject($priceInfo));
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidData(
@@ -123,42 +124,42 @@ final class PriceInfoDuplicateNameValidatingRequestBodyParserTest extends TestCa
      */
     public function it_throws_on_same_names_with_different_spacing(): void
     {
-        $priceInfo = (object) [
-            'priceInfo' => (object) [
-                (object)[
+        $priceInfo = [
+            'priceInfo' =>  [
+                [
                     'category' => 'tariff',
-                    'name' => (object) [
+                    'name' =>  [
                         'nl' => 'Studenten',
                     ],
                     'price' => 10,
                     'priceCurrency' => 'EUR',
                 ],
-                (object)[
+                [
                     'category' => 'base',
-                    'name' => (object) [
+                    'name' =>  [
                         'nl' => 'Basistarief',
                     ],
                     'price' => 50,
                     'priceCurrency' => 'EUR',
                 ],
-                (object)[
+                [
                     'category' => 'tariff',
-                    'name' => (object) [
+                    'name' =>  [
                         'nl' => 'Studenten ',
                     ],
                     'price' => 15,
                     'priceCurrency' => 'EUR',
                 ],
-                (object)[
+                [
                     'category' => 'tariff',
-                    'name' => (object) [
+                    'name' =>  [
                         'nl' => 'Leraren',
                     ],
                     'price' => 20,
                 ],
-                (object)[
+                [
                     'category' => 'tariff',
-                    'name' => (object) [
+                    'name' =>  [
                         'nl' => 'Studenten   ',
                     ],
                     'price' => 30,
@@ -168,7 +169,7 @@ final class PriceInfoDuplicateNameValidatingRequestBodyParserTest extends TestCa
 
         $request = $this->requestBuilder
             ->build('POST')
-            ->withParsedBody($priceInfo);
+            ->withParsedBody($this->arrayAsObject($priceInfo));
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidData(
@@ -177,5 +178,10 @@ final class PriceInfoDuplicateNameValidatingRequestBodyParserTest extends TestCa
             ),
             fn () => $this->priceInfoDuplicateNameValidatingRequestBodyParser->parse($request)
         );
+    }
+
+    private function arrayAsObject(array $priceInfoArry): object
+    {
+        return Json::decode(Json::encode($priceInfoArry));
     }
 }


### PR DESCRIPTION
### Changed

- `PriceInfoDuplicateNameValidatingRequestBodyParser`: Improved check on duplicate `TariffName`, to take spacing into account.
- `PriceInfoDuplicateNameValidatingRequestBodyParserTest`: refactor to avoid endless casting to `object`
 via new private function `arrayAsObject()` + new test for trimming 
---
Ticket: https://jira.publiq.be/browse/III-6239
