### PR TITLE
III-3558 Replace `json_decode` with `Json::decode`

### DIFF
--- a/app/Console/Command/UpdateUniqueLabels.php
+++ b/app/Console/Command/UpdateUniqueLabels.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Console\Command;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
@@ -139,7 +140,7 @@ final class UpdateUniqueLabels extends Command
 
     private function getLabelName(array $labelAddedEvent): LabelName
     {
-        $payloadArray = json_decode($labelAddedEvent['payload'], true);
+        $payloadArray = Json::decodeAssociatively($labelAddedEvent['payload']);
         return new LabelName($payloadArray['payload']['name']);
     }
 }

--- a/app/Console/Command/UpdateUniqueOrganizers.php
+++ b/app/Console/Command/UpdateUniqueOrganizers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Console\Command;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Organizer\WebsiteNormalizer;
 use Doctrine\DBAL\Connection;
@@ -204,7 +205,7 @@ class UpdateUniqueOrganizers extends Command
 
     private function getOrganizerWebsite(array $organizerEvent): string
     {
-        $payloadArray = json_decode($organizerEvent['payload'], true);
+        $payloadArray = Json::decodeAssociatively($organizerEvent['payload']);
         return $payloadArray['payload']['website'];
     }
 }

--- a/src/Deserializer/JSONDeserializer.php
+++ b/src/Deserializer/JSONDeserializer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Deserializer;
 
