### PR TITLE
III-3558 Replace `json_encode` with `Json::encode`

### DIFF
--- a/features/Steps/OwnershipSteps.php
+++ b/features/Steps/OwnershipSteps.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Steps;
 
+use CultuurNet\UDB3\Json;
+
 trait OwnershipSteps
 {
     /**
@@ -17,7 +19,7 @@ trait OwnershipSteps
     ): void {
         $this->requestOwnership(
             '/ownerships',
-            $this->variableState->replaceVariables(json_encode([
+            $this->variableState->replaceVariables(Json::encode([
                 'itemId' => $organizerId,
                 'itemType' => 'organizer',
                 'ownerId' => $ownerId,

--- a/src/Broadway/AMQP/Message/Body/EntireDomainMessageBodyFactory.php
+++ b/src/Broadway/AMQP/Message/Body/EntireDomainMessageBodyFactory.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Broadway\AMQP\Message\Body;
 use Broadway\Domain\DomainMessage;
 use Broadway\Serializer\Serializable;
 use Broadway\Serializer\SerializationException;
+use CultuurNet\UDB3\Json;
 
 class EntireDomainMessageBodyFactory implements BodyFactoryInterface
 {
@@ -23,7 +24,7 @@ class EntireDomainMessageBodyFactory implements BodyFactoryInterface
             'recorded_on' => $domainMessage->getRecordedOn()->toString(),
         ];
 
-        return json_encode($data);
+        return Json::encode($data);
     }
 
     /**

--- a/src/Broadway/AMQP/Message/Body/PayloadOnlyBodyFactory.php
+++ b/src/Broadway/AMQP/Message/Body/PayloadOnlyBodyFactory.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Broadway\AMQP\Message\Body;
 use Broadway\Domain\DomainMessage;
 use Broadway\Serializer\Serializable;
 use Broadway\Serializer\SerializationException;
+use CultuurNet\UDB3\Json;
 
 class PayloadOnlyBodyFactory implements BodyFactoryInterface
 {
@@ -14,7 +15,7 @@ class PayloadOnlyBodyFactory implements BodyFactoryInterface
     {
         $this->guardSerializable($domainMessage->getPayload());
 
-        return json_encode(
+        return Json::encode(
             $domainMessage->getPayload()->serialize()
         );
     }

--- a/src/Http/Deserializer/Event/MajorInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/Event/MajorInfoJSONDeserializer.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarForEventDataValidator;
 use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONDeserializer;
 use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONParser;
 use CultuurNet\UDB3\Http\Deserializer\Theme\ThemeJSONDeserializer;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 
 /**
@@ -49,9 +50,9 @@ class MajorInfoJSONDeserializer extends JSONDeserializer
         $data = parent::deserialize($data);
         $this->validator->validate($data);
 
-        $type = $this->typeDeserializer->deserialize(json_encode($data['type']));
+        $type = $this->typeDeserializer->deserialize(Json::encode($data['type']));
 
-        $calendar = $this->calendarDeserializer->deserialize(json_encode($data['calendar']));
+        $calendar = $this->calendarDeserializer->deserialize(Json::encode($data['calendar']));
 
         $locationId = $data['location'];
         if (is_array($locationId) && isset($locationId['id'])) {
@@ -61,7 +62,7 @@ class MajorInfoJSONDeserializer extends JSONDeserializer
 
         $theme = null;
         if (!empty($data['theme'])) {
-            $theme = $this->themeDeserializer->deserialize(json_encode($data['theme']));
+            $theme = $this->themeDeserializer->deserialize(Json::encode($data['theme']));
         }
 
         return new MajorInfo(

--- a/src/Http/Deserializer/Place/MajorInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/Place/MajorInfoJSONDeserializer.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarForPlaceDataValidator;
 use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONDeserializer;
 use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONParser;
 use CultuurNet\UDB3\Http\Deserializer\Event\EventTypeJSONDeserializer;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 
 /**
@@ -49,11 +50,11 @@ class MajorInfoJSONDeserializer extends JSONDeserializer
         $data = parent::deserialize($data);
         $this->validator->validate($data);
 
-        $type = $this->typeDeserializer->deserialize(json_encode($data['type']));
+        $type = $this->typeDeserializer->deserialize(Json::encode($data['type']));
 
-        $address = $this->addressDeserializer->deserialize(json_encode($data['address']));
+        $address = $this->addressDeserializer->deserialize(Json::encode($data['address']));
 
-        $calendar = $this->calendarDeserializer->deserialize(json_encode($data['calendar']));
+        $calendar = $this->calendarDeserializer->deserialize(Json::encode($data['calendar']));
 
         return new MajorInfo(
             new Title($data['name']),

--- a/src/Http/Response/JsonResponse.php
+++ b/src/Http/Response/JsonResponse.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Response;
 
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Json;
 use Fig\Http\Message\StatusCodeInterface;
 use JsonException;
 use Slim\Psr7\Factory\StreamFactory;
@@ -22,7 +23,7 @@ class JsonResponse extends Response
     {
         try {
             if (!is_string($data)) {
-                $data = json_encode($data, JSON_THROW_ON_ERROR);
+                $data = Json::encode($data);
             }
 
             $body = (new StreamFactory())->createStream($data);

--- a/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
+++ b/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Deserializer\NotWellFormedException;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
@@ -45,7 +46,7 @@ class AddLabelToMultipleJSONDeserializer extends JSONDeserializer
 
         foreach ($data->offers as $offer) {
             $offers = $offers->with(
-                $this->offerIdentifierDeserializer->deserialize(json_encode($offer))
+                $this->offerIdentifierDeserializer->deserialize(Json::encode($offer))
             );
         }
 

--- a/src/Role/ReadModel/Labels/LabelRolesProjector.php
+++ b/src/Role/ReadModel/Labels/LabelRolesProjector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Role\ReadModel\Labels;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\Events\Created as LabelCreated;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
@@ -71,7 +72,7 @@ class LabelRolesProjector extends RoleProjector
     {
         $document = new JsonDocument(
             $uuid->toString(),
-            json_encode([])
+            Json::encode([])
         );
         return $document;
     }

--- a/src/Role/ReadModel/Labels/RoleLabelsProjector.php
+++ b/src/Role/ReadModel/Labels/RoleLabelsProjector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Role\ReadModel\Labels;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\Events\LabelDetailsProjectedToJSONLD;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
@@ -136,7 +137,7 @@ class RoleLabelsProjector extends RoleProjector
     {
         $document = new JsonDocument(
             $uuid->toString(),
-            json_encode([])
+            Json::encode([])
         );
         return $document;
     }

--- a/src/Role/ReadModel/Users/RoleUsersProjector.php
+++ b/src/Role/ReadModel/Users/RoleUsersProjector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Role\ReadModel\Users;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
@@ -69,7 +70,7 @@ class RoleUsersProjector extends RoleProjector
         $this->repository->save(
             new JsonDocument(
                 $roleCreated->getUuid()->toString(),
-                json_encode([])
+                Json::encode([])
             )
         );
     }

--- a/src/Role/ReadModel/Users/UserRolesProjector.php
+++ b/src/Role/ReadModel/Users/UserRolesProjector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Role\ReadModel\Users;
 
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
@@ -49,7 +50,7 @@ class UserRolesProjector extends RoleProjector
         } catch (DocumentDoesNotExist $e) {
             $document = new JsonDocument(
                 $userId,
-                json_encode([])
+                Json::encode([])
             );
         }
 

--- a/src/User/ManagementToken/CacheRepository.php
+++ b/src/User/ManagementToken/CacheRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\User\ManagementToken;
 
+use CultuurNet\UDB3\Json;
 use DateTimeImmutable;
 use Doctrine\Common\Cache\Cache;
 
@@ -35,13 +36,12 @@ class CacheRepository implements TokenRepository
 
     public function store(ManagementToken $token): void
     {
-        $tokenAsJson = json_encode(
+        $tokenAsJson = Json::encode(
             [
                 'token' => $token->getToken(),
                 'issuedAt' => $token->getIssuedAt()->format(DATE_ATOM),
                 'expiresIn' => $token->getExpiresIn(),
-            ],
-            JSON_THROW_ON_ERROR
+            ]
         );
 
         $this->cache->save(self::TOKEN_KEY, $tokenAsJson);

--- a/tests/Contributor/ContributorEnrichedRepositoryTest.php
+++ b/tests/Contributor/ContributorEnrichedRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Contributor;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
@@ -80,7 +81,7 @@ final class ContributorEnrichedRepositoryTest extends TestCase
             );
 
 
-        $jsonLd = new JsonDocument($this->offerId, json_encode(['@type' => $itemType]));
+        $jsonLd = new JsonDocument($this->offerId, Json::encode(['@type' => $itemType]));
         $this->documentRepository->save($jsonLd);
 
         $fetchJsonLd = $this->contributorEnrichedRepository->fetch($this->offerId, false);
@@ -88,7 +89,7 @@ final class ContributorEnrichedRepositoryTest extends TestCase
         $this->assertEquals(
             new JsonDocument(
                 $this->offerId,
-                json_encode([
+                Json::encode([
                     '@type' => $itemType,
                     'contributors' => [
                         'info@example.com',
@@ -123,7 +124,7 @@ final class ContributorEnrichedRepositoryTest extends TestCase
             );
 
 
-        $jsonLd = new JsonDocument($this->offerId, json_encode(['@type' => $itemType]));
+        $jsonLd = new JsonDocument($this->offerId, Json::encode(['@type' => $itemType]));
         $this->documentRepository->save($jsonLd);
 
         $fetchJsonLd = $this->contributorEnrichedRepository->fetch($this->offerId, false);
@@ -131,7 +132,7 @@ final class ContributorEnrichedRepositoryTest extends TestCase
         $this->assertEquals(
             new JsonDocument(
                 $this->offerId,
-                json_encode([
+                Json::encode([
                     '@type' => $itemType,
                 ])
             ),
@@ -159,7 +160,7 @@ final class ContributorEnrichedRepositoryTest extends TestCase
             ->with(new UUID($this->offerId));
 
 
-        $jsonLd = new JsonDocument($this->offerId, json_encode(['@type' => $itemType]));
+        $jsonLd = new JsonDocument($this->offerId, Json::encode(['@type' => $itemType]));
         $this->documentRepository->save($jsonLd);
 
         $fetchJsonLd = $this->contributorEnrichedRepository->fetch($this->offerId);
@@ -167,7 +168,7 @@ final class ContributorEnrichedRepositoryTest extends TestCase
         $this->assertEquals(
             new JsonDocument(
                 $this->offerId,
-                json_encode([
+                Json::encode([
                     '@type' => $itemType,
                 ])
             ),
@@ -184,7 +185,7 @@ final class ContributorEnrichedRepositoryTest extends TestCase
         $this->contributorEnrichedRepository->save(
             new JsonDocument(
                 $this->offerId,
-                json_encode([
+                Json::encode([
                     '@type' => $itemType,
                     'contributors' => [
                         'info@example.com',
@@ -197,7 +198,7 @@ final class ContributorEnrichedRepositoryTest extends TestCase
         $this->assertEquals(
             new JsonDocument(
                 $this->offerId,
-                json_encode(['@type' => $itemType])
+                Json::encode(['@type' => $itemType])
             ),
             $this->contributorEnrichedRepository->fetch($this->offerId)
         );

--- a/tests/Event/GeoCoordinatesCommandHandlerTest.php
+++ b/tests/Event/GeoCoordinatesCommandHandlerTest.php
@@ -25,6 +25,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
@@ -60,13 +61,12 @@ class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
         $documentRepository->expects($this->once())
             ->method('fetch')
             ->with(self::EVENT_ID)
-            ->willReturn(new JsonDocument(self::EVENT_ID, json_encode([
+            ->willReturn(new JsonDocument(self::EVENT_ID, Json::encode([
                 'name' => [
                     'nl' => 'Faith no More',
                     'fr' => 'Faith no More - a la francais',
-
                 ],
-            ], JSON_THROW_ON_ERROR)));
+            ])));
 
         return new GeoCoordinatesCommandHandler(
             $eventRepository,

--- a/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
+++ b/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Event\Productions;
 
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
@@ -53,7 +54,7 @@ final class ProductionEnrichedEventRepositoryTest extends TestCase
         $eventId = Uuid::uuid4()->toString();
         $originalJsonDocument = new JsonDocument(
             $eventId,
-            json_encode((object) ['@id' => $eventId])
+            Json::encode((object) ['@id' => $eventId])
         );
 
 
@@ -78,7 +79,7 @@ final class ProductionEnrichedEventRepositoryTest extends TestCase
         $eventId = Uuid::uuid4()->toString();
         $originalJsonDocument = new JsonDocument(
             $eventId,
-            json_encode((object) ['@id' => $eventId])
+            Json::encode((object) ['@id' => $eventId])
         );
 
         $otherEventId = Uuid::uuid4()->toString();
@@ -122,7 +123,7 @@ final class ProductionEnrichedEventRepositoryTest extends TestCase
         $newProductionEnrichedEventRepository->save(
             new JsonDocument(
                 $eventId,
-                json_encode([
+                Json::encode([
                     '@type' => 'Event',
                     'production' => [
                         'id' => Uuid::uuid4()->toString(),
@@ -140,7 +141,7 @@ final class ProductionEnrichedEventRepositoryTest extends TestCase
         $this->assertEquals(
             new JsonDocument(
                 $eventId,
-                json_encode(['@type' => 'Event'])
+                Json::encode(['@type' => 'Event'])
             ),
             $inMemoryDocumentRepository->fetch($eventId)
         );

--- a/tests/Event/ReadModel/JSONLD/EventJsonDocumentLanguageAnalyzerTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventJsonDocumentLanguageAnalyzerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ReadModel\JSONLD;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\TestCase;
@@ -50,7 +51,7 @@ class EventJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expected = [
             new Language('nl'),
@@ -99,7 +100,7 @@ class EventJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expected = [
             new Language('nl'),
@@ -134,7 +135,7 @@ class EventJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expectedAll = [
             new Language('nl'),
@@ -182,7 +183,7 @@ class EventJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expectedAll = [
             new Language('nl'),

--- a/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
+++ b/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event\ReadModel\RDF;
 use CultuurNet\UDB3\Address\Parser\AddressParser;
 use CultuurNet\UDB3\Address\Parser\ParsedAddress;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\Serializer\Event\EventDenormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\RDF\JsonDataCouldNotBeConverted;
@@ -98,7 +99,7 @@ class EventJsonToTurtleConverterTest extends TestCase
             '@id' => 'https://mock.io.uitdatabank.be/events/' . $eventId,
         ];
 
-        $this->documentRepository->save(new JsonDocument($eventId, json_encode($event)));
+        $this->documentRepository->save(new JsonDocument($eventId, Json::encode($event)));
 
         $this->logger->expects($this->once())
             ->method('warning')
@@ -146,7 +147,7 @@ class EventJsonToTurtleConverterTest extends TestCase
             'modified' => '2023-01-01T12:30:15+01:00',
         ];
 
-        $this->documentRepository->save(new JsonDocument($eventId, json_encode($event)));
+        $this->documentRepository->save(new JsonDocument($eventId, Json::encode($event)));
 
         $this->logger->expects($this->once())
             ->method('warning')
@@ -1090,6 +1091,6 @@ class EventJsonToTurtleConverterTest extends TestCase
     private function givenThereIsAnEvent(array $extraProperties = []): void
     {
         $event = array_merge($this->event, $extraProperties);
-        $this->documentRepository->save(new JsonDocument($this->eventId, json_encode($event)));
+        $this->documentRepository->save(new JsonDocument($this->eventId, Json::encode($event)));
     }
 }

--- a/tests/Http/Deserializer/Address/AddressJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Address/AddressJSONDeserializerTest.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use PHPUnit\Framework\TestCase;
 
@@ -51,7 +52,7 @@ class AddressJSONDeserializerTest extends TestCase
      */
     public function it_returns_an_address_object(): void
     {
-        $data = json_encode(
+        $data = Json::encode(
             [
                 'streetAddress' => 'Wetstraat 1',
                 'postalCode' => '1000',

--- a/tests/Http/Offer/UpdateStatusRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateStatusRequestHandlerTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Offer\Commands\Status\UpdateStatus;
 use PHPUnit\Framework\TestCase;
@@ -41,7 +42,7 @@ class UpdateStatusRequestHandlerTest extends TestCase
     {
         $this->requestHandler->handle(
             (new Psr7RequestBuilder())
-                ->withBodyFromString(json_encode($data))
+                ->withBodyFromString(Json::encode($data))
                 ->withRouteParameter('offerType', $offerType)
                 ->withRouteParameter('offerId', self::OFFER_ID)
                 ->build('PUT')
@@ -198,7 +199,7 @@ class UpdateStatusRequestHandlerTest extends TestCase
             ApiProblem::bodyInvalidData(...$expectedSchemaErrors),
             fn () => $this->requestHandler->handle(
                 (new Psr7RequestBuilder())
-                    ->withBodyFromString(json_encode($data))
+                    ->withBodyFromString(Json::encode($data))
                     ->withRouteParameter('offerType', $offerType)
                     ->withRouteParameter('offerId', self::OFFER_ID)
                     ->build('PUT')

--- a/tests/Label/ReadModels/JSON/Repository/EntityTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/EntityTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Label\ReadModels\JSON\Repository;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
@@ -106,7 +107,7 @@ class EntityTest extends TestCase
      */
     public function it_can_encode_to_json(): void
     {
-        $json = json_encode($this->entity);
+        $json = Json::encode($this->entity);
 
         $expectedJson = '{"uuid":"' . $this->uuid->toString()
             . '","name":"' . $this->name

--- a/tests/Offer/Popularity/PopularityEnrichedOfferRepositoryTest.php
+++ b/tests/Offer/Popularity/PopularityEnrichedOfferRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Popularity;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
@@ -47,7 +48,7 @@ class PopularityEnrichedOfferRepositoryTest extends TestCase
         $popularity = new Popularity(1234567);
         $this->popularityRepository->saveScore($offerId, $popularity);
 
-        $jsonLd = new JsonDocument($offerId, json_encode(['@type' => 'Event']));
+        $jsonLd = new JsonDocument($offerId, Json::encode(['@type' => 'Event']));
         $this->decoratedRepository->save($jsonLd);
 
         $fetchJsonLd = $this->popularityEnrichedOfferRepository->fetch($offerId, false);
@@ -79,14 +80,14 @@ class PopularityEnrichedOfferRepositoryTest extends TestCase
         $popularity = new Popularity(1234567);
         $this->popularityRepository->saveScore($offerId, $popularity);
 
-        $jsonLd = new JsonDocument($offerId, json_encode(['@type' => 'Event']));
+        $jsonLd = new JsonDocument($offerId, Json::encode(['@type' => 'Event']));
         $this->decoratedRepository->save($jsonLd);
 
         $fetchJsonLd = $this->popularityEnrichedOfferRepository->fetch($offerId, true);
 
         $expectedJsonLd = new JsonDocument(
             $offerId,
-            json_encode(
+            Json::encode(
                 [
                     '@type' => 'Event',
                     'metadata' => [

--- a/tests/Offer/ReadModel/JSONLD/OfferUpdateTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferUpdateTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
 
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +21,7 @@ class OfferUpdateTest extends TestCase
 
         $initialDocument = new JsonDocument(
             'some_id',
-            json_encode([
+            Json::encode([
                 'name' => [
                     'nl' => 'heyo!',
                 ],
@@ -42,7 +43,7 @@ class OfferUpdateTest extends TestCase
 
         $expectedDocument = new JsonDocument(
             'some_id',
-            json_encode([
+            Json::encode([
                 'name' => [
                     'nl' => 'heyo!',
                 ],

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
@@ -818,7 +819,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
         $this->repository->save(
             new JsonDocument(
                 self::DOCUMENT_ID,
-                json_encode($given)
+                Json::encode($given)
             )
         );
         return $this;

--- a/tests/Offer/ReadModel/JSONLD/TermLabelOfferRepositoryDecoratorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/TermLabelOfferRepositoryDecoratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Term\TermRepository;
@@ -82,7 +83,7 @@ class TermLabelOfferRepositoryDecoratorTest extends TestCase
             ],
         ];
 
-        $givenDocument = new JsonDocument($id, json_encode($givenJson));
+        $givenDocument = new JsonDocument($id, Json::encode($givenJson));
 
         $expectedJson = [
             'terms' => [
@@ -129,7 +130,7 @@ class TermLabelOfferRepositoryDecoratorTest extends TestCase
         $id = 'b8fa0fcb-4062-42a7-9e39-d3a515421ec9';
 
         $givenJson = ['foo' => 'bar'];
-        $givenDocument = new JsonDocument($id, json_encode($givenJson));
+        $givenDocument = new JsonDocument($id, Json::encode($givenJson));
 
         $expectedJson = ['foo' => 'bar'];
 
@@ -148,7 +149,7 @@ class TermLabelOfferRepositoryDecoratorTest extends TestCase
         $id = 'b220e450-0cec-4607-84a2-0026dfda77ff';
 
         $givenJson = ['terms' => 'foo'];
-        $givenDocument = new JsonDocument($id, json_encode($givenJson));
+        $givenDocument = new JsonDocument($id, Json::encode($givenJson));
 
         $expectedJson = ['terms' => 'foo'];
 

--- a/tests/Offer/ReadModel/MainLanguage/JSONLDMainLanguageQueryTest.php
+++ b/tests/Offer/ReadModel/MainLanguage/JSONLDMainLanguageQueryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\ReadModel\MainLanguage;
 
 use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
@@ -78,7 +79,7 @@ class JSONLDMainLanguageQueryTest extends TestCase
      */
     private function expectDocumentWithJsonLd($cdbid, array $data): void
     {
-        $document = new JsonDocument($cdbid, json_encode($data));
+        $document = new JsonDocument($cdbid, Json::encode($data));
 
         $this->documentRepository->expects($this->any())
             ->method('fetch')

--- a/tests/Offer/ReadModel/Metadata/OfferMetadataEnrichedOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/Metadata/OfferMetadataEnrichedOfferRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\ReadModel\Metadata;
 
 use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -45,7 +46,7 @@ class OfferMetadataEnrichedOfferRepositoryTest extends TestCase
     {
         $offerId = '4ff559bd-9543-4ae2-900f-fe6d32fd019b';
 
-        $jsonLd = new JsonDocument($offerId, json_encode(['@type' => 'Event']));
+        $jsonLd = new JsonDocument($offerId, Json::encode(['@type' => 'Event']));
         $this->decoratedRepository->save($jsonLd);
 
         $fetchJsonLd = $this->offerMetadataEnrichedOfferRepository->fetch($offerId, false);
@@ -64,14 +65,14 @@ class OfferMetadataEnrichedOfferRepositoryTest extends TestCase
             new OfferMetadata($offerId, 'uitdatabank-ui')
         );
 
-        $jsonLd = new JsonDocument($offerId, json_encode(['@type' => 'Event']));
+        $jsonLd = new JsonDocument($offerId, Json::encode(['@type' => 'Event']));
         $this->decoratedRepository->save($jsonLd);
 
         $fetchJsonLd = $this->offerMetadataEnrichedOfferRepository->fetch($offerId, true);
 
         $expectedJsonLd = new JsonDocument(
             $offerId,
-            json_encode(
+            Json::encode(
                 [
                     '@type' => 'Event',
                     'metadata' => [
@@ -95,14 +96,14 @@ class OfferMetadataEnrichedOfferRepositoryTest extends TestCase
             new EntityNotFoundException()
         );
 
-        $jsonLd = new JsonDocument($offerId, json_encode(['@type' => 'Event']));
+        $jsonLd = new JsonDocument($offerId, Json::encode(['@type' => 'Event']));
         $this->decoratedRepository->save($jsonLd);
 
         $fetchJsonLd = $this->offerMetadataEnrichedOfferRepository->fetch($offerId, true);
 
         $expectedJsonLd = new JsonDocument(
             $offerId,
-            json_encode(
+            Json::encode(
                 [
                     '@type' => 'Event',
                     'metadata' => [

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -186,7 +186,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
 
         $initialDocument = new JsonDocument(
             $id,
-            json_encode(
+            Json::encode(
                 [
                     'name' => [
                         'nl' => 'Foo',
@@ -323,7 +323,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
 
         $initialDocument = new JsonDocument(
             $id,
-            json_encode([
+            Json::encode([
                 'typicalAgeRange' => '12-14',
             ])
         );
@@ -352,7 +352,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
 
         $initialDocument = new JsonDocument(
             $id,
-            json_encode([
+            Json::encode([
                 'typicalAgeRange' => '-18',
             ])
         );

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -873,7 +873,7 @@ final class OrganizerLDProjectorTest extends TestCase
         $organizerJson = file_get_contents(__DIR__ . '/Samples/organizer_with_main_language.json');
         $organizerJson = json_decode($organizerJson);
         $organizerJson->name->en = 'English name';
-        $organizerJson = json_encode($organizerJson);
+        $organizerJson = Json::encode($organizerJson);
 
         $this->documentRepository->method('fetch')
             ->with($organizerId)

--- a/tests/Organizer/ReadModel/JSONLD/OrganizerJsonDocumentLanguageAnalyzerTest.php
+++ b/tests/Organizer/ReadModel/JSONLD/OrganizerJsonDocumentLanguageAnalyzerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\ReadModel\JSONLD;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\TestCase;
@@ -43,7 +44,7 @@ class OrganizerJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expected = [
             new Language('nl'),
@@ -88,7 +89,7 @@ class OrganizerJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expected = [
             new Language('fr'),
@@ -109,7 +110,7 @@ class OrganizerJsonDocumentLanguageAnalyzerTest extends TestCase
             'name' => 'Naam NL',
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expected = [
             new Language('nl'),
@@ -141,7 +142,7 @@ class OrganizerJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expectedAll = [
             new Language('nl'),

--- a/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
+++ b/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\ReadModel\JSONLD;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
@@ -251,7 +252,7 @@ final class PropertyPolyfillRepositoryTest extends TestCase
         $this->repository->save(
             new JsonDocument(
                 self::DOCUMENT_ID,
-                json_encode($given)
+                Json::encode($given)
             )
         );
         return $this;

--- a/tests/Organizer/ReadModel/RDF/OrganizerJsonToTurtleConverterTest.php
+++ b/tests/Organizer/ReadModel/RDF/OrganizerJsonToTurtleConverterTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Organizer\ReadModel\RDF;
 use CultuurNet\UDB3\Address\Parser\AddressParser;
 use CultuurNet\UDB3\Address\Parser\ParsedAddress;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
@@ -111,7 +112,7 @@ class OrganizerJsonToTurtleConverterTest extends TestCase
             'modified' => '2023-01-01T12:30:15+01:00',
         ];
 
-        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+        $this->documentRepository->save(new JsonDocument($organizerId, Json::encode($organizer)));
 
         $turtle = $this->organizerJsonToTurtleConverter->convert($organizerId);
 
@@ -136,7 +137,7 @@ class OrganizerJsonToTurtleConverterTest extends TestCase
             'modified' => '2023-01-01T12:30:15+01:00',
         ];
 
-        $this->documentRepository->save(new JsonDocument($organizerId, json_encode($organizer)));
+        $this->documentRepository->save(new JsonDocument($organizerId, Json::encode($organizer)));
 
         $turtle = $this->organizerJsonToTurtleConverter->convert($organizerId);
 
@@ -226,6 +227,6 @@ class OrganizerJsonToTurtleConverterTest extends TestCase
     private function givenThereIsAnOrganizer(array $extraProperties = []): void
     {
         $organizer = array_merge($this->organizer, $extraProperties);
-        $this->documentRepository->save(new JsonDocument($this->organizerId, json_encode($organizer)));
+        $this->documentRepository->save(new JsonDocument($this->organizerId, Json::encode($organizer)));
     }
 }

--- a/tests/Place/DummyPlaceProjectionEnricherTest.php
+++ b/tests/Place/DummyPlaceProjectionEnricherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Place;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -67,7 +68,7 @@ class DummyPlaceProjectionEnricherTest extends TestCase
 
     private function getEventJsonForPlace(string $placeId): string
     {
-        return json_encode(
+        return Json::encode(
             [
                 '@id' => 'https://example.com/entity/' . $placeId,
             ]

--- a/tests/Place/GeoCoordinatesCommandHandlerTest.php
+++ b/tests/Place/GeoCoordinatesCommandHandlerTest.php
@@ -21,6 +21,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
 use CultuurNet\UDB3\Geocoding\GeocodingService;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Place\Commands\UpdateGeoCoordinatesFromAddress;
@@ -58,13 +59,12 @@ class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
         $documentRepository->expects($this->once())
             ->method('fetch')
             ->with(self::PLACE_ID)
-            ->willReturn(new JsonDocument(self::PLACE_ID, json_encode([
+            ->willReturn(new JsonDocument(self::PLACE_ID, Json::encode([
                 'name' => [
                     'nl' => 'Faith no More',
                     'fr' => 'Faith no More - a la francais',
-
                 ],
-            ], JSON_THROW_ON_ERROR)));
+            ])));
 
         return new GeoCoordinatesCommandHandler(
             $repository,

--- a/tests/Place/GeoCoordinatesProcessManagerTest.php
+++ b/tests/Place/GeoCoordinatesProcessManagerTest.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Place\Commands\UpdateGeoCoordinatesFromAddress;
@@ -407,7 +408,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
         $this->documentRepository->expects($this->once())
             ->method('fetch')
             ->with('4b735422-2bf3-4241-aabb-d70609d2d1d3')
-            ->willReturn(new JsonDocument('4b735422-2bf3-4241-aabb-d70609d2d1d3', json_encode([
+            ->willReturn(new JsonDocument('4b735422-2bf3-4241-aabb-d70609d2d1d3', Json::encode([
                 'mainLanguage' => 'nl',
                 'address' => [
                     'nl' => [
@@ -417,7 +418,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                         'streetAddress' => 'Bondgenotenlaan 1',
                     ],
                 ],
-            ], JSON_THROW_ON_ERROR)));
+            ])));
 
         $expectedCommand = new UpdateGeoCoordinatesFromAddress(
             '4b735422-2bf3-4241-aabb-d70609d2d1d3',

--- a/tests/Place/ReadModel/JSONLD/PlaceJsonDocumentLanguageAnalyzerTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceJsonDocumentLanguageAnalyzerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Place\ReadModel\JSONLD;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\TestCase;
@@ -64,7 +65,7 @@ class PlaceJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expected = [
             new Language('nl'),
@@ -127,7 +128,7 @@ class PlaceJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expected = [
             new Language('nl'),
@@ -165,7 +166,7 @@ class PlaceJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expectedAll = [
             new Language('nl'),
@@ -208,7 +209,7 @@ class PlaceJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expectedAll = [
             new Language('nl'),
@@ -256,7 +257,7 @@ class PlaceJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expectedAll = [
             new Language('nl'),

--- a/tests/Place/ReadModel/RDF/PlaceJsonToTurtleConverterTest.php
+++ b/tests/Place/ReadModel/RDF/PlaceJsonToTurtleConverterTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Address\Parser\ParsedAddress;
 use CultuurNet\UDB3\Address\PostalCode as LegacyPostalCode;
 use CultuurNet\UDB3\Address\Street as LegacyStreet;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\Serializer\Place\PlaceDenormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
@@ -111,7 +112,7 @@ class PlaceJsonToTurtleConverterTest extends TestCase
             '@id' => 'https://mock.io.uitdatabank.be/places/' . $placeId,
         ];
 
-        $this->documentRepository->save(new JsonDocument($placeId, json_encode($place)));
+        $this->documentRepository->save(new JsonDocument($placeId, Json::encode($place)));
 
         $this->logger->expects($this->once())
             ->method('warning')
@@ -150,7 +151,7 @@ class PlaceJsonToTurtleConverterTest extends TestCase
             'created' => '2023-01-01T12:30:15+01:00',
             'modified' => '2023-01-01T12:30:15+01:00',
         ];
-        $this->documentRepository->save(new JsonDocument($this->placeId, json_encode($place)));
+        $this->documentRepository->save(new JsonDocument($this->placeId, Json::encode($place)));
 
         $this->logger->expects($this->once())
             ->method('warning')
@@ -329,6 +330,6 @@ class PlaceJsonToTurtleConverterTest extends TestCase
     private function givenThereIsAPlace(array $extraProperties = []): void
     {
         $place = array_merge($this->place, $extraProperties);
-        $this->documentRepository->save(new JsonDocument($this->placeId, json_encode($place)));
+        $this->documentRepository->save(new JsonDocument($this->placeId, Json::encode($place)));
     }
 }

--- a/tests/ReadModel/ConfigurableJsonDocumentLanguageAnalyzerTest.php
+++ b/tests/ReadModel/ConfigurableJsonDocumentLanguageAnalyzerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\ReadModel;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language;
 use PHPUnit\Framework\TestCase;
 
@@ -50,7 +51,7 @@ class ConfigurableJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expected = [
             new Language('nl'),
@@ -89,7 +90,7 @@ class ConfigurableJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expected = [
             new Language('nl'),
@@ -121,7 +122,7 @@ class ConfigurableJsonDocumentLanguageAnalyzerTest extends TestCase
             ],
         ];
 
-        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', json_encode($data));
+        $document = new JsonDocument('919c7904-ecfa-440c-92d0-ae912213c615', Json::encode($data));
 
         $expectedAll = [
             new Language('nl'),

--- a/tests/ReadModel/JsonDocumentLanguageEnricherTest.php
+++ b/tests/ReadModel/JsonDocumentLanguageEnricherTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\ReadModel;
 
 use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Json;
 use PHPUnit\Framework\TestCase;
 
 class JsonDocumentLanguageEnricherTest extends TestCase
@@ -38,7 +39,7 @@ class JsonDocumentLanguageEnricherTest extends TestCase
     {
         $givenJsonDocument = new JsonDocument(
             '41278834-8a90-4b4a-bca2-c3189787146d',
-            json_encode(
+            Json::encode(
                 [
                     'name' => [
                         'nl' => 'Naam NL',
@@ -55,7 +56,7 @@ class JsonDocumentLanguageEnricherTest extends TestCase
 
         $expectedJsonDocument = new JsonDocument(
             '41278834-8a90-4b4a-bca2-c3189787146d',
-            json_encode(
+            Json::encode(
                 [
                     'name' => [
                         'nl' => 'Naam NL',
@@ -91,7 +92,7 @@ class JsonDocumentLanguageEnricherTest extends TestCase
     {
         $givenJsonDocument = new JsonDocument(
             '41278834-8a90-4b4a-bca2-c3189787146d',
-            json_encode(
+            Json::encode(
                 [
                     'foo' => 'bar',
                 ]

--- a/tests/Role/ReadModel/Labels/RoleLabelsProjectorTest.php
+++ b/tests/Role/ReadModel/Labels/RoleLabelsProjectorTest.php
@@ -8,6 +8,7 @@ use Broadway\Domain\DateTime as BroadwayDateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\Serializer\Serializable;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\Events\LabelDetailsProjectedToJSONLD;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
@@ -206,7 +207,7 @@ class RoleLabelsProjectorTest extends TestCase
 
         $jsonDocument = new JsonDocument(
             $labelProjected->getUuid()->toString(),
-            json_encode([$roleId->toString() => $roleId->toString()])
+            Json::encode([$roleId->toString() => $roleId->toString()])
         );
 
         $this->labelRolesRepository
@@ -252,7 +253,7 @@ class RoleLabelsProjectorTest extends TestCase
     {
         return new JsonDocument(
             $uuid->toString(),
-            json_encode([])
+            Json::encode([])
         );
     }
 
@@ -263,7 +264,7 @@ class RoleLabelsProjectorTest extends TestCase
     {
         return new JsonDocument(
             $uuid->toString(),
-            json_encode([$labelId->toString() => $this->createLabelEntity($labelId)])
+            Json::encode([$labelId->toString() => $this->createLabelEntity($labelId)])
         );
     }
 

--- a/tests/Role/ReadModel/Users/RoleUsersProjectorTest.php
+++ b/tests/Role/ReadModel/Users/RoleUsersProjectorTest.php
@@ -8,6 +8,7 @@ use Broadway\Domain\DateTime as BroadwayDateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\Serializer\Serializable;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
@@ -293,7 +294,7 @@ class RoleUsersProjectorTest extends TestCase
     {
         return new JsonDocument(
             $uuid->toString(),
-            json_encode([])
+            Json::encode([])
         );
     }
 
@@ -306,6 +307,6 @@ class RoleUsersProjectorTest extends TestCase
         $key = $userIdentityDetail->getUserId();
         $userIdentityDetails[$key] = $userIdentityDetail;
 
-        return new JsonDocument($uuid->toString(), json_encode($userIdentityDetails));
+        return new JsonDocument($uuid->toString(), Json::encode($userIdentityDetails));
     }
 }

--- a/tests/Role/ReadModel/Users/UserRolesProjectorTest.php
+++ b/tests/Role/ReadModel/Users/UserRolesProjectorTest.php
@@ -8,6 +8,7 @@ use Broadway\Domain\DateTime as BroadwayDateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\Serializer\Serializable;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
@@ -93,14 +94,14 @@ class UserRolesProjectorTest extends TestCase
             ->with($userAdded->getUserId())
             ->willReturn(new JsonDocument(
                 $userAdded->getUserId(),
-                json_encode($roles)
+                Json::encode($roles)
             ));
 
         // The resulting user role document with 2 roles.
         $roles[$newRoleUuid->toString()] = $newRoleDetailsDocument->getBody();
         $expectedUserRolesDocument = new JsonDocument(
             $userAdded->getUserId(),
-            json_encode($roles)
+            Json::encode($roles)
         );
 
         $this->userRolesDocumentRepository->expects($this->once())
@@ -148,7 +149,7 @@ class UserRolesProjectorTest extends TestCase
         $roles[$userAdded->getUuid()->toString()] = $roleDetailsDocument->getBody();
         $jsonDocument = new JsonDocument(
             $userAdded->getUserId(),
-            json_encode($roles)
+            Json::encode($roles)
         );
 
         $this->userRolesDocumentRepository->expects($this->once())
@@ -175,7 +176,7 @@ class UserRolesProjectorTest extends TestCase
 
         $jsonDocument = new JsonDocument(
             $userRemoved->getUserId(),
-            json_encode([$userRemoved->getUuid()->toString()])
+            Json::encode([$userRemoved->getUuid()->toString()])
         );
 
         $this->userRolesDocumentRepository->method('fetch')
@@ -216,7 +217,7 @@ class UserRolesProjectorTest extends TestCase
         $users[$userIdentityDetails->getUserId()] = $userIdentityDetails;
         $roleUsersDocument = new JsonDocument(
             $roleDetailsProjectedToJSONLD->getUuid()->toString(),
-            json_encode($users)
+            Json::encode($users)
         );
         $this->roleUsersDocumentRepository->method('fetch')
             ->with($roleDetailsProjectedToJSONLD->getUuid()->toString())
@@ -230,7 +231,7 @@ class UserRolesProjectorTest extends TestCase
         $roles[$roleDetailsProjectedToJSONLD->getUuid()->toString()] = $oldRoleDetailsDocument->getBody();
         $existingUserRolesDocument = new JsonDocument(
             'userId',
-            json_encode($roles)
+            Json::encode($roles)
         );
         $this->userRolesDocumentRepository->method('fetch')
             ->with('userId')
@@ -240,7 +241,7 @@ class UserRolesProjectorTest extends TestCase
         $roles[$roleDetailsProjectedToJSONLD->getUuid()->toString()] = $newRoleDetailsDocument->getBody();
         $newUserRolesDocument = new JsonDocument(
             'userId',
-            json_encode($roles)
+            Json::encode($roles)
         );
         $this->userRolesDocumentRepository->expects($this->once())
             ->method('save')

--- a/tests/Security/Sapi3RoleConstraintVoterTest.php
+++ b/tests/Security/Sapi3RoleConstraintVoterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Security\Permission\Sapi3RoleConstraintVoter;
 use CultuurNet\UDB3\Role\ReadModel\Constraints\UserConstraintsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
@@ -78,7 +79,7 @@ class Sapi3RoleConstraintVoterTest extends TestCase
             ['X-Api-Key' => 'cf462083-7bbd-46fc-95c3-6a0bc95918a5']
         );
 
-        $response = new Response(200, [], json_encode(['totalItems' => $totalItems]));
+        $response = new Response(200, [], Json::encode(['totalItems' => $totalItems]));
 
         $this->httpClient
             ->expects($this->once())

--- a/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
+++ b/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPAS\Event\Event;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
 use PHPUnit\Framework\TestCase;
 
@@ -21,7 +22,7 @@ final class EventCardSystemsUpdatedDeserializerTest extends TestCase
      */
     public function it_should_deserialize_a_valid_message(): void
     {
-        $json = json_encode(
+        $json = Json::encode(
             [
                 'cdbid' => '48ef34b0-e34a-4a15-9ae2-a5a01f189f90',
                 'cardSystems' => [
@@ -53,7 +54,7 @@ final class EventCardSystemsUpdatedDeserializerTest extends TestCase
      */
     public function it_should_deserialize_a_valid_message_with_only_one_card_system(): void
     {
-        $json = json_encode(
+        $json = Json::encode(
             [
                 'cdbid' => '48ef34b0-e34a-4a15-9ae2-a5a01f189f90',
                 'cardSystems' => [
@@ -79,7 +80,7 @@ final class EventCardSystemsUpdatedDeserializerTest extends TestCase
      */
     public function it_should_deserialize_a_valid_message_without_card_systems(): void
     {
-        $json = json_encode(
+        $json = Json::encode(
             [
                 'cdbid' => '48ef34b0-e34a-4a15-9ae2-a5a01f189f90',
                 'cardSystems' => [],
@@ -100,7 +101,7 @@ final class EventCardSystemsUpdatedDeserializerTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $json = json_encode(
+        $json = Json::encode(
             [
                 'cardSystems' => [],
             ]
@@ -116,7 +117,7 @@ final class EventCardSystemsUpdatedDeserializerTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $json = json_encode(
+        $json = Json::encode(
             [
                 'cdbid' => '48ef34b0-e34a-4a15-9ae2-a5a01f189f90',
             ]
@@ -132,7 +133,7 @@ final class EventCardSystemsUpdatedDeserializerTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $json = json_encode(
+        $json = Json::encode(
             [
                 'cdbid' => '48ef34b0-e34a-4a15-9ae2-a5a01f189f90',
                 'cardSystems' => false,
@@ -149,7 +150,7 @@ final class EventCardSystemsUpdatedDeserializerTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $json = json_encode(
+        $json = Json::encode(
             [
                 'cdbid' => '48ef34b0-e34a-4a15-9ae2-a5a01f189f90',
                 'cardSystems' => [
@@ -170,7 +171,7 @@ final class EventCardSystemsUpdatedDeserializerTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $json = json_encode(
+        $json = Json::encode(
             [
                 'cdbid' => '48ef34b0-e34a-4a15-9ae2-a5a01f189f90',
                 'cardSystems' => [

--- a/tests/User/Auth0/Auth0UserIdentityResolverTest.php
+++ b/tests/User/Auth0/Auth0UserIdentityResolverTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\User\Auth0;
 
 use Auth0\SDK\Contract\API\Management\UsersInterface;
 use Auth0\SDK\Contract\API\ManagementInterface;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
@@ -33,7 +34,7 @@ class Auth0UserIdentityResolverTest extends TestCase
         $users->expects($this->any())
             ->method('getAll')
             ->with(['q' => 'user_id:"9f3e9228-4eca-40ad-982f-4420bf4bbf09" OR app_metadata.uitidv1id:"9f3e9228-4eca-40ad-982f-4420bf4bbf09"'])
-            ->willReturn(new Response(200, [], json_encode([$user])));
+            ->willReturn(new Response(200, [], Json::encode([$user])));
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
 
@@ -60,7 +61,7 @@ class Auth0UserIdentityResolverTest extends TestCase
         $users->expects($this->any())
             ->method('getAll')
             ->with(['q' => 'user_id:"9f3e9228-4eca-40ad-982f-4420bf4bbf09" OR app_metadata.uitidv1id:"9f3e9228-4eca-40ad-982f-4420bf4bbf09"'])
-            ->willReturn(new Response(200, [], json_encode([])));
+            ->willReturn(new Response(200, [], Json::encode([])));
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
 
@@ -89,7 +90,7 @@ class Auth0UserIdentityResolverTest extends TestCase
         $users->expects($this->atLeast(1))
             ->method('getAll')
             ->with(['q' => 'email:"ivo@hdz.com"'])
-            ->willReturn(new Response(200, [], json_encode([$user])));
+            ->willReturn(new Response(200, [], Json::encode([$user])));
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
 
@@ -117,7 +118,7 @@ class Auth0UserIdentityResolverTest extends TestCase
         $users->expects($this->atLeast(1))
             ->method('getAll')
             ->with(['q' => 'email:"ivo@hdz.com"'])
-            ->willReturn(new Response(200, [], json_encode([])));
+            ->willReturn(new Response(200, [], Json::encode([])));
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
 
@@ -146,7 +147,7 @@ class Auth0UserIdentityResolverTest extends TestCase
         $users->expects($this->atLeast(1))
             ->method('getAll')
             ->with(['q' => 'email:"Caca" OR nickname:"Caca"'])
-            ->willReturn(new Response(200, [], json_encode([$user])));
+            ->willReturn(new Response(200, [], Json::encode([$user])));
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
 
@@ -174,7 +175,7 @@ class Auth0UserIdentityResolverTest extends TestCase
         $users->expects($this->atLeast(1))
             ->method('getAll')
             ->with(['q' => 'email:"Caca" OR nickname:"Caca"'])
-            ->willReturn(new Response(200, [], json_encode([])));
+            ->willReturn(new Response(200, [], Json::encode([])));
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
 
@@ -202,7 +203,7 @@ class Auth0UserIdentityResolverTest extends TestCase
 
         $users->expects($this->atLeast(1))
             ->method('getAll')
-            ->willReturn(new Response(200, [], json_encode([$user])));
+            ->willReturn(new Response(200, [], Json::encode([$user])));
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
 


### PR DESCRIPTION
### Changed
- Replaced `json_encode` with `Json::encode` for two main reasons:
  - By using the wrapper method throwing an error is enforced
  - The returned type is always a `string` and not `string|boolean` as with the built-in method

### Note
- This is a prerequisite to increase the PHPStan level to 7

---
Ticket: https://jira.uitdatabank.be/browse/III-3558