+use JsonException;
+
 class JSONDeserializer implements DeserializerInterface
 {
     private bool $assoc;
@@ -23,7 +25,7 @@ class JSONDeserializer implements DeserializerInterface
         $data = json_decode($data, $this->assoc);
 
         if (null === $data) {
-            throw new NotWellFormedException('Invalid JSON');
+            throw new JsonException('Invalid JSON');
         }
 
         return $data;

--- a/src/Deserializer/JSONDeserializer.php
+++ b/src/Deserializer/JSONDeserializer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Deserializer;
 
-use JsonException;
+use CultuurNet\UDB3\Json;
 
 class JSONDeserializer implements DeserializerInterface
 {
@@ -22,12 +22,10 @@ class JSONDeserializer implements DeserializerInterface
      */
     public function deserialize(string $data)
     {
-        $data = json_decode($data, $this->assoc);
-
-        if (null === $data) {
-            throw new JsonException('Invalid JSON');
+        if ($this->assoc) {
+            return Json::decodeAssociatively($data);
         }
 
-        return $data;
+        return Json::decode($data);
     }
 }

--- a/src/Deserializer/NotWellFormedException.php
+++ b/src/Deserializer/NotWellFormedException.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace CultuurNet\UDB3\Deserializer;
-
-class NotWellFormedException extends \RuntimeException
-{
-}

--- a/src/Event/EventType.php
+++ b/src/Event/EventType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Category;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Category as Udb3ModelCategory;
 use InvalidArgumentException;
 
@@ -23,7 +24,7 @@ final class EventType extends Category
 
     public static function fromJSONLDEvent(string $eventString): ?EventType
     {
-        $event = json_decode($eventString, false);
+        $event = Json::decode($eventString);
         foreach ($event->terms as $term) {
             if ($term->domain === self::DOMAIN) {
                 return new self($term->id, $term->label);

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -65,6 +65,7 @@ use CultuurNet\UDB3\Event\EventTypeResolver;
 use CultuurNet\UDB3\Event\ValueObjects\Audience;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
 use CultuurNet\UDB3\Model\Place\ImmutablePlace;
 use CultuurNet\UDB3\Model\Serializer\Place\NilLocationNormalizer;
@@ -87,6 +88,7 @@ use CultuurNet\UDB3\ReadModel\JsonDocumentMetaDataEnricherInterface;
 use CultuurNet\UDB3\RecordedOn;
 use CultuurNet\UDB3\SameAsForUitInVlaanderen;
 use CultuurNet\UDB3\Theme;
+use JsonException;
 
 final class EventLDProjector extends OfferLDProjector implements
     EventListener,
@@ -581,11 +583,10 @@ final class EventLDProjector extends OfferLDProjector implements
         }
 
         try {
-            $placeJSONLD = $this->placeService->getEntity(
-                $placeId
-            );
-
-            return (array) json_decode($placeJSONLD);
+            $placeJSONLD = $this->placeService->getEntity($placeId);
+            return (array)Json::decode($placeJSONLD);
+        } catch (JsonException $e) {
+            return [];
         } catch (EntityNotFoundException $e) {
             // In case the place can not be found at the moment, just add its ID
             return [

--- a/src/EventSourcing/DBAL/AggregateAwareDBALEventStore.php
+++ b/src/EventSourcing/DBAL/AggregateAwareDBALEventStore.php
@@ -173,8 +173,8 @@ class AggregateAwareDBALEventStore implements EventStore
         return new DomainMessage(
             $row['uuid'],
             (int) $row['playhead'],
-            $this->metadataSerializer->deserialize(json_decode($row['metadata'], true)),
-            $this->payloadSerializer->deserialize(json_decode($row['payload'], true)),
+            $this->metadataSerializer->deserialize(Json::decodeAssociatively($row['metadata'])),
+            $this->payloadSerializer->deserialize(Json::decodeAssociatively($row['payload'])),
             DateTime::fromString($row['recorded_on'])
         );
     }

--- a/src/EventSourcing/DBAL/EventStream.php
+++ b/src/EventSourcing/DBAL/EventStream.php
@@ -9,6 +9,7 @@ use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\EventSourcing\EventStreamDecorator;
 use Broadway\Serializer\Serializer;
+use CultuurNet\UDB3\Json;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\DBALException;
@@ -180,8 +181,8 @@ class EventStream
         return new DomainMessage(
             $row['uuid'],
             (int) $row['playhead'],
-            $this->metadataSerializer->deserialize(json_decode($row['metadata'], true)),
-            $this->payloadSerializer->deserialize(json_decode($row['payload'], true)),
+            $this->metadataSerializer->deserialize(Json::decodeAssociatively($row['metadata'])),
+            $this->payloadSerializer->deserialize(Json::decodeAssociatively($row['payload'])),
             DateTime::fromString($row['recorded_on'])
         );
     }

--- a/src/Http/ApiProblem/ApiProblemFactory.php
+++ b/src/Http/ApiProblem/ApiProblemFactory.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\ApiGuard\Request\RequestAuthenticationException;
 use CultuurNet\UDB3\Calendar\EndDateCanNotBeEarlierThanStartDate;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\Productions\EventCannotBeAddedToProduction;
 use CultuurNet\UDB3\Event\Productions\EventCannotBeRemovedFromProduction;
@@ -24,6 +23,7 @@ use CultuurNet\UDB3\Security\CommandAuthorizationException;
 use CultuurNet\UDB3\UiTPAS\Validation\ChangeNotAllowedByTicketSales;
 use Error;
 use Exception;
+use JsonException;
 use League\Route\Http\Exception\MethodNotAllowedException;
 use League\Route\Http\Exception\NotFoundException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -116,7 +116,7 @@ final class ApiProblemFactory
 
             case $e instanceof MissingValueException:
             case $e instanceof ChangeNotAllowedByTicketSales:
-            case $e instanceof NotWellFormedException:
+            case $e instanceof JsonException:
             case $e instanceof FormatterException:
             case $e instanceof EventCannotBeAddedToProduction:
             case $e instanceof EventCannotBeRemovedFromProduction:

--- a/src/Http/Request/Body/JsonRequestBodyParser.php
+++ b/src/Http/Request/Body/JsonRequestBodyParser.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Http\Request\Body;
 
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use CultuurNet\UDB3\Json;
 use InvalidArgumentException;
 use JsonException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -20,7 +21,7 @@ final class JsonRequestBodyParser implements RequestBodyParser
         }
 
         try {
-            $decoded = json_decode($body, false, 512, JSON_THROW_ON_ERROR);
+            $decoded = Json::decode($body);
         } catch (JsonException $e) {
             throw ApiProblem::bodyInvalidSyntax('JSON');
         }

--- a/src/Model/Import/DecodedDocument.php
+++ b/src/Model/Import/DecodedDocument.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Import;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use InvalidArgumentException;
+use JsonException;
 
 class DecodedDocument
 {
@@ -53,10 +56,10 @@ class DecodedDocument
 
     public static function fromJson(string $id, string $json): self
     {
-        $body = json_decode($json, true);
-
-        if (is_null($body)) {
-            throw new \InvalidArgumentException('The given JSON is not valid and can not be decoded.');
+        try {
+            $body = Json::decodeAssociatively($json);
+        } catch (JsonException $e) {
+            throw new InvalidArgumentException('The given JSON is not valid and can not be decoded.');
         }
 
         return new self($id, $body);

--- a/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
+++ b/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Offer\Commands;
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
@@ -27,9 +26,6 @@ class AddLabelToMultipleJSONDeserializer extends JSONDeserializer
         $this->offerIdentifierDeserializer = $offerIdentifierDeserializer;
     }
 
-    /**
-     * @throws NotWellFormedException
-     */
     public function deserialize(string $data): AddLabelToMultiple
     {
         $data = parent::deserialize($data);

--- a/src/Offer/IriOfferIdentifierJSONDeserializer.php
+++ b/src/Offer/IriOfferIdentifierJSONDeserializer.php
@@ -6,8 +6,8 @@ namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use JsonException;
 
 /**
  * @deprecated
@@ -27,11 +27,7 @@ class IriOfferIdentifierJSONDeserializer implements DeserializerInterface
 
     public function deserialize(string $data): IriOfferIdentifier
     {
-        $data = json_decode($data, true);
-
-        if (null === $data) {
-            throw new JsonException('Invalid JSON');
-        }
+        $data = Json::decodeAssociatively($data);
 
         if (!isset($data['@id'])) {
             throw new MissingValueException('Missing property "@id".');

--- a/src/Offer/IriOfferIdentifierJSONDeserializer.php
+++ b/src/Offer/IriOfferIdentifierJSONDeserializer.php
@@ -6,8 +6,8 @@ namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use JsonException;
 
 /**
  * @deprecated
@@ -30,7 +30,7 @@ class IriOfferIdentifierJSONDeserializer implements DeserializerInterface
         $data = json_decode($data, true);
 
         if (null === $data) {
-            throw new NotWellFormedException('Invalid JSON');
+            throw new JsonException('Invalid JSON');
         }
 
         if (!isset($data['@id'])) {

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Event\ReadModel\JSONLD\OrganizerServiceInterface;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
@@ -61,6 +62,7 @@ use CultuurNet\UDB3\ReadModel\MultilingualJsonLDProjectorTrait;
 use CultuurNet\UDB3\RecordedOn;
 use CultuurNet\UDB3\SluggerInterface;
 use DateTimeInterface;
+use JsonException;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 
@@ -939,8 +941,9 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
     {
         try {
             $organizerJSONLD = $this->organizerRepository->fetch($organizerId)->getRawBody();
-
-            return (array)json_decode($organizerJSONLD);
+            return (array)Json::decode($organizerJSONLD);
+        } catch (JsonException $e) {
+            return [];
         } catch (DocumentDoesNotExist $e) {
             // In case the place can not be found at the moment, just add its ID
             return [

--- a/src/Role/ReadModel/Labels/LabelRolesProjector.php
+++ b/src/Role/ReadModel/Labels/LabelRolesProjector.php
@@ -62,7 +62,7 @@ class LabelRolesProjector extends RoleProjector
      */
     private function getRoleDetails(JsonDocument $document)
     {
-        return json_decode($document->getRawBody(), true);
+        return Json::decodeAssociatively($document->getRawBody());
     }
 
     /**

--- a/src/Role/ReadModel/Labels/RoleLabelsProjector.php
+++ b/src/Role/ReadModel/Labels/RoleLabelsProjector.php
@@ -127,7 +127,7 @@ class RoleLabelsProjector extends RoleProjector
      */
     private function getLabelDetails(JsonDocument $document)
     {
-        return json_decode($document->getRawBody(), true);
+        return Json::decodeAssociatively($document->getRawBody());
     }
 
     /**

--- a/src/Role/ReadModel/Labels/RoleLabelsProjector.php
+++ b/src/Role/ReadModel/Labels/RoleLabelsProjector.php
@@ -86,7 +86,7 @@ class RoleLabelsProjector extends RoleProjector
             return;
         }
 
-        $roles = json_decode($document->getRawBody());
+        $roles = Json::decode($document->getRawBody());
 
         foreach ($roles as $roleId) {
             $role = $this->getDocument(new UUID($roleId));

--- a/src/Role/ReadModel/Users/RoleUsersProjector.php
+++ b/src/Role/ReadModel/Users/RoleUsersProjector.php
@@ -94,6 +94,6 @@ class RoleUsersProjector extends RoleProjector
      */
     private function getUserIdentityDetails(JsonDocument $document): array
     {
-        return json_decode($document->getRawBody(), true);
+        return Json::decodeAssociatively($document->getRawBody());
     }
 }

--- a/src/Role/ReadModel/Users/UserRolesProjector.php
+++ b/src/Role/ReadModel/Users/UserRolesProjector.php
@@ -54,7 +54,7 @@ class UserRolesProjector extends RoleProjector
             );
         }
 
-        $roles = json_decode($document->getRawBody(), true);
+        $roles = Json::decodeAssociatively($document->getRawBody());
         $roles[$roleId] = $roleDetails;
 
         $document = $document->withAssocBody($roles);
@@ -73,7 +73,7 @@ class UserRolesProjector extends RoleProjector
             return;
         }
 
-        $roles = json_decode($document->getRawBody(), true);
+        $roles = Json::decodeAssociatively($document->getRawBody());
         unset($roles[$roleId]);
 
         $document = $document->withAssocBody($roles);
@@ -99,13 +99,13 @@ class UserRolesProjector extends RoleProjector
 
         $roleDetails = $roleDetailsDocument->getBody();
 
-        $roleUsers = json_decode($roleUsersDocument->getRawBody(), true);
+        $roleUsers = Json::decodeAssociatively($roleUsersDocument->getRawBody());
         $roleUserIds = array_keys($roleUsers);
 
         foreach ($roleUserIds as $roleUserId) {
             $userRolesDocument = $this->repository->fetch($roleUserId);
 
-            $userRoles = json_decode($userRolesDocument->getRawBody(), true);
+            $userRoles = Json::decodeAssociatively($userRolesDocument->getRawBody());
             $userRoles[$roleId] = $roleDetails;
 
             $userRolesDocument = $userRolesDocument->withAssocBody($userRoles);

--- a/src/Security/Permission/Sapi3RoleConstraintVoter.php
+++ b/src/Security/Permission/Sapi3RoleConstraintVoter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security\Permission;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Role\ReadModel\Constraints\UserConstraintsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use GuzzleHttp\Psr7\Request;
@@ -115,7 +116,7 @@ final class Sapi3RoleConstraintVoter implements PermissionVoter
 
         $response = $this->httpClient->sendRequest($request);
 
-        $decodedResponse = json_decode(
+        $decodedResponse = Json::decode(
             $response->getBody()->getContents()
         );
 

--- a/src/User/Auth0/Auth0ManagementTokenGenerator.php
+++ b/src/User/Auth0/Auth0ManagementTokenGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\User\Auth0;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\User\ManagementToken\ManagementToken;
 use CultuurNet\UDB3\User\ManagementToken\ManagementTokenGenerator;
 use DateTimeImmutable;
@@ -37,7 +38,7 @@ class Auth0ManagementTokenGenerator implements ManagementTokenGenerator
             ]
         );
 
-        $res = json_decode($response->getBody()->getContents(), true);
+        $res = Json::decodeAssociatively($response->getBody()->getContents());
 
         return new ManagementToken(
             $res['access_token'],

--- a/src/User/ManagementToken/CacheRepository.php
+++ b/src/User/ManagementToken/CacheRepository.php
@@ -25,7 +25,7 @@ class CacheRepository implements TokenRepository
             return null;
         }
 
-        $tokenAsArray = json_decode($this->cache->fetch(self::TOKEN_KEY), true);
+        $tokenAsArray = Json::decodeAssociatively($this->cache->fetch(self::TOKEN_KEY));
 
         return new ManagementToken(
             $tokenAsArray['token'],

--- a/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
+++ b/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
@@ -77,7 +77,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
         Language $expectedMainLanguage
     ): void {
         $serialized = file_get_contents($sampleFile);
-        $decoded = json_decode($serialized, true);
+        $decoded = Json::decodeAssociatively($serialized);
 
         /** @var EventCreated|PlaceCreated|OrganizerCreatedWithUniqueWebsite $created */
         $created = $this->serializer->deserialize($decoded);
@@ -482,7 +482,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
         $sampleFile = $this->sampleDir . 'serialized_event_booking_info_updated_without_availability.json';
 
         $serialized = file_get_contents($sampleFile);
-        $decoded = json_decode($serialized, true);
+        $decoded = Json::decodeAssociatively($serialized);
 
         /* @var BookingInfoUpdated $bookingInfoUpdated */
         $bookingInfoUpdated = $this->serializer->deserialize($decoded);
@@ -684,7 +684,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
     private function assertKeywordReplacedWithLabel(string $sampleFile): void
     {
         $serialized = file_get_contents($sampleFile);
-        $decoded = json_decode($serialized, true);
+        $decoded = Json::decodeAssociatively($serialized);
         $keyword = $decoded['payload']['keyword'];
 
         /** @var AbstractLabelEvent $abstractLabelEvent */

--- a/tests/Deserializer/JSONDeserializerTest.php
+++ b/tests/Deserializer/JSONDeserializerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Deserializer;
 
+use JsonException;
 use PHPUnit\Framework\TestCase;
 
 class JSONDeserializerTest extends TestCase
@@ -22,9 +23,9 @@ class JSONDeserializerTest extends TestCase
     /**
      * @test
      */
-    public function itThrowsANotWellFormedExceptionForInvalidJson(): void
+    public function itThrowsJsonExceptionForInvalidJson(): void
     {
-        $this->expectException(NotWellFormedException::class);
+        $this->expectException(JsonException::class);
         $this->expectExceptionMessage('Invalid JSON');
 
         $this->deserializer->deserialize(

--- a/tests/Deserializer/JSONDeserializerTest.php
+++ b/tests/Deserializer/JSONDeserializerTest.php
@@ -26,7 +26,7 @@ class JSONDeserializerTest extends TestCase
     public function itThrowsJsonExceptionForInvalidJson(): void
     {
         $this->expectException(JsonException::class);
-        $this->expectExceptionMessage('Invalid JSON');
+        $this->expectExceptionMessage('Syntax error');
 
         $this->deserializer->deserialize(
             '{

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -267,7 +267,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $recordedOn = '2022-01-20T13:25:21+01:00';
 
-        $jsonLD = json_decode(file_get_contents(__DIR__ . '/copied_event_with_place_type.json'));
+        $jsonLD = Json::decode(file_get_contents(__DIR__ . '/copied_event_with_place_type.json'));
         $jsonLD->created = $recordedOn;
         $jsonLD->modified = $recordedOn;
         $jsonLD->playhead = 1;
@@ -488,7 +488,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             DateTime::fromString($recordedOn)
         );
 
-        $expectedJsonLD = json_decode(file_get_contents(__DIR__ . '/copied_event.json'));
+        $expectedJsonLD = Json::decode(file_get_contents(__DIR__ . '/copied_event.json'));
         $expectedJsonLD->created = $recordedOn;
         $expectedJsonLD->modified = $recordedOn;
         $expectedJsonLD->creator = '20a72430-7e3e-4b75-ab59-043156b3169c';
@@ -525,7 +525,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             DateTime::fromString($recordedOn)
         );
 
-        $expectedJsonLD = json_decode(file_get_contents(__DIR__ . '/copied_event_without_working_hours.json'));
+        $expectedJsonLD = Json::decode(file_get_contents(__DIR__ . '/copied_event_without_working_hours.json'));
         $expectedJsonLD->created = $recordedOn;
         $expectedJsonLD->modified = $recordedOn;
         $expectedJsonLD->creator = $userId;

--- a/tests/Event/ReadModel/JSONLD/Specifications/EventSpecificationTestTrait.php
+++ b/tests/Event/ReadModel/JSONLD/Specifications/EventSpecificationTestTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ReadModel\JSONLD\Specifications;
 
+use CultuurNet\UDB3\Json;
+
 trait EventSpecificationTestTrait
 {
     protected function getEventLdFromFile(string $fileName): \stdClass
@@ -12,6 +14,6 @@ trait EventSpecificationTestTrait
             __DIR__ . '/../../../samples/' . $fileName
         );
 
-        return json_decode($jsonEvent);
+        return Json::decode($jsonEvent);
     }
 }

--- a/tests/Http/Assert/JsonEquals.php
+++ b/tests/Http/Assert/JsonEquals.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Assert;
 
+use CultuurNet\UDB3\Json;
 use PHPUnit\Framework\TestCase;
 
 class JsonEquals
@@ -21,8 +22,8 @@ class JsonEquals
 
     public function assert(string $expectedJson, string $actualJson): void
     {
-        $expected = json_decode($expectedJson, true);
-        $actual = json_decode($actualJson, true);
+        $expected = Json::decodeAssociatively($expectedJson);
+        $actual = Json::decodeAssociatively($actualJson);
 
         if (is_null($expected)) {
             $this->testCase->fail('Expected json is not valid json.');

--- a/tests/Http/Deserializer/Calendar/CalendarForEventDataValidatorTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarForEventDataValidatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Deserializer\Calendar;
 
 use CultuurNet\UDB3\Deserializer\DataValidationException;
+use CultuurNet\UDB3\Json;
 use PHPUnit\Framework\TestCase;
 
 class CalendarForEventDataValidatorTest extends TestCase
@@ -25,9 +26,8 @@ class CalendarForEventDataValidatorTest extends TestCase
      */
     public function it_does_not_throw_for_valid_calendars(string $file): void
     {
-        $data = json_decode(
-            file_get_contents(__DIR__ . '/samples/' . $file),
-            true
+        $data = Json::decodeAssociatively(
+            file_get_contents(__DIR__ . '/samples/' . $file)
         );
 
         $this->calendarForEventDataValidator->validate($data);

--- a/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Calendar\OpeningTime;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
@@ -34,7 +35,7 @@ class CalendarJSONParserTest extends TestCase
     protected function setUp(): void
     {
         $updateCalendar = file_get_contents(__DIR__ . '/samples/calendar_all_fields.json');
-        $this->updateCalendarAsArray = json_decode($updateCalendar, true);
+        $this->updateCalendarAsArray = Json::decodeAssociatively($updateCalendar);
 
         $this->calendarJSONParser = new CalendarJSONParser();
     }
@@ -60,7 +61,7 @@ class CalendarJSONParserTest extends TestCase
     public function it_returns_null_when_start_date_is_missing(): void
     {
         $updateCalendar = file_get_contents(__DIR__ . '/samples/calendar_missing_start_and_end.json');
-        $updateCalendarAsArray = json_decode($updateCalendar, true);
+        $updateCalendarAsArray = Json::decodeAssociatively($updateCalendar);
 
         $this->assertNull(
             $this->calendarJSONParser->getStartDate(
@@ -90,7 +91,7 @@ class CalendarJSONParserTest extends TestCase
     public function it_returns_null_when_end_date_is_missing(): void
     {
         $updateCalendar = file_get_contents(__DIR__ . '/samples/calendar_missing_start_and_end.json');
-        $updateCalendarAsArray = json_decode($updateCalendar, true);
+        $updateCalendarAsArray = Json::decodeAssociatively($updateCalendar);
 
         $this->assertNull(
             $this->calendarJSONParser->getEndDate(
@@ -180,9 +181,8 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_should_not_create_timestamps_when_json_is_missing_an_end_property(): void
     {
-        $calendarData = json_decode(
-            file_get_contents(__DIR__ . '/samples/calendar_missing_time_span_end.json'),
-            true
+        $calendarData = Json::decodeAssociatively(
+            file_get_contents(__DIR__ . '/samples/calendar_missing_time_span_end.json')
         );
 
         $this->assertEmpty(
@@ -195,9 +195,8 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_should_not_create_timestamps_when_json_is_missing_a_start_property(): void
     {
-        $calendarData = json_decode(
-            file_get_contents(__DIR__ . '/samples/calendar_missing_time_span_start.json'),
-            true
+        $calendarData = Json::decodeAssociatively(
+            file_get_contents(__DIR__ . '/samples/calendar_missing_time_span_start.json')
         );
 
         $this->assertEmpty(
@@ -255,9 +254,8 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_should_not_create_opening_hours_when_fields_are_missing(): void
     {
-        $calendarData = json_decode(
-            file_get_contents(__DIR__ . '/samples/calendar_with_opening_hours_but_missing_fields.json'),
-            true
+        $calendarData = Json::decodeAssociatively(
+            file_get_contents(__DIR__ . '/samples/calendar_with_opening_hours_but_missing_fields.json')
         );
 
         $this->assertEmpty(

--- a/tests/Http/Ownership/RequestOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/RequestOwnershipRequestHandlerTest.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
@@ -98,7 +99,7 @@ class RequestOwnershipRequestHandlerTest extends TestCase
             [
                 'id' => 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
             ],
-            json_decode((string) $response->getBody(), true)
+            Json::decodeAssociatively((string) $response->getBody())
         );
 
         $this->assertEquals(
@@ -156,7 +157,7 @@ class RequestOwnershipRequestHandlerTest extends TestCase
             [
                 'id' => 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
             ],
-            json_decode((string) $response->getBody(), true)
+            Json::decodeAssociatively((string) $response->getBody())
         );
 
         $this->assertEquals(

--- a/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
+++ b/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
@@ -58,7 +58,7 @@ class IriOfferIdentifierJSONDeserializerTest extends TestCase
         $json = '{"foo"';
 
         $this->expectException(JsonException::class);
-        $this->expectExceptionMessage('Invalid JSON');
+        $this->expectExceptionMessage('Syntax error');
 
         $this->deserializer->deserialize($json);
     }

--- a/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
+++ b/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
@@ -53,7 +53,7 @@ class IriOfferIdentifierJSONDeserializerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_an_json_exception_when_the_json_is_malformed(): void
+    public function it_throws_a_json_exception_when_the_json_is_malformed(): void
     {
         $json = '{"foo"';
 

--- a/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
+++ b/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use JsonException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -53,11 +53,11 @@ class IriOfferIdentifierJSONDeserializerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_an_exception_when_the_json_is_malformed(): void
+    public function it_throws_an_json_exception_when_the_json_is_malformed(): void
     {
         $json = '{"foo"';
 
-        $this->expectException(NotWellFormedException::class);
+        $this->expectException(JsonException::class);
         $this->expectExceptionMessage('Invalid JSON');
 
         $this->deserializer->deserialize($json);

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -871,7 +871,7 @@ final class OrganizerLDProjectorTest extends TestCase
         $organizerId = 'someId';
 
         $organizerJson = file_get_contents(__DIR__ . '/Samples/organizer_with_main_language.json');
-        $organizerJson = json_decode($organizerJson);
+        $organizerJson = Json::decode($organizerJson);
         $organizerJson->name->en = 'English name';
         $organizerJson = Json::encode($organizerJson);
 


### PR DESCRIPTION
### Changed
- Replaced `json_decode` with `Json::decode`

### Removed
-Removed `NotWellFormedException` and used `JsonException` 

### Note
- This is a prerequisite to increase the PHPStan level to 7

---
Ticket: https://jira.uitdatabank.be/browse/III-3558
