### PR TITLE
III-3558 Use factory method to create ATOM datetime

### DIFF
--- a/src/BackwardsCompatiblePayloadSerializerFactory.php
+++ b/src/BackwardsCompatiblePayloadSerializerFactory.php
@@ -264,7 +264,7 @@ class BackwardsCompatiblePayloadSerializerFactory
 
             // The new serialized date time format is a string according the ISO 8601 format.
             // If this is so return without modifications.
-            $dateTimeFromAtom = \DateTimeImmutable::createFromFormat(\DATE_ATOM, $dateTimeString);
+            $dateTimeFromAtom = \DateTimeImmutable::createFromFormat(DATE_ATOM, $dateTimeString);
             if ($dateTimeFromAtom) {
                 return $serializedBookingInfo;
             }

--- a/src/Calendar/Timestamp.php
+++ b/src/Calendar/Timestamp.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Calendar;
 
 use Broadway\Serializer\Serializable;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
-use DateTime;
 use DateTimeInterface;
 
 /**
@@ -88,8 +88,8 @@ final class Timestamp implements Serializable
             $bookingAvailability = BookingAvailability::deserialize($data['bookingAvailability']);
         }
 
-        $startDate = DateTime::createFromFormat(DateTimeInterface::ATOM, $data['startDate']);
-        $endDate = DateTime::createFromFormat(DateTimeInterface::ATOM, $data['endDate']);
+        $startDate = DateTimeFactory::fromAtom($data['startDate']);
+        $endDate = DateTimeFactory::fromAtom($data['endDate']);
 
         if ($startDate > $endDate) {
             $endDate = $startDate;

--- a/src/DateTimeFactory.php
+++ b/src/DateTimeFactory.php
@@ -43,4 +43,15 @@ final class DateTimeFactory
         // Throw a specific exception, so that it can be converted to a suitable ApiProblem higher up.
         throw new DateTimeInvalid($datetime . ' does not appear to be a valid ISO-8601 datetime string.');
     }
+
+    public static function fromAtom(string $datetime): DateTimeImmutable
+    {
+        $object = DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $datetime);
+
+        if ($object instanceof DateTimeImmutable) {
+            return $object;
+        }
+
+        throw new DateTimeInvalid($datetime . ' does not appear to be a valid ATOM datetime string.');
+    }
 }

--- a/src/Event/Events/EventCreated.php
+++ b/src/Event/Events/EventCreated.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Event\Events;
 
 use CultuurNet\UDB3\Calendar\Calendar;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\EventEvent;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
@@ -125,10 +126,7 @@ final class EventCreated extends EventEvent implements ConvertsToGranularEvents,
         }
         $publicationDate = null;
         if (!empty($data['publication_date'])) {
-            $publicationDate = DateTimeImmutable::createFromFormat(
-                DateTimeInterface::ATOM,
-                $data['publication_date']
-            );
+            $publicationDate = DateTimeFactory::fromAtom($data['publication_date']);
         }
         return new self(
             $data['event_id'],

--- a/src/EventExport/Format/TabularData/TabularDataEventFormatter.php
+++ b/src/EventExport/Format/TabularData/TabularDataEventFormatter.php
@@ -10,6 +10,7 @@ use CommerceGuys\Intl\Currency\CurrencyRepositoryInterface;
 use CommerceGuys\Intl\Formatter\NumberFormatter;
 use CommerceGuys\Intl\Formatter\NumberFormatterInterface;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\EventExport\CalendarSummary\CalendarSummaryRepositoryInterface;
 use CultuurNet\UDB3\EventExport\CalendarSummary\ContentType;
 use CultuurNet\UDB3\EventExport\CalendarSummary\Format;
@@ -122,7 +123,7 @@ class TabularDataEventFormatter
     protected function formatDateWithoutTime(string $date): string
     {
         $timezone = new \DateTimeZone('Europe/Brussels');
-        $datetime = \DateTime::createFromFormat(DateTimeInterface::ATOM, $date, $timezone);
+        $datetime = DateTimeFactory::fromAtom($date)->setTimezone($timezone);
         return $datetime->format('Y-m-d');
     }
 

--- a/src/Model/ValueObject/Moderation/AvailableTo.php
+++ b/src/Model/ValueObject/Moderation/AvailableTo.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\ValueObject\Moderation;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\CalendarWithDateRange;
 use DateTimeImmutable;
-use DateTimeInterface;
 
 class AvailableTo
 {
@@ -22,9 +22,6 @@ class AvailableTo
 
     public static function forever(): DateTimeImmutable
     {
-        return DateTimeImmutable::createFromFormat(
-            DateTimeInterface::ATOM,
-            '2100-01-01T00:00:00+00:00'
-        );
+        return DateTimeFactory::fromAtom('2100-01-01T00:00:00+00:00');
     }
 }

--- a/src/Offer/AvailableTo.php
+++ b/src/Offer/AvailableTo.php
@@ -6,9 +6,9 @@ namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\EventTypeResolver;
-use DateTimeImmutable;
 use DateTimeInterface;
 
 /**
@@ -44,10 +44,8 @@ class AvailableTo
          * When available to has no time information, it needs to be set to almost midnight 23:59:59.
          */
         if ($availableTo->format('H:i:s') === '00:00:00') {
-            $availableTo = DateTimeImmutable::createFromFormat(
-                DATE_ATOM,
-                $availableTo->format(DATE_ATOM)
-            )->setTime(23, 59, 59);
+            $availableTo = DateTimeFactory::fromAtom($availableTo->format(DATE_ATOM))
+                ->setTime(23, 59, 59);
         }
 
         return new self($availableTo);

--- a/src/Offer/Events/AbstractAvailableFromUpdated.php
+++ b/src/Offer/Events/AbstractAvailableFromUpdated.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Events;
 
-use DateTimeImmutable;
+use CultuurNet\UDB3\DateTimeFactory;
 use DateTimeInterface;
 
 abstract class AbstractAvailableFromUpdated extends AbstractEvent
@@ -34,7 +34,7 @@ abstract class AbstractAvailableFromUpdated extends AbstractEvent
     {
         return new static(
             $data['item_id'],
-            DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $data['available_from'])
+            DateTimeFactory::fromAtom($data['available_from'])
         );
     }
 }

--- a/src/Offer/Events/Moderation/AbstractPublished.php
+++ b/src/Offer/Events/Moderation/AbstractPublished.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Events\Moderation;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Offer\Events\AbstractEvent;
-use DateTime;
 use DateTimeInterface;
 
 abstract class AbstractPublished extends AbstractEvent
@@ -38,7 +38,7 @@ abstract class AbstractPublished extends AbstractEvent
     {
         return new static(
             $data['item_id'],
-            DateTime::createFromFormat(DateTimeInterface::ATOM, $data['publication_date'])
+            DateTimeFactory::fromAtom($data['publication_date'])
         );
     }
 }

--- a/src/Place/Events/PlaceCreated.php
+++ b/src/Place/Events/PlaceCreated.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Place\Events;
 
 use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Calendar\Calendar;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
@@ -102,10 +103,7 @@ final class PlaceCreated extends PlaceEvent implements ConvertsToGranularEvents,
     {
         $publicationDate = null;
         if (!empty($data['publication_date'])) {
-            $publicationDate = DateTimeImmutable::createFromFormat(
-                DateTimeInterface::ATOM,
-                $data['publication_date']
-            );
+            $publicationDate = DateTimeFactory::fromAtom($data['publication_date']);
         }
         return new static(
             $data['place_id'],

--- a/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
+++ b/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
@@ -404,12 +404,12 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
         $bookingInfoUpdated = $this->serializer->deserialize($decoded);
 
         $this->assertEquals(
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-02-20T15:11:26+00:00'),
+            DateTimeFactory::fromAtom('2018-02-20T15:11:26+00:00'),
             $bookingInfoUpdated->getBookingInfo()->getAvailabilityStarts()
         );
 
         $this->assertEquals(
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-04-30T14:11:26+00:00'),
+            DateTimeFactory::fromAtom('2018-04-30T14:11:26+00:00'),
             $bookingInfoUpdated->getBookingInfo()->getAvailabilityEnds()
         );
     }
@@ -464,12 +464,12 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
         $bookingInfoUpdated = $this->serializer->deserialize($decoded);
 
         $this->assertEquals(
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-02-20T15:11:26+01:00'),
+            DateTimeFactory::fromAtom('2018-02-20T15:11:26+01:00'),
             $bookingInfoUpdated->getBookingInfo()->getAvailabilityStarts()
         );
 
         $this->assertEquals(
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-04-30T14:11:26+01:00'),
+            DateTimeFactory::fromAtom('2018-04-30T14:11:26+01:00'),
             $bookingInfoUpdated->getBookingInfo()->getAvailabilityEnds()
         );
     }

--- a/tests/BookingInfoTest.php
+++ b/tests/BookingInfoTest.php
@@ -71,8 +71,8 @@ class BookingInfoTest extends TestCase
             new TelephoneNumber('044/444444'),
             new EmailAddress('info@publiq.be'),
             new BookingAvailability(
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T00:00:00+01:00'),
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T00:00:00+01:00')
+                DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00'),
+                DateTimeFactory::fromAtom('2018-01-10T00:00:00+01:00')
             )
         );
 
@@ -84,8 +84,8 @@ class BookingInfoTest extends TestCase
             ),
             '044/444444',
             'info@publiq.be',
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T00:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T00:00:00+01:00')
+            DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2018-01-10T00:00:00+01:00')
         );
 
         $actual = BookingInfo::fromUdb3ModelBookingInfo($udb3ModelBookingInfo);
@@ -210,8 +210,8 @@ class BookingInfoTest extends TestCase
             ),
             '044/444444',
             'info@publiq.be',
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T00:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-14T23:59:59+01:00')
+            DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2018-01-14T23:59:59+01:00')
         );
 
         $actual = BookingInfo::deserialize($data);

--- a/tests/Calendar/CalendarConverterTest.php
+++ b/tests/Calendar/CalendarConverterTest.php
@@ -7,10 +7,10 @@ namespace CultuurNet\UDB3\Calendar;
 use CultureFeed_Cdb_Data_Calendar_Period;
 use CultureFeed_Cdb_Data_Calendar_PeriodList;
 use CultureFeed_Cdb_Data_Calendar_Permanent;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
 use DateTime;
-use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class CalendarConverterTest extends TestCase
@@ -350,8 +350,8 @@ class CalendarConverterTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-26T21:00:00+02:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-27T02:00:00+02:00')
+                    DateTimeFactory::fromAtom('2017-05-26T21:00:00+02:00'),
+                    DateTimeFactory::fromAtom('2017-05-27T02:00:00+02:00')
                 ),
             ],
             []
@@ -390,8 +390,8 @@ class CalendarConverterTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-26T21:00:00+02:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-28T02:00:00+02:00')
+                    DateTimeFactory::fromAtom('2017-05-26T21:00:00+02:00'),
+                    DateTimeFactory::fromAtom('2017-05-28T02:00:00+02:00')
                 ),
             ],
             []
@@ -447,8 +447,8 @@ class CalendarConverterTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-01T09:00:00+02:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-07T18:00:00+02:00')
+                    DateTimeFactory::fromAtom('2017-05-01T09:00:00+02:00'),
+                    DateTimeFactory::fromAtom('2017-05-07T18:00:00+02:00')
                 ),
             ],
             []
@@ -513,16 +513,16 @@ class CalendarConverterTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-01T09:00:00+02:00'),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-28T02:00:00+02:00'),
+            DateTimeFactory::fromAtom('2017-05-01T09:00:00+02:00'),
+            DateTimeFactory::fromAtom('2017-05-28T02:00:00+02:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-01T09:00:00+02:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-07T18:00:00+02:00')
+                    DateTimeFactory::fromAtom('2017-05-01T09:00:00+02:00'),
+                    DateTimeFactory::fromAtom('2017-05-07T18:00:00+02:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-26T21:00:00+02:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-28T02:00:00+02:00')
+                    DateTimeFactory::fromAtom('2017-05-26T21:00:00+02:00'),
+                    DateTimeFactory::fromAtom('2017-05-28T02:00:00+02:00')
                 ),
             ],
             []
@@ -568,20 +568,20 @@ class CalendarConverterTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-25T10:00:00+02:00'),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-06-30T16:00:00+02:00'),
+            DateTimeFactory::fromAtom('2017-05-25T10:00:00+02:00'),
+            DateTimeFactory::fromAtom('2017-06-30T16:00:00+02:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-25T10:00:00+02:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-25T16:00:00+02:00')
+                    DateTimeFactory::fromAtom('2017-05-25T10:00:00+02:00'),
+                    DateTimeFactory::fromAtom('2017-05-25T16:00:00+02:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-25T20:00:00+02:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-26T01:00:00+02:00')
+                    DateTimeFactory::fromAtom('2017-05-25T20:00:00+02:00'),
+                    DateTimeFactory::fromAtom('2017-05-26T01:00:00+02:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-06-28T10:00:00+02:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-06-30T16:00:00+02:00')
+                    DateTimeFactory::fromAtom('2017-06-28T10:00:00+02:00'),
+                    DateTimeFactory::fromAtom('2017-06-30T16:00:00+02:00')
                 ),
             ],
             []

--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -31,7 +31,6 @@ use CultuurNet\UDB3\Offer\CalendarTypeNotSupported;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailabilityType;
 use DateTime;
-use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class CalendarTest extends TestCase
@@ -50,13 +49,13 @@ class CalendarTest extends TestCase
     public function setUp(): void
     {
         $timestamp1 = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_1_START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_1_END_DATE)
+            DateTimeFactory::fromAtom(self::TIMESTAMP_1_START_DATE),
+            DateTimeFactory::fromAtom(self::TIMESTAMP_1_END_DATE)
         );
 
         $timestamp2 = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_2_START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_2_END_DATE)
+            DateTimeFactory::fromAtom(self::TIMESTAMP_2_START_DATE),
+            DateTimeFactory::fromAtom(self::TIMESTAMP_2_END_DATE)
         );
 
         $weekDays = (new DayOfWeekCollection())
@@ -90,8 +89,8 @@ class CalendarTest extends TestCase
 
         $this->calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE),
             [
                 self::TIMESTAMP_1 => $timestamp1,
                 self::TIMESTAMP_2 => $timestamp2,
@@ -125,8 +124,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::available()
                         ),
@@ -141,8 +140,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
@@ -157,14 +156,14 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::available()
                         ),
@@ -179,14 +178,14 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
@@ -208,8 +207,8 @@ class CalendarTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00')
+                    DateTimeFactory::fromAtom('2021-03-18T14:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2021-03-18T14:00:00+01:00')
                 ),
             ]
         );
@@ -230,12 +229,12 @@ class CalendarTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00')
+                    DateTimeFactory::fromAtom('2020-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2020-03-13T12:00:00+01:00')
                 ),
             ]
         );
@@ -284,8 +283,8 @@ class CalendarTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00')
+                    DateTimeFactory::fromAtom('2021-03-18T14:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2021-03-18T14:00:00+01:00')
                 ),
             ]
         );
@@ -309,12 +308,12 @@ class CalendarTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00')
+                    DateTimeFactory::fromAtom('2020-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2020-03-13T12:00:00+01:00')
                 ),
             ]
         );
@@ -511,8 +510,8 @@ class CalendarTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::PERMANENT(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
+            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00')
         );
 
         $this->assertEquals(
@@ -545,8 +544,8 @@ class CalendarTest extends TestCase
             new DateTime('2021-03-18T16:00:00+01:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T16:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2021-03-18T14:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2021-03-18T16:00:00+01:00'),
                     null,
                     BookingAvailability::unavailable()
                 ),
@@ -583,8 +582,8 @@ class CalendarTest extends TestCase
     public function it_can_deserialize_without_overwriting_the_status_of_subEvents(): void
     {
         $timestamp1 = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_1_START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_1_END_DATE),
+            DateTimeFactory::fromAtom(self::TIMESTAMP_1_START_DATE),
+            DateTimeFactory::fromAtom(self::TIMESTAMP_1_END_DATE),
             new Status(
                 StatusType::unavailable(),
                 [
@@ -594,8 +593,8 @@ class CalendarTest extends TestCase
         );
 
         $timestamp2 = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_2_START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_2_END_DATE),
+            DateTimeFactory::fromAtom(self::TIMESTAMP_2_START_DATE),
+            DateTimeFactory::fromAtom(self::TIMESTAMP_2_END_DATE),
             new Status(
                 StatusType::temporarilyUnavailable(),
                 [
@@ -606,8 +605,8 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE),
             [
                 self::TIMESTAMP_1 => $timestamp1,
                 self::TIMESTAMP_2 => $timestamp2,
@@ -646,8 +645,8 @@ class CalendarTest extends TestCase
                 new DateTime('2021-03-18T14:00:00+01:00'),
                 [
                     new Timestamp(
-                        DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00'),
-                        DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00')
+                        DateTimeFactory::fromAtom('2021-03-18T14:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2021-03-18T14:00:00+01:00')
                     ),
                 ]
             ),
@@ -676,8 +675,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00')
                         ),
                     ]
                 ),
@@ -714,8 +713,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::temporarilyUnavailable(),
                                 [
@@ -767,12 +766,12 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00')
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00')
+                            DateTimeFactory::fromAtom('2020-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-13T12:00:00+01:00')
                         ),
                     ]
                 ),
@@ -821,8 +820,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::temporarilyUnavailable(),
                                 [
@@ -832,8 +831,8 @@ class CalendarTest extends TestCase
                             )
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::available(),
                                 [
@@ -897,8 +896,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::temporarilyUnavailable(),
                                 [
@@ -908,8 +907,8 @@ class CalendarTest extends TestCase
                             )
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::unavailable(),
                                 [
@@ -973,8 +972,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::unavailable(),
                                 [
@@ -984,8 +983,8 @@ class CalendarTest extends TestCase
                             )
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::unavailable(),
                                 [
@@ -1049,8 +1048,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::unavailable(),
                                 [
@@ -1060,8 +1059,8 @@ class CalendarTest extends TestCase
                             )
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::unavailable(),
                                 [
@@ -1133,14 +1132,14 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-06T10:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2020-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
@@ -1187,8 +1186,8 @@ class CalendarTest extends TestCase
             'periodic' => [
                 'calendar' => new Calendar(
                     CalendarType::PERIODIC(),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
+                    DateTimeFactory::fromAtom(self::START_DATE),
+                    DateTimeFactory::fromAtom(self::END_DATE)
                 ),
                 'jsonld' => [
                     'calendarType' => 'periodic',
@@ -1257,8 +1256,8 @@ class CalendarTest extends TestCase
 
         $expectedCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE)
         );
 
         $calendar = Calendar::deserialize($oldCalendarData);
@@ -1314,12 +1313,12 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::SINGLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00')
                 ),
             ]
         );
@@ -1343,12 +1342,12 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::SINGLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00')
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00')
                 ),
             ]
         );
@@ -1372,12 +1371,12 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-13T12:00:00+01:00')
                 ),
             ]
         );
@@ -1401,12 +1400,12 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00')
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00')
                 ),
             ]
         );
@@ -1737,20 +1736,20 @@ class CalendarTest extends TestCase
     {
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
+            DateTimeFactory::fromAtom('2020-01-26T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2020-01-27T12:12:12+01:00')
         );
 
         $sameCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
+            DateTimeFactory::fromAtom('2020-01-26T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2020-01-27T12:12:12+01:00')
         );
 
         $otherCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T11:11:11+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-28T12:12:12+01:00')
+            DateTimeFactory::fromAtom('2020-01-27T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2020-01-28T12:12:12+01:00')
         );
 
         $this->assertTrue($calendar->sameAs($sameCalendar));
@@ -1764,44 +1763,44 @@ class CalendarTest extends TestCase
     {
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-30T12:12:12+01:00'),
+            DateTimeFactory::fromAtom('2020-04-01T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2020-04-30T12:12:12+01:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-05T11:11:11+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-10T12:12:12+01:00')
+                    DateTimeFactory::fromAtom('2020-04-05T11:11:11+01:00'),
+                    DateTimeFactory::fromAtom('2020-04-10T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-07T11:11:11+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-09T12:12:12+01:00')
+                    DateTimeFactory::fromAtom('2020-04-07T11:11:11+01:00'),
+                    DateTimeFactory::fromAtom('2020-04-09T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-15T11:11:11+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-25T12:12:12+01:00')
+                    DateTimeFactory::fromAtom('2020-04-15T11:11:11+01:00'),
+                    DateTimeFactory::fromAtom('2020-04-25T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-20T12:12:12+01:00')
+                    DateTimeFactory::fromAtom('2020-04-01T11:11:11+01:00'),
+                    DateTimeFactory::fromAtom('2020-04-20T12:12:12+01:00')
                 ),
             ]
         );
 
         $expected = [
             new Timestamp(
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-20T12:12:12+01:00')
+                DateTimeFactory::fromAtom('2020-04-01T11:11:11+01:00'),
+                DateTimeFactory::fromAtom('2020-04-20T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-05T11:11:11+01:00'),
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-10T12:12:12+01:00')
+                DateTimeFactory::fromAtom('2020-04-05T11:11:11+01:00'),
+                DateTimeFactory::fromAtom('2020-04-10T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-07T11:11:11+01:00'),
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-09T12:12:12+01:00')
+                DateTimeFactory::fromAtom('2020-04-07T11:11:11+01:00'),
+                DateTimeFactory::fromAtom('2020-04-09T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-15T11:11:11+01:00'),
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-25T12:12:12+01:00')
+                DateTimeFactory::fromAtom('2020-04-15T11:11:11+01:00'),
+                DateTimeFactory::fromAtom('2020-04-25T12:12:12+01:00')
             ),
         ];
 
@@ -1818,27 +1817,27 @@ class CalendarTest extends TestCase
     {
         $timestamps = [
             new Timestamp(
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-20T12:12:12+01:00')
+                DateTimeFactory::fromAtom('2020-04-01T11:11:11+01:00'),
+                DateTimeFactory::fromAtom('2020-04-20T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-05T11:11:11+01:00'),
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-10T12:12:12+01:00')
+                DateTimeFactory::fromAtom('2020-04-05T11:11:11+01:00'),
+                DateTimeFactory::fromAtom('2020-04-10T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-07T11:11:11+01:00'),
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-09T12:12:12+01:00')
+                DateTimeFactory::fromAtom('2020-04-07T11:11:11+01:00'),
+                DateTimeFactory::fromAtom('2020-04-09T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-15T11:11:11+01:00'),
-                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-25T12:12:12+01:00')
+                DateTimeFactory::fromAtom('2020-04-15T11:11:11+01:00'),
+                DateTimeFactory::fromAtom('2020-04-25T12:12:12+01:00')
             ),
         ];
 
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-30T12:12:12+01:00'),
+            DateTimeFactory::fromAtom('2020-04-01T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2020-04-30T12:12:12+01:00'),
             $timestamps
         );
 
@@ -1867,24 +1866,24 @@ class CalendarTest extends TestCase
     {
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-30T12:12:12+01:00'),
+            DateTimeFactory::fromAtom('2020-04-01T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2020-04-30T12:12:12+01:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-05T11:11:11+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-10T12:12:12+01:00')
+                    DateTimeFactory::fromAtom('2020-04-05T11:11:11+01:00'),
+                    DateTimeFactory::fromAtom('2020-04-10T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-07T11:11:11+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-09T12:12:12+01:00')
+                    DateTimeFactory::fromAtom('2020-04-07T11:11:11+01:00'),
+                    DateTimeFactory::fromAtom('2020-04-09T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-15T11:11:11+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-25T12:12:12+01:00')
+                    DateTimeFactory::fromAtom('2020-04-15T11:11:11+01:00'),
+                    DateTimeFactory::fromAtom('2020-04-25T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
-                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-20T12:12:12+01:00')
+                    DateTimeFactory::fromAtom('2020-04-01T11:11:11+01:00'),
+                    DateTimeFactory::fromAtom('2020-04-20T12:12:12+01:00')
                 ),
             ]
         );
@@ -1922,8 +1921,8 @@ class CalendarTest extends TestCase
 
         new Calendar(
             CalendarType::SINGLE(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE),
             ['wrong timestamp'] // @phpstan-ignore-line
         );
     }
@@ -1938,8 +1937,8 @@ class CalendarTest extends TestCase
 
         new Calendar(
             CalendarType::PERIODIC(),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE),
             [],
             ['wrong opening hours'] // @phpstan-ignore-line
         );

--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Calendar;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
@@ -1457,8 +1458,8 @@ class CalendarTest extends TestCase
     {
         $subEvent = new SubEvent(
             new DateRange(
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00')
+                DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00')
             ),
             new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
             new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable())
@@ -1474,8 +1475,8 @@ class CalendarTest extends TestCase
             null,
             [
                 new Timestamp(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00'),
                     new Status(StatusType::unavailable(), []),
                     BookingAvailability::unavailable()
                 ),
@@ -1497,16 +1498,16 @@ class CalendarTest extends TestCase
         $subEvents = new SubEvents(
             new SubEvent(
                 new DateRange(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00')
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00')
                 ),
                 new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
                 new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable())
             ),
             new SubEvent(
                 new DateRange(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-09T10:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-10T10:00:00+01:00')
+                    DateTimeFactory::fromAtom('2016-03-09T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-10T10:00:00+01:00')
                 ),
                 new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
                 new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable())
@@ -1523,14 +1524,14 @@ class CalendarTest extends TestCase
             null,
             [
                 new Timestamp(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00'),
                     new Status(StatusType::unavailable(), []),
                     BookingAvailability::unavailable()
                 ),
                 new Timestamp(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-09T10:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-10T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-09T10:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2016-03-10T10:00:00+01:00'),
                     new Status(StatusType::unavailable(), []),
                     BookingAvailability::unavailable()
                 ),
@@ -1550,8 +1551,8 @@ class CalendarTest extends TestCase
     public function it_should_be_creatable_from_an_udb3_model_periodic_calendar(): void
     {
         $dateRange = new DateRange(
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00')
+            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00')
         );
 
         $openingHours = new OpeningHours();
@@ -1560,8 +1561,8 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00'),
             [],
             []
         );
@@ -1577,8 +1578,8 @@ class CalendarTest extends TestCase
     public function it_should_be_creatable_from_an_udb3_model_periodic_calendar_with_opening_hours(): void
     {
         $dateRange = new DateRange(
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00')
+            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00')
         );
 
         $openingHours = new OpeningHours(
@@ -1615,8 +1616,8 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00'),
             [],
             [
                 new OpeningHour(

--- a/tests/Calendar/TimestampTest.php
+++ b/tests/Calendar/TimestampTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Calendar;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailabilityType;
-use DateTime;
-use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class TimestampTest extends TestCase
@@ -27,8 +26,8 @@ class TimestampTest extends TestCase
     public function setUp(): void
     {
         $this->timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE)
         );
     }
 
@@ -38,12 +37,12 @@ class TimestampTest extends TestCase
     public function it_stores_a_start_and_end_date(): void
     {
         $this->assertEquals(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTimeFactory::fromAtom(self::START_DATE),
             $this->timestamp->getStartDate()
         );
 
         $this->assertEquals(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE),
             $this->timestamp->getEndDate()
         );
     }
@@ -59,8 +58,8 @@ class TimestampTest extends TestCase
         $this->expectExceptionMessage('End date can not be earlier than start date.');
 
         new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, $pastDate)
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom($pastDate)
         );
     }
 
@@ -70,8 +69,8 @@ class TimestampTest extends TestCase
     public function it_will_add_the_default_event_status(): void
     {
         $timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE)
         );
 
         $this->assertEquals(
@@ -86,8 +85,8 @@ class TimestampTest extends TestCase
     public function it_has_a_default_booking_availability(): void
     {
         $timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE)
         );
 
         $this->assertEquals(BookingAvailability::available(), $timestamp->getBookingAvailability());
@@ -99,8 +98,8 @@ class TimestampTest extends TestCase
     public function it_can_serialize_and_deserialize(): void
     {
         $timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE),
             new Status(
                 StatusType::unavailable(),
                 [
@@ -134,8 +133,8 @@ class TimestampTest extends TestCase
     public function itCanChangeStatus(): void
     {
         $timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE),
             new Status(StatusType::available(), [])
         );
 
@@ -147,8 +146,8 @@ class TimestampTest extends TestCase
         );
 
         $expected = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE),
             $newStatus
         );
 
@@ -164,16 +163,16 @@ class TimestampTest extends TestCase
     public function it_allows_changing_the_booking_availability(): void
     {
         $timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
+            DateTimeFactory::fromAtom(self::START_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE)
         );
 
         $updatedTimestamp = $timestamp->withBookingAvailability(BookingAvailability::unavailable());
 
         $this->assertEquals(
             new Timestamp(
-                DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
-                DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+                DateTimeFactory::fromAtom(self::START_DATE),
+                DateTimeFactory::fromAtom(self::END_DATE),
                 new Status(StatusType::available(), []),
                 BookingAvailability::unavailable()
             ),
@@ -187,8 +186,8 @@ class TimestampTest extends TestCase
     public function it_will_set_end_date_to_start_date_when_deserializing_incorrect_events(): void
     {
         $expected = new Timestamp(
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
-            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE),
+            DateTimeFactory::fromAtom(self::END_DATE),
             new Status(StatusType::available(), [])
         );
 

--- a/tests/DateTimeFactoryTest.php
+++ b/tests/DateTimeFactoryTest.php
@@ -69,4 +69,54 @@ class DateTimeFactoryTest extends TestCase
             'just_a_date' => ['dateTime' => '2022-02-28'],
         ];
     }
+
+    /**
+     * @test
+     * @dataProvider validAtomDataProvider
+     */
+    public function it_creates_a_date_time_object_from_a_valid_atom_string(string $given, string $expected): void
+    {
+        $object = DateTimeFactory::fromAtom($given)->setTimezone(new DateTimeZone('Europe/Brussels'));
+        $datetime = $object->format(DATE_ATOM);
+        $this->assertEquals($expected, $datetime);
+    }
+
+    public function validAtomDataProvider(): array
+    {
+        return [
+            'utc' => [
+                'given' => '2024-04-08T18:00:00Z',
+                'expected' => '2024-04-08T20:00:00+02:00',
+            ],
+            'offset_positive' => [
+                'given' => '2024-04-08T18:00:00+02:00',
+                'expected' => '2024-04-08T18:00:00+02:00',
+            ],
+            'offset_negative' => [
+                'given' => '2024-04-08T18:00:00-04:00',
+                'expected' => '2024-04-09T00:00:00+02:00',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidAtomDateTimeProvider
+     */
+    public function it_throws_when_given_an_invalid_atom_string(string $invalidDateTime): void
+    {
+        $this->expectException(DateTimeInvalid::class);
+        DateTimeFactory::fromAtom($invalidDateTime);
+    }
+
+    public function invalidAtomDateTimeProvider(): array
+    {
+        return [
+            'no_timezone' => ['dateTime' => '2022-02-28T13:23:47'],
+            'no_T' => ['dateTime' => '2022-02-28 13:23:47+01:30'],
+            'just_a_date' => ['dateTime' => '2022-02-28'],
+            'zulu' => ['dateTime' => '2024-04-08T18:00:00.500Z'],
+            'seconds' => ['dateTime' => '2024-04-08T18:00:00.250+01:00'],
+        ];
+    }
 }

--- a/tests/Event/CommandHandlers/CopyEventHandlerTest.php
+++ b/tests/Event/CommandHandlers/CopyEventHandlerTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event\CommandHandlers;
 use Broadway\Domain\DomainMessage;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\Commands\CopyEvent;
 use CultuurNet\UDB3\Event\Event;
@@ -22,7 +23,6 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
 use CultuurNet\UDB3\Calendar\Timestamp;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
-use DateTimeImmutable;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -73,8 +73,8 @@ final class CopyEventHandlerTest extends TestCase
                 null,
                 [
                     new Timestamp(
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2022-01-01T12:00:00+01:00'),
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2022-01-02T12:00:00+01:00')
+                        DateTimeFactory::fromAtom('2022-01-01T12:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2022-01-02T12:00:00+01:00')
                     ),
                 ]
             )
@@ -141,8 +141,8 @@ final class CopyEventHandlerTest extends TestCase
                 null,
                 [
                     new Timestamp(
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2022-01-01T12:00:00+01:00'),
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2022-01-02T12:00:00+01:00')
+                        DateTimeFactory::fromAtom('2022-01-01T12:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2022-01-02T12:00:00+01:00')
                     ),
                 ]
             )
@@ -216,8 +216,8 @@ final class CopyEventHandlerTest extends TestCase
                 null,
                 [
                     new Timestamp(
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2022-01-01T12:00:00+01:00'),
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2022-01-02T12:00:00+01:00')
+                        DateTimeFactory::fromAtom('2022-01-01T12:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2022-01-02T12:00:00+01:00')
                     ),
                 ]
             )

--- a/tests/Event/Commands/UpdateBookingInfoTest.php
+++ b/tests/Event/Commands/UpdateBookingInfoTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Event\Commands;
 
 use CultuurNet\UDB3\BookingInfo;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
@@ -25,8 +26,8 @@ class UpdateBookingInfoTest extends TestCase
                 new MultilingualString(new Language('nl'), 'urlLabel'),
                 '0123456789',
                 'foo@bar.com',
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-01T00:00:00+01:00'),
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-31T00:00:00+01:00')
+                DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
+                DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
             )
         );
     }
@@ -43,8 +44,8 @@ class UpdateBookingInfoTest extends TestCase
                 new MultilingualString(new Language('nl'), 'urlLabel'),
                 '0123456789',
                 'foo@bar.com',
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-01T00:00:00+01:00'),
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-31T00:00:00+01:00')
+                DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
+                DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
             )
         );
 

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
 use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\AudienceUpdated;
 use CultuurNet\UDB3\Event\Events\BookingInfoUpdated;
@@ -60,7 +61,6 @@ use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
-use DateTimeInterface;
 use Money\Currency;
 use Money\Money;
 use RuntimeException;
@@ -502,8 +502,8 @@ class EventTest extends AggregateRootScenarioTestCase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
+            DateTimeFactory::fromAtom('2020-01-26T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2020-01-27T12:12:12+01:00')
         );
 
         $xmlData = $this->getSample('EventTest.cdbxml.xml');

--- a/tests/Event/Events/BookingInfoUpdatedTest.php
+++ b/tests/Event/Events/BookingInfoUpdatedTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Event\Events;
 
 use CultuurNet\UDB3\BookingInfo;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
@@ -61,8 +62,8 @@ class BookingInfoUpdatedTest extends TestCase
                         new MultilingualString(new Language('nl'), 'urlLabel'),
                         '0123456789',
                         'foo@bar.com',
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-01T00:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-31T00:00:00+01:00')
+                        DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
                     )
                 ),
             ],

--- a/tests/Event/Events/CalendarUpdatedTest.php
+++ b/tests/Event/Events/CalendarUpdatedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Event\Events;
 
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
-use DateTimeInterface;
+use CultuurNet\UDB3\DateTimeFactory;
 use PHPUnit\Framework\TestCase;
 
 class CalendarUpdatedTest extends TestCase
@@ -37,8 +37,8 @@ class CalendarUpdatedTest extends TestCase
 
         $this->calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-01-27T12:12:12+01:00')
+            DateTimeFactory::fromAtom('2020-01-26T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2021-01-27T12:12:12+01:00')
         );
 
         $this->calendarUpdatedAsArray = [

--- a/tests/Event/Events/EventCreatedTest.php
+++ b/tests/Event/Events/EventCreatedTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Event\Events;
 
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
@@ -13,7 +14,6 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Theme;
 use DateTimeImmutable;
-use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class EventCreatedTest extends TestCase
@@ -302,10 +302,7 @@ class EventCreatedTest extends TestCase
                         CalendarType::PERMANENT()
                     ),
                     null,
-                    DateTimeImmutable::createFromFormat(
-                        DateTimeInterface::ATOM,
-                        '2016-08-01T00:00:00+02:00'
-                    )
+                    DateTimeFactory::fromAtom('2016-08-01T00:00:00+02:00')
                 ),
             ],
         ];

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event\ReadModel\History;
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\AvailableFromUpdated;
 use CultuurNet\UDB3\Event\Events\OnlineUrlDeleted;
@@ -1455,10 +1456,7 @@ class HistoryProjectorTest extends TestCase
     {
         $event = new Published(
             self::EVENT_ID_1,
-            DateTimeImmutable::createFromFormat(
-                DateTimeInterface::ATOM,
-                '2015-04-30T02:00:00+02:00'
-            )
+            DateTimeFactory::fromAtom('2015-04-30T02:00:00+02:00')
         );
 
         $domainMessage = new DomainMessage(

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Cdb\CdbXmlPriceInfoParser;
 use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Completeness\CompletenessFromWeights;
 use CultuurNet\UDB3\Completeness\Weights;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\OnlineUrlDeleted;
 use CultuurNet\UDB3\Event\Events\OnlineUrlUpdated;
@@ -69,7 +70,6 @@ use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Calendar\Timestamp;
-use DateTimeImmutable;
 use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
@@ -539,8 +539,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
      */
     public function it_projects_start_date_as_available_to_for_workshops(): void
     {
-        $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
-        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
+        $startDate = DateTimeFactory::fromAtom('2018-01-01T12:00:00+01:00');
+        $endDate = DateTimeFactory::fromAtom('2020-01-01T12:00:00+01:00');
         $eventType = new EventType('0.3.1.0.0', 'Cursus of workshop');
 
         $calendar = new Calendar(
@@ -576,8 +576,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
      */
     public function it_projects_end_date_as_available_to_for_other_event_types(): void
     {
-        $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
-        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
+        $startDate = DateTimeFactory::fromAtom('2018-01-01T12:00:00+01:00');
+        $endDate = DateTimeFactory::fromAtom('2020-01-01T12:00:00+01:00');
         $eventType = new EventType('1.50.0.0.0', 'Eten en drinken');
 
         $calendar = new Calendar(
@@ -1608,8 +1608,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         );
         $this->documentRepository->save($eventThatsAvailableTillStart);
 
-        $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
-        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
+        $startDate = DateTimeFactory::fromAtom('2018-01-01T12:00:00+01:00');
+        $endDate = DateTimeFactory::fromAtom('2020-01-01T12:00:00+01:00');
         $calendarUpdated = new CalendarUpdated(
             $eventId,
             new Calendar(
@@ -1668,7 +1668,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         );
         $this->documentRepository->save($eventThatShouldAvailableTillStart);
 
-        $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
+        $startDate = DateTimeFactory::fromAtom('2018-01-01T12:00:00+01:00');
 
         $typeUpdated = new TypeUpdated($eventId, (new EventTypeResolver())->byId($termId));
 
@@ -1718,7 +1718,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         );
         $this->documentRepository->save($eventThatShouldAvailableTillStart);
 
-        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
+        $endDate = DateTimeFactory::fromAtom('2020-01-01T12:00:00+01:00');
 
         $typeUpdated = new TypeUpdated($eventId, (new EventTypeResolver())->byId('0.50.4.0.0'));
 
@@ -1767,7 +1767,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         );
         $this->documentRepository->save($eventThatShouldAvailableTillStart);
 
-        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
+        $endDate = DateTimeFactory::fromAtom('2020-01-01T12:00:00+01:00');
 
         $typeUpdated = new TypeUpdated($eventId, (new EventTypeResolver())->byId('0.50.4.0.0'));
 
@@ -1977,8 +1977,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
     {
         return new Calendar(
             CalendarType::PERIODIC(),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00'),
             [],
             [
                 new OpeningHour(

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -70,7 +70,6 @@ use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Calendar\Timestamp;
-use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
@@ -197,8 +196,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00')
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00')
         );
 
         $eventCreated = $this->createEventCreated($eventId, $calendar, null);
@@ -241,8 +240,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e'),
             new Calendar(
                 CalendarType::PERIODIC(),
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00')
+                DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+                DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00')
             ),
             null
         );
@@ -260,8 +259,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             $eventId,
             new Calendar(
                 CalendarType::PERIODIC(),
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2022-01-26T13:25:21+01:00'),
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2022-01-26T13:25:21+01:00')
+                DateTimeFactory::fromAtom('2022-01-26T13:25:21+01:00'),
+                DateTimeFactory::fromAtom('2022-01-26T13:25:21+01:00')
             )
         );
 
@@ -291,8 +290,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventId = '1';
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00')
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00')
         );
         $theme = new Theme('123', 'theme label');
 
@@ -339,8 +338,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventId = '1';
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00')
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00')
         );
         $theme = new Theme('123', 'theme label');
 
@@ -439,8 +438,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $originalEventId = 'f8e4f084-1b75-4893-b2b9-fc67fd6e73fb';
         $originalCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-01-26T13:25:21+01:00')
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2017-01-26T13:25:21+01:00')
         );
         $eventCreated = $this->createEventCreated($originalEventId, $originalCalendar, null);
 
@@ -464,18 +463,18 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventId = 'f0b24f97-4b03-4eb2-96d1-5074819a7648';
         $timestamps = [
             new Timestamp(
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-27T13:25:21+01:00')
+                DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+                DateTimeFactory::fromAtom('2015-01-27T13:25:21+01:00')
             ),
             new Timestamp(
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-28T13:25:21+01:00'),
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-29T13:25:21+01:00')
+                DateTimeFactory::fromAtom('2015-01-28T13:25:21+01:00'),
+                DateTimeFactory::fromAtom('2015-01-29T13:25:21+01:00')
             ),
         ];
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-29T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2015-01-29T13:25:21+01:00'),
             $timestamps
         );
         $eventCopied = new EventCopied($eventId, $originalEventId, $calendar);
@@ -509,8 +508,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-29T13:25:21+01:00')
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2015-01-29T13:25:21+01:00')
         );
 
         $eventCopied = new EventCopied('f0b24f97-4b03-4eb2-96d1-5074819a7648', $eventCreated->getEventId(), $calendar);
@@ -617,19 +616,19 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $timestamps = [
             new Timestamp(
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-27T13:25:21+01:00')
+                DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+                DateTimeFactory::fromAtom('2015-01-27T13:25:21+01:00')
             ),
             new Timestamp(
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-28T13:25:21+01:00'),
-                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-29T13:25:21+01:00')
+                DateTimeFactory::fromAtom('2015-01-28T13:25:21+01:00'),
+                DateTimeFactory::fromAtom('2015-01-29T13:25:21+01:00')
             ),
         ];
 
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-29T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2015-01-29T13:25:21+01:00'),
             $timestamps
         );
 
@@ -714,8 +713,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventId = 'a2d50a8d-5b83-4c8b-84e6-e9c0bacbb1a3';
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-01-26T13:25:21+01:00')
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2017-01-26T13:25:21+01:00')
         );
         $eventCreated = $this->createEventCreated($eventId, $calendar, null);
         $this->mockPlaceService();
@@ -1019,8 +1018,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                     new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e'),
                     new Calendar(
                         CalendarType::PERIODIC(),
-                        \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-                        \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-02-26T13:25:21+01:00')
+                        DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+                        DateTimeFactory::fromAtom('2015-02-26T13:25:21+01:00')
                     ),
                     new Theme('123', 'theme label')
                 ),
@@ -1039,8 +1038,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                     new LocationId('00000000-0000-0000-0000-000000000000'),
                     new Calendar(
                         CalendarType::PERIODIC(),
-                        \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-                        \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-02-26T13:25:21+01:00')
+                        DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+                        DateTimeFactory::fromAtom('2015-02-26T13:25:21+01:00')
                     ),
                     new Theme('123', 'theme label')
                 ),
@@ -1056,8 +1055,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                     new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e'),
                     new Calendar(
                         CalendarType::PERIODIC(),
-                        \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-                        \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-02-26T13:25:21+01:00')
+                        DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+                        DateTimeFactory::fromAtom('2015-02-26T13:25:21+01:00')
                     ),
                     new Theme('123', 'theme label')
                 ),
@@ -1166,8 +1165,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
+            DateTimeFactory::fromAtom('2020-01-26T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2020-01-27T12:12:12+01:00')
         );
 
         $calendarUpdated = new CalendarUpdated($eventId, $calendar);
@@ -1317,8 +1316,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $location = new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e');
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-02-26T13:25:21+01:00')
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2015-02-26T13:25:21+01:00')
         );
         $theme = new Theme('123', 'theme label');
         $majorInfoUpdated = new MajorInfoUpdated(

--- a/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Calendar\DayOfWeekCollection;
 use CultuurNet\UDB3\Calendar\OpeningHour;
 use CultuurNet\UDB3\Calendar\OpeningTime;
 use CultuurNet\UDB3\Calendar\CalendarType;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
@@ -19,7 +20,6 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Calendar\Timestamp;
-use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -81,8 +81,8 @@ class CalendarJSONDeserializerTest extends TestCase
 
         $expectedCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00'),
+            DateTimeFactory::fromAtom('2020-01-26T09:00:00+01:00'),
+            DateTimeFactory::fromAtom('2020-02-10T16:00:00+01:00'),
             [],
             $openingHours
         );
@@ -107,8 +107,8 @@ class CalendarJSONDeserializerTest extends TestCase
 
         $expectedCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00')
+            DateTimeFactory::fromAtom('2020-01-26T09:00:00+01:00'),
+            DateTimeFactory::fromAtom('2020-02-10T16:00:00+01:00')
         );
 
         $expectedCalendar = $expectedCalendar->withStatus(
@@ -145,8 +145,8 @@ class CalendarJSONDeserializerTest extends TestCase
             null,
             [
                 (new TimeStamp(
-                    \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-03T09:00:00+01:00'),
-                    \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00')
+                    DateTimeFactory::fromAtom('2020-02-03T09:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2020-02-10T16:00:00+01:00')
                 ))->withBookingAvailability(BookingAvailability::unavailable()),
             ]
         ))->withBookingAvailability(BookingAvailability::unavailable());
@@ -169,11 +169,11 @@ class CalendarJSONDeserializerTest extends TestCase
             $this->calendarDataValidator
         );
 
-        $startDate1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00');
-        $endDate1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-01T16:00:00+01:00');
+        $startDate1 = DateTimeFactory::fromAtom('2020-01-26T09:00:00+01:00');
+        $endDate1 = DateTimeFactory::fromAtom('2020-02-01T16:00:00+01:00');
 
-        $startDate2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-03T09:00:00+01:00');
-        $endDate2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00');
+        $startDate2 = DateTimeFactory::fromAtom('2020-02-03T09:00:00+01:00');
+        $endDate2 = DateTimeFactory::fromAtom('2020-02-10T16:00:00+01:00');
 
         $timestamps = [
             (new Timestamp(
@@ -237,11 +237,11 @@ class CalendarJSONDeserializerTest extends TestCase
             $this->calendarDataValidator
         );
 
-        $startDate1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00');
-        $endDate1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-01T16:00:00+01:00');
+        $startDate1 = DateTimeFactory::fromAtom('2020-01-26T09:00:00+01:00');
+        $endDate1 = DateTimeFactory::fromAtom('2020-02-01T16:00:00+01:00');
 
-        $startDate2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-03T09:00:00+01:00');
-        $endDate2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00');
+        $startDate2 = DateTimeFactory::fromAtom('2020-02-03T09:00:00+01:00');
+        $endDate2 = DateTimeFactory::fromAtom('2020-02-10T16:00:00+01:00');
 
         $timestamps = [
             (new Timestamp(

--- a/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Calendar\DayOfWeek;
 use CultuurNet\UDB3\Calendar\DayOfWeekCollection;
 use CultuurNet\UDB3\Calendar\OpeningHour;
 use CultuurNet\UDB3\Calendar\OpeningTime;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
@@ -17,7 +18,6 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Calendar\Timestamp;
-use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class CalendarJSONParserTest extends TestCase
@@ -45,7 +45,7 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_can_get_the_start_date(): void
     {
-        $startDate = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00');
+        $startDate = DateTimeFactory::fromAtom('2020-01-26T09:00:00+01:00');
 
         $this->assertEquals(
             $startDate,
@@ -75,7 +75,7 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_can_get_the_end_date(): void
     {
-        $endDate = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00');
+        $endDate = DateTimeFactory::fromAtom('2020-02-10T16:00:00+01:00');
 
         $this->assertEquals(
             $endDate,
@@ -135,11 +135,11 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_can_get_the_timestamps(): void
     {
-        $startDatePeriod1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00');
-        $endDatePeriod1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-01T16:00:00+01:00');
+        $startDatePeriod1 = DateTimeFactory::fromAtom('2020-01-26T09:00:00+01:00');
+        $endDatePeriod1 = DateTimeFactory::fromAtom('2020-02-01T16:00:00+01:00');
 
-        $startDatePeriod2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-03T09:00:00+01:00');
-        $endDatePeriod2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00');
+        $startDatePeriod2 = DateTimeFactory::fromAtom('2020-02-03T09:00:00+01:00');
+        $endDatePeriod2 = DateTimeFactory::fromAtom('2020-02-10T16:00:00+01:00');
 
         $timestamps = [
             (new Timestamp(

--- a/tests/Http/Event/CopyEventRequestHandlerTest.php
+++ b/tests/Http/Event/CopyEventRequestHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Event;
 
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\Commands\CopyEvent;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
@@ -32,7 +33,6 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvents;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\TranslatedStatusReason;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
-use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactoryInterface;
@@ -107,8 +107,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     new SingleSubEventCalendar(
                         new SubEvent(
                             new DateRange(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                             ),
                             new Status(
                                 StatusType::Available()
@@ -136,8 +136,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     new SingleSubEventCalendar(
                         new SubEvent(
                             new DateRange(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                             ),
                             new Status(
                                 StatusType::Available()
@@ -172,8 +172,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     new SingleSubEventCalendar(
                         new SubEvent(
                             new DateRange(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                             ),
                             new Status(
                                 StatusType::Available()
@@ -203,8 +203,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     new SingleSubEventCalendar(
                         new SubEvent(
                             new DateRange(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                             ),
                             new Status(
                                 StatusType::Unavailable()
@@ -236,8 +236,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     new SingleSubEventCalendar(
                         new SubEvent(
                             new DateRange(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                             ),
                             new Status(
                                 StatusType::TemporarilyUnavailable(),
@@ -274,8 +274,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     (new SingleSubEventCalendar(
                         new SubEvent(
                             new DateRange(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                             ),
                             new Status(
                                 StatusType::TemporarilyUnavailable(),
@@ -321,8 +321,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     new SingleSubEventCalendar(
                         new SubEvent(
                             new DateRange(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                             ),
                             new Status(
                                 StatusType::Available()
@@ -346,8 +346,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     new SingleSubEventCalendar(
                         new SubEvent(
                             new DateRange(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                             ),
                             new Status(
                                 StatusType::Available()
@@ -380,8 +380,8 @@ class CopyEventRequestHandlerTest extends TestCase
                         new SubEvents(
                             new SubEvent(
                                 new DateRange(
-                                    DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                    DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                                    DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                    DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                                 ),
                                 new Status(
                                     StatusType::Available()
@@ -392,8 +392,8 @@ class CopyEventRequestHandlerTest extends TestCase
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-03T14:00:30+01:00'),
-                                    DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-03T17:00:30+01:00'),
+                                    DateTimeFactory::fromAtom('2021-01-03T14:00:30+01:00'),
+                                    DateTimeFactory::fromAtom('2021-01-03T17:00:30+01:00'),
                                 ),
                                 new Status(
                                     StatusType::Available()
@@ -427,8 +427,8 @@ class CopyEventRequestHandlerTest extends TestCase
                         new SubEvents(
                             new SubEvent(
                                 new DateRange(
-                                    DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                    DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                                    DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                    DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                                 ),
                                 new Status(
                                     StatusType::Available()
@@ -439,8 +439,8 @@ class CopyEventRequestHandlerTest extends TestCase
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-03T14:00:30+01:00'),
-                                    DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-03T17:00:30+01:00'),
+                                    DateTimeFactory::fromAtom('2021-01-03T14:00:30+01:00'),
+                                    DateTimeFactory::fromAtom('2021-01-03T17:00:30+01:00'),
                                 ),
                                 new Status(
                                     StatusType::Available()
@@ -464,8 +464,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     self::NEW_EVENT_ID,
                     new PeriodicCalendar(
                         new DateRange(
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                            DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                         ),
                         new OpeningHours()
                     )
@@ -487,8 +487,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     self::NEW_EVENT_ID,
                     (new PeriodicCalendar(
                         new DateRange(
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                            DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                         ),
                         new OpeningHours()
                     ))
@@ -532,8 +532,8 @@ class CopyEventRequestHandlerTest extends TestCase
                     self::NEW_EVENT_ID,
                     new PeriodicCalendar(
                         new DateRange(
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                            DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                         ),
                         new OpeningHours(
                             new OpeningHour(

--- a/tests/Http/Offer/PatchOfferRequestHandlerTest.php
+++ b/tests/Http/Offer/PatchOfferRequestHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\Commands\Moderation\Approve;
 use CultuurNet\UDB3\Event\Commands\Moderation\FlagAsDuplicate;
 use CultuurNet\UDB3\Event\Commands\Moderation\FlagAsInappropriate;
@@ -20,7 +21,6 @@ use CultuurNet\UDB3\Place\Commands\Moderation\FlagAsDuplicate as FlagAsDuplicate
 use CultuurNet\UDB3\Place\Commands\Moderation\FlagAsInappropriate as FlagAsInappropriatePlace;
 use CultuurNet\UDB3\Place\Commands\Moderation\Publish as PublishPlace;
 use CultuurNet\UDB3\Place\Commands\Moderation\Reject as RejectPlace;
-use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 final class PatchOfferRequestHandlerTest extends TestCase
@@ -104,7 +104,7 @@ final class PatchOfferRequestHandlerTest extends TestCase
                 'body' => ['publicationDate' => '2030-02-01T12:00:00+00:00'],
                 'expectedCommand' => new Publish(
                     $this->offerId,
-                    \DateTime::createFromFormat(DateTimeInterface::ATOM, '2030-02-01T12:00:00+00:00')
+                    DateTimeFactory::fromAtom('2030-02-01T12:00:00+00:00')
                 ),
             ],
             'Approve place' => [
@@ -137,7 +137,7 @@ final class PatchOfferRequestHandlerTest extends TestCase
                 'body' => ['publicationDate' => '2030-02-01T12:00:00+00:00'],
                 'expectedCommand' => new PublishPlace(
                     $this->offerId,
-                    \DateTime::createFromFormat(DateTimeInterface::ATOM, '2030-02-01T12:00:00+00:00')
+                    DateTimeFactory::fromAtom('2030-02-01T12:00:00+00:00')
                 ),
             ],
         ];

--- a/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use CultuurNet\UDB3\BookingInfo;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\Commands\UpdateBookingInfo as EventUpdateBookingInfo;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
@@ -98,8 +99,8 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
             new MultilingualString(new Language('nl'), 'Publiq vzw'),
             '02/1232323',
             'info@publiq.be',
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2023-01-01T00:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2028-01-31T23:59:59+01:00')
+            DateTimeFactory::fromAtom('2023-01-01T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2028-01-31T23:59:59+01:00')
         );
 
         $bookingInfoSpecialCharactersUrl = new BookingInfo(
@@ -107,8 +108,8 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
             new MultilingualString(new Language('nl'), 'Publiq vzw'),
             '02/1232323',
             'info@publiq.be',
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2023-01-01T00:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2028-01-31T23:59:59+01:00')
+            DateTimeFactory::fromAtom('2023-01-01T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2028-01-31T23:59:59+01:00')
         );
 
         return [

--- a/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Calendar\DayOfWeek;
 use CultuurNet\UDB3\Calendar\DayOfWeekCollection;
 use CultuurNet\UDB3\Calendar\OpeningHour;
 use CultuurNet\UDB3\Calendar\OpeningTime;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
@@ -24,7 +25,6 @@ use CultuurNet\UDB3\Offer\Commands\UpdateCalendar;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailabilityType;
 use CultuurNet\UDB3\Calendar\Timestamp;
-use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 class UpdateCalendarRequestHandlerTest extends TestCase
@@ -80,8 +80,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     self::EVENT_ID,
                     Calendar::single(
                         new Timestamp(
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         )
                     )
                 ),
@@ -100,8 +100,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     self::EVENT_ID,
                     Calendar::single(
                         new Timestamp(
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         )
                     )
                 ),
@@ -116,8 +116,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     self::EVENT_ID,
                     Calendar::single(
                         new Timestamp(
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         )
                     )
                 ),
@@ -139,8 +139,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     Calendar::single(
                         (
                             new Timestamp(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                             )
                         )
                             ->withStatus(new Status(StatusType::unavailable(), []))
@@ -167,8 +167,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     Calendar::single(
                         (
                             new Timestamp(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                             )
                         )
                             ->withStatus(
@@ -201,8 +201,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                         Calendar::single(
                             (
                                 new Timestamp(
-                                    DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                    DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                                    DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                    DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                                 )
                             )
                                 ->withStatus(
@@ -235,8 +235,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     self::EVENT_ID,
                     Calendar::single(
                         new Timestamp(
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         )
                     )
                 ),
@@ -251,8 +251,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     self::EVENT_ID,
                     Calendar::single(
                         new Timestamp(
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                            DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                            DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         )
                     )
                 ),
@@ -276,12 +276,12 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     Calendar::multiple(
                         [
                             new Timestamp(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                             ),
                             new Timestamp(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-03T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-03T17:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-03T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-03T17:00:30+01:00'),
                             ),
                         ]
                     )
@@ -306,12 +306,12 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     Calendar::multiple(
                         [
                             new Timestamp(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                             ),
                             new Timestamp(
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-03T14:00:30+01:00'),
-                                DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-03T17:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-03T14:00:30+01:00'),
+                                DateTimeFactory::fromAtom('2021-01-03T17:00:30+01:00'),
                             ),
                         ]
                     )
@@ -326,8 +326,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                 'expected_command' => new UpdateCalendar(
                     self::EVENT_ID,
                     Calendar::periodic(
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                        DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                        DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                     )
                 ),
             ],
@@ -345,8 +345,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                 'expected_command' => new UpdateCalendar(
                     self::EVENT_ID,
                     Calendar::periodic(
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                        DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                        DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         [],
                         new Status(
                             StatusType::temporarilyUnavailable(),
@@ -382,8 +382,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                 'expected_command' => new UpdateCalendar(
                     self::EVENT_ID,
                     Calendar::periodic(
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                        DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                        DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         [
                             new OpeningHour(
                                 new OpeningTime(new Hour(10), new Minute(0)),
@@ -787,8 +787,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                 'expected_command' => new UpdateCalendar(
                     self::PLACE_ID,
                     Calendar::periodic(
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00')
+                        DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                        DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00')
                     )
                 ),
             ],
@@ -806,8 +806,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                 'expected_command' => new UpdateCalendar(
                     self::PLACE_ID,
                     Calendar::periodic(
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                        DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                        DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         [],
                         new Status(
                             StatusType::temporarilyUnavailable(),
@@ -843,8 +843,8 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                 'expected_command' => new UpdateCalendar(
                     self::PLACE_ID,
                     Calendar::periodic(
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T14:00:30+01:00'),
-                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2021-01-01T17:00:30+01:00'),
+                        DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
+                        DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         [
                             new OpeningHour(
                                 new OpeningTime(new Hour(10), new Minute(0)),

--- a/tests/Kinepolis/KinepolisServiceTest.php
+++ b/tests/Kinepolis/KinepolisServiceTest.php
@@ -9,6 +9,7 @@ use Broadway\Repository\Repository;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
 use Cake\Chronos\Chronos;
 use CultuurNet\UDB3\Calendar\Calendar;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Description as LegacyDescription;
 use CultuurNet\UDB3\Event\Commands\AddImage;
 use CultuurNet\UDB3\Event\Commands\Moderation\Publish;
@@ -246,16 +247,16 @@ final class KinepolisServiceTest extends TestCase
                             new SubEvents(
                                 new SubEvent(
                                     new DateRange(
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:39:00+00:00')
+                                        DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00'),
+                                        DateTimeFactory::fromAtom('2024-04-08T19:39:00+00:00')
                                     ),
                                     new Status(StatusType::Available()),
                                     new BookingAvailability(BookingAvailabilityType::Available())
                                 ),
                                 new SubEvent(
                                     new DateRange(
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:15:00+00:00'),
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T21:54:00+00:00')
+                                        DateTimeFactory::fromAtom('2024-04-08T20:15:00+00:00'),
+                                        DateTimeFactory::fromAtom('2024-04-08T21:54:00+00:00')
                                     ),
                                     new Status(StatusType::Available()),
                                     new BookingAvailability(BookingAvailabilityType::Available())
@@ -423,16 +424,16 @@ final class KinepolisServiceTest extends TestCase
                             new SubEvents(
                                 new SubEvent(
                                     new DateRange(
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:39:00+00:00')
+                                        DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00'),
+                                        DateTimeFactory::fromAtom('2024-04-08T19:39:00+00:00')
                                     ),
                                     new Status(StatusType::Available()),
                                     new BookingAvailability(BookingAvailabilityType::Available())
                                 ),
                                 new SubEvent(
                                     new DateRange(
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:15:00+00:00'),
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T21:54:00+00:00')
+                                        DateTimeFactory::fromAtom('2024-04-08T20:15:00+00:00'),
+                                        DateTimeFactory::fromAtom('2024-04-08T21:54:00+00:00')
                                     ),
                                     new Status(StatusType::Available()),
                                     new BookingAvailability(BookingAvailabilityType::Available())
@@ -602,16 +603,16 @@ final class KinepolisServiceTest extends TestCase
                             new SubEvents(
                                 new SubEvent(
                                     new DateRange(
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:39:00+00:00')
+                                        DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00'),
+                                        DateTimeFactory::fromAtom('2024-04-08T19:39:00+00:00')
                                     ),
                                     new Status(StatusType::Available()),
                                     new BookingAvailability(BookingAvailabilityType::Available())
                                 ),
                                 new SubEvent(
                                     new DateRange(
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:15:00+00:00'),
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T21:54:00+00:00')
+                                        DateTimeFactory::fromAtom('2024-04-08T20:15:00+00:00'),
+                                        DateTimeFactory::fromAtom('2024-04-08T21:54:00+00:00')
                                     ),
                                     new Status(StatusType::Available()),
                                     new BookingAvailability(BookingAvailabilityType::Available())
@@ -691,16 +692,16 @@ final class KinepolisServiceTest extends TestCase
                             new SubEvents(
                                 new SubEvent(
                                     new DateRange(
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:39:00+00:00')
+                                        DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00'),
+                                        DateTimeFactory::fromAtom('2024-04-08T19:39:00+00:00')
                                     ),
                                     new Status(StatusType::Available()),
                                     new BookingAvailability(BookingAvailabilityType::Available())
                                 ),
                                 new SubEvent(
                                     new DateRange(
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:15:00+00:00'),
-                                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T21:54:00+00:00')
+                                        DateTimeFactory::fromAtom('2024-04-08T20:15:00+00:00'),
+                                        DateTimeFactory::fromAtom('2024-04-08T21:54:00+00:00')
                                     ),
                                     new Status(StatusType::Available()),
                                     new BookingAvailability(BookingAvailabilityType::Available())

--- a/tests/Kinepolis/Parser/KinepolisDateParserTest.php
+++ b/tests/Kinepolis/Parser/KinepolisDateParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Kinepolis\Parser;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
@@ -44,32 +45,32 @@ final class KinepolisDateParserTest extends TestCase
                         '2D' => [
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:15:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:15:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T20:15:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T20:15:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T12:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T12:00:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T12:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T12:00:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T15:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T15:00:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T15:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T15:00:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
@@ -80,40 +81,40 @@ final class KinepolisDateParserTest extends TestCase
                         '2D' => [
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:30:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:30:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T20:30:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T20:30:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T17:45:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T17:45:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T17:45:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T17:45:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T12:15:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T12:15:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T12:15:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T12:15:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T15:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T15:00:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T15:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T15:00:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T20:30:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T20:30:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T20:30:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T20:30:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
@@ -130,32 +131,32 @@ final class KinepolisDateParserTest extends TestCase
                         '2D' => [
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:39:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T19:39:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:15:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T21:54:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T20:15:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T21:54:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T12:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T13:39:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T12:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T13:39:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T15:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T16:39:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T15:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T16:39:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
@@ -166,40 +167,40 @@ final class KinepolisDateParserTest extends TestCase
                         '2D' => [
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:30:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T22:09:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T20:30:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T22:09:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T17:45:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:24:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T17:45:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T19:24:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T12:15:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T13:54:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T12:15:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T13:54:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T15:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T16:39:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T15:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T16:39:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T20:30:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T22:09:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T20:30:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T22:09:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
@@ -216,24 +217,24 @@ final class KinepolisDateParserTest extends TestCase
                         '2D' => [
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:00:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T20:00:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T12:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T14:00:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T12:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T14:00:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T15:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T17:00:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T15:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T17:00:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
@@ -242,8 +243,8 @@ final class KinepolisDateParserTest extends TestCase
                         '3D' => [
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:15:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T22:15:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T20:15:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T22:15:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
@@ -254,32 +255,32 @@ final class KinepolisDateParserTest extends TestCase
                         '2D' => [
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:30:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T22:30:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T20:30:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T22:30:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T12:15:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T14:15:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T12:15:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T14:15:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T15:00:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T17:00:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T15:00:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T17:00:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
                             ),
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T20:30:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-09T22:30:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-09T20:30:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-09T22:30:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())
@@ -288,8 +289,8 @@ final class KinepolisDateParserTest extends TestCase
                         '3D' => [
                             new SubEvent(
                                 new DateRange(
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T17:45:00+00:00'),
-                                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:45:00+00:00')
+                                    DateTimeFactory::fromAtom('2024-04-08T17:45:00+00:00'),
+                                    DateTimeFactory::fromAtom('2024-04-08T19:45:00+00:00')
                                 ),
                                 new Status(StatusType::Available()),
                                 new BookingAvailability(BookingAvailabilityType::Available())

--- a/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
+++ b/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Kinepolis\Parser;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\EventThemeResolver;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Json;
@@ -42,8 +43,8 @@ final class KinepolisMovieParserTest extends TestCase
                     '2D' => [
                         new SubEvent(
                             new DateRange(
-                                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
-                                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:00:00+00:00')
+                                DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00'),
+                                DateTimeFactory::fromAtom('2024-04-08T20:00:00+00:00')
                             ),
                             new Status(StatusType::Available()),
                             new BookingAvailability(BookingAvailabilityType::Available())
@@ -54,8 +55,8 @@ final class KinepolisMovieParserTest extends TestCase
                     '2D' => [
                         new SubEvent(
                             new DateRange(
-                                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:30:00+00:00'),
-                                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T22:30:00+00:00')
+                                DateTimeFactory::fromAtom('2024-04-08T20:30:00+00:00'),
+                                DateTimeFactory::fromAtom('2024-04-08T22:30:00+00:00')
                             ),
                             new Status(StatusType::Available()),
                             new BookingAvailability(BookingAvailabilityType::Available())
@@ -64,8 +65,8 @@ final class KinepolisMovieParserTest extends TestCase
                     '3D' => [
                         new SubEvent(
                             new DateRange(
-                                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T17:45:00+00:00'),
-                                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:45:00+00:00')
+                                DateTimeFactory::fromAtom('2024-04-08T17:45:00+00:00'),
+                                DateTimeFactory::fromAtom('2024-04-08T19:45:00+00:00')
                             ),
                             new Status(StatusType::Available()),
                             new BookingAvailability(BookingAvailabilityType::Available())
@@ -106,8 +107,8 @@ final class KinepolisMovieParserTest extends TestCase
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:00:00+00:00')
+                            DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00'),
+                            DateTimeFactory::fromAtom('2024-04-08T20:00:00+00:00')
                         ),
                         new Status(StatusType::Available()),
                         new BookingAvailability(BookingAvailabilityType::Available())
@@ -146,8 +147,8 @@ final class KinepolisMovieParserTest extends TestCase
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:30:00+00:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T22:30:00+00:00')
+                            DateTimeFactory::fromAtom('2024-04-08T20:30:00+00:00'),
+                            DateTimeFactory::fromAtom('2024-04-08T22:30:00+00:00')
                         ),
                         new Status(StatusType::Available()),
                         new BookingAvailability(BookingAvailabilityType::Available())
@@ -186,8 +187,8 @@ final class KinepolisMovieParserTest extends TestCase
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T17:45:00+00:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:45:00+00:00')
+                            DateTimeFactory::fromAtom('2024-04-08T17:45:00+00:00'),
+                            DateTimeFactory::fromAtom('2024-04-08T19:45:00+00:00')
                         ),
                         new Status(StatusType::Available()),
                         new BookingAvailability(BookingAvailabilityType::Available())
@@ -256,8 +257,8 @@ final class KinepolisMovieParserTest extends TestCase
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T18:00:00+00:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:00:00+00:00')
+                            DateTimeFactory::fromAtom('2024-04-08T18:00:00+00:00'),
+                            DateTimeFactory::fromAtom('2024-04-08T20:00:00+00:00')
                         ),
                         new Status(StatusType::Available()),
                         new BookingAvailability(BookingAvailabilityType::Available())
@@ -296,8 +297,8 @@ final class KinepolisMovieParserTest extends TestCase
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T20:30:00+00:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T22:30:00+00:00')
+                            DateTimeFactory::fromAtom('2024-04-08T20:30:00+00:00'),
+                            DateTimeFactory::fromAtom('2024-04-08T22:30:00+00:00')
                         ),
                         new Status(StatusType::Available()),
                         new BookingAvailability(BookingAvailabilityType::Available())
@@ -336,8 +337,8 @@ final class KinepolisMovieParserTest extends TestCase
                     (new EventThemeResolver())->byId('1.7.2.0.0'),
                     new SingleSubEventCalendar(new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T17:45:00+00:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-04-08T19:45:00+00:00')
+                            DateTimeFactory::fromAtom('2024-04-08T17:45:00+00:00'),
+                            DateTimeFactory::fromAtom('2024-04-08T19:45:00+00:00')
                         ),
                         new Status(StatusType::Available()),
                         new BookingAvailability(BookingAvailabilityType::Available())

--- a/tests/Model/Import/Event/Udb3ModelToLegacyEventAdapterTest.php
+++ b/tests/Model/Import/Event/Udb3ModelToLegacyEventAdapterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Import\Event;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Model\Event\ImmutableEvent;
 use CultuurNet\UDB3\Model\Place\PlaceReference;
@@ -58,7 +59,7 @@ class Udb3ModelToLegacyEventAdapterTest extends TestCase
                 AudienceType::members()
             )
             ->withAvailableFrom(
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T10:00:00+01:00')
+                DateTimeFactory::fromAtom('2018-01-01T10:00:00+01:00')
             );
 
         $this->adapter = new Udb3ModelToLegacyEventAdapter($event);

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Model\Import\Offer;
 
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Model\Event\ImmutableEvent;
 use CultuurNet\UDB3\Model\Offer\ImmutableOffer;
@@ -144,8 +145,8 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
                     new TelephoneNumber('044/444444'),
                     new EmailAddress('info@publiq.be'),
                     new BookingAvailability(
-                        DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T10:00:00+01:00'),
-                        DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T10:00:00+01:00')
+                        DateTimeFactory::fromAtom('2018-01-01T10:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2018-01-10T10:00:00+01:00')
                     )
                 )
             )
@@ -166,7 +167,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
                 )
             )
             ->withAvailableFrom(
-                DateTimeImmutable::createFromFormat(\DATE_ATOM, '2040-01-01T10:00:00+01:00')
+                DateTimeFactory::fromAtom('2040-01-01T10:00:00+01:00')
             );
 
         $this->adapter = new Udb3ModelToLegacyOfferAdapter($this->offer);
@@ -401,7 +402,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
      */
     public function it_should_return_available_from_if_there_is_one(): void
     {
-        $expected = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2040-01-01T10:00:00+01:00');
+        $expected = DateTimeFactory::fromAtom('2040-01-01T10:00:00+01:00');
         $actual = $this->completeAdapter->getAvailableFrom(new DateTimeImmutable());
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Model/Import/Place/Udb3ModelToLegacyPlaceAdapterTest.php
+++ b/tests/Model/Import/Place/Udb3ModelToLegacyPlaceAdapterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Import\Place;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\Place\ImmutablePlace;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
@@ -58,7 +59,7 @@ class Udb3ModelToLegacyPlaceAdapterTest extends TestCase
 
         /** @var ImmutablePlace $place */
         $place = $place->withAvailableFrom(
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T10:00:00+01:00')
+            DateTimeFactory::fromAtom('2018-01-01T10:00:00+01:00')
         );
 
         $translatedAddress = $place->getAddress()

--- a/tests/Model/Offer/ImmutableOfferTest.php
+++ b/tests/Model/Offer/ImmutableOfferTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Offer;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\Organizer\OrganizerReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
@@ -49,7 +50,6 @@ use CultuurNet\UDB3\Model\ValueObject\Web\TranslatedWebsiteLabel;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Model\ValueObject\Web\WebsiteLabel;
 use CultuurNet\UDB3\Model\ValueObject\Web\WebsiteLink;
-use DateTimeInterface;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
@@ -527,10 +527,7 @@ class ImmutableOfferTest extends TestCase
      */
     public function it_should_return_a_copy_with_an_updated_available_from(): void
     {
-        $availableFrom = \DateTimeImmutable::createFromFormat(
-            DateTimeInterface::ATOM,
-            '2018-01-01T00:00:00+00:00'
-        );
+        $availableFrom = DateTimeFactory::fromAtom('2018-01-01T00:00:00+00:00');
 
         $offer = $this->getOffer();
         $updatedOffer = $offer->withAvailableFrom($availableFrom);
@@ -545,10 +542,7 @@ class ImmutableOfferTest extends TestCase
      */
     public function it_should_return_a_copy_without_available_from(): void
     {
-        $availableFrom = \DateTimeImmutable::createFromFormat(
-            DateTimeInterface::ATOM,
-            '2018-01-01T00:00:00+00:00'
-        );
+        $availableFrom = DateTimeFactory::fromAtom('2018-01-01T00:00:00+00:00');
 
         $offer = $this->getOffer()->withAvailableFrom($availableFrom);
         $updatedOffer = $offer->withoutAvailableFrom();

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Serializer\Event;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\Event\ImmutableEvent;
 use CultuurNet\UDB3\Model\Organizer\OrganizerReference;
 use CultuurNet\UDB3\Model\Place\ImmutablePlace;
@@ -409,8 +410,8 @@ class EventDenormalizerTest extends TestCase
             new SingleSubEventCalendar(
                 new SubEvent(
                     new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2018-01-01T17:00:00+01:00')
                     ),
                     new Status(
                         StatusType::Available()
@@ -481,8 +482,8 @@ class EventDenormalizerTest extends TestCase
             new SingleSubEventCalendar(
                 new SubEvent(
                     new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2018-01-01T17:00:00+01:00')
                     ),
                     new Status(
                         StatusType::Unavailable(),
@@ -544,8 +545,8 @@ class EventDenormalizerTest extends TestCase
             new SingleSubEventCalendar(
                 new SubEvent(
                     new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2018-01-01T17:00:00+01:00')
                     ),
                     new Status(
                         StatusType::Available()
@@ -620,8 +621,8 @@ class EventDenormalizerTest extends TestCase
                 new SubEvents(
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-01T17:00:00+01:00')
                         ),
                         new Status(
                             StatusType::Available()
@@ -630,8 +631,8 @@ class EventDenormalizerTest extends TestCase
                     ),
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-03T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-03T17:00:00+01:00')
                         ),
                         new Status(
                             StatusType::Available()
@@ -640,8 +641,8 @@ class EventDenormalizerTest extends TestCase
                     ),
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-10T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-10T17:00:00+01:00')
                         ),
                         new Status(
                             StatusType::Available()
@@ -741,8 +742,8 @@ class EventDenormalizerTest extends TestCase
                 new SubEvents(
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-01T17:00:00+01:00')
                         ),
                         new Status(
                             StatusType::Unavailable(),
@@ -756,8 +757,8 @@ class EventDenormalizerTest extends TestCase
                     ),
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-03T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-03T17:00:00+01:00')
                         ),
                         new Status(
                             StatusType::Available()
@@ -766,8 +767,8 @@ class EventDenormalizerTest extends TestCase
                     ),
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-10T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-10T17:00:00+01:00')
                         ),
                         new Status(
                             StatusType::TemporarilyUnavailable()
@@ -776,8 +777,8 @@ class EventDenormalizerTest extends TestCase
                     ),
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-10T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-10T17:00:00+01:00')
                         ),
                         new Status(
                             StatusType::Available(),
@@ -862,16 +863,16 @@ class EventDenormalizerTest extends TestCase
                 new SubEvents(
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-01T17:00:00+01:00')
                         ),
                         new Status(StatusType::Available()),
                         new BookingAvailability(BookingAvailabilityType::Unavailable())
                     ),
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-03T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-03T17:00:00+01:00')
                         ),
                         new Status(StatusType::Available()),
                         new BookingAvailability(BookingAvailabilityType::Unavailable())
@@ -934,8 +935,8 @@ class EventDenormalizerTest extends TestCase
             (new SingleSubEventCalendar(
                 new SubEvent(
                     new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2018-01-01T17:00:00+01:00')
                     ),
                     new Status(
                         StatusType::TemporarilyUnavailable(),
@@ -1018,8 +1019,8 @@ class EventDenormalizerTest extends TestCase
             (new SingleSubEventCalendar(
                 new SubEvent(
                     new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2018-01-01T17:00:00+01:00')
                     ),
                     new Status(
                         StatusType::TemporarilyUnavailable(),
@@ -1115,8 +1116,8 @@ class EventDenormalizerTest extends TestCase
                 new SubEvents(
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-01T17:00:00+01:00')
                         ),
                         new Status(
                             StatusType::Unavailable(),
@@ -1130,8 +1131,8 @@ class EventDenormalizerTest extends TestCase
                     ),
                     new SubEvent(
                         new DateRange(
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T13:00:00+01:00'),
-                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
+                            DateTimeFactory::fromAtom('2018-01-03T13:00:00+01:00'),
+                            DateTimeFactory::fromAtom('2018-01-03T17:00:00+01:00')
                         ),
                         new Status(
                             StatusType::TemporarilyUnavailable(),
@@ -1200,8 +1201,8 @@ class EventDenormalizerTest extends TestCase
             ),
             new PeriodicCalendar(
                 new DateRange(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00')
+                    DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2018-01-10T17:00:00+01:00')
                 ),
                 new OpeningHours()
             ),
@@ -1270,8 +1271,8 @@ class EventDenormalizerTest extends TestCase
             ),
             new PeriodicCalendar(
                 new DateRange(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00')
+                    DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2018-01-10T17:00:00+01:00')
                 ),
                 new OpeningHours(
                     new OpeningHour(
@@ -1637,7 +1638,7 @@ class EventDenormalizerTest extends TestCase
                     ->withTranslation(new Language('en'), new Description('Example description'))
             )
             ->withAvailableFrom(
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T00:00:00+01:00')
+                DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00')
             )
             ->withLabels(
                 new Labels(
@@ -1700,8 +1701,8 @@ class EventDenormalizerTest extends TestCase
                     new TelephoneNumber('02 551 18 70'),
                     new EmailAddress('info@publiq.be'),
                     new ContactBookingAvailability(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T00:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-10-01T00:00:00+01:00')
+                        DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2018-10-01T00:00:00+01:00')
                     )
                 )
             )

--- a/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
+++ b/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Serializer\Place;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
@@ -397,8 +398,8 @@ class PlaceDenormalizerTest extends TestCase
             ),
             new PeriodicCalendar(
                 new DateRange(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00')
+                    DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2018-01-10T17:00:00+01:00')
                 ),
                 new OpeningHours()
             ),
@@ -480,8 +481,8 @@ class PlaceDenormalizerTest extends TestCase
             ),
             new PeriodicCalendar(
                 new DateRange(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00')
+                    DateTimeFactory::fromAtom('2018-01-01T13:00:00+01:00'),
+                    DateTimeFactory::fromAtom('2018-01-10T17:00:00+01:00')
                 ),
                 new OpeningHours(
                     new OpeningHour(
@@ -843,7 +844,7 @@ class PlaceDenormalizerTest extends TestCase
                     ->withTranslation(new Language('en'), new Description('Example description'))
             )
             ->withAvailableFrom(
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T00:00:00+01:00')
+                DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00')
             )
             ->withLabels(
                 new Labels(
@@ -903,8 +904,8 @@ class PlaceDenormalizerTest extends TestCase
                     new TelephoneNumber('02 551 18 70'),
                     new EmailAddress('info@publiq.be'),
                     new BookingAvailability(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T00:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-10-01T00:00:00+01:00')
+                        DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2018-10-01T00:00:00+01:00')
                     )
                 )
             )

--- a/tests/Model/ValueObject/Calendar/DateRangesTest.php
+++ b/tests/Model/ValueObject/Calendar/DateRangesTest.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
-use DateTimeImmutable;
+use CultuurNet\UDB3\DateTimeFactory;
 use PHPUnit\Framework\TestCase;
-use const DATE_ATOM;
 
 class DateRangesTest extends TestCase
 {
@@ -52,8 +51,8 @@ class DateRangesTest extends TestCase
 
             return new SubEvent(
                 new DateRange(
-                    DateTimeImmutable::createFromFormat(DATE_ATOM, $from),
-                    DateTimeImmutable::createFromFormat(DATE_ATOM, $to)
+                    DateTimeFactory::fromAtom($from),
+                    DateTimeFactory::fromAtom($to)
                 ),
                 new Status(StatusType::Available()),
                 new BookingAvailability(BookingAvailabilityType::Available())
@@ -68,11 +67,11 @@ class DateRangesTest extends TestCase
         $this->assertEquals($expected, $ranges->toArray());
         $this->assertEquals(7, $ranges->getLength());
         $this->assertEquals(
-            DateTimeImmutable::createFromFormat(DATE_ATOM, '2018-01-01T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00'),
             $ranges->getStartDate()
         );
         $this->assertEquals(
-            DateTimeImmutable::createFromFormat(DATE_ATOM, '2018-08-31T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2018-08-31T00:00:00+01:00'),
             $ranges->getEndDate()
         );
     }

--- a/tests/Offer/Commands/AbstractUpdateBookingInfoTest.php
+++ b/tests/Offer/Commands/AbstractUpdateBookingInfoTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\BookingInfo;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -35,8 +36,8 @@ class AbstractUpdateBookingInfoTest extends TestCase
             new MultilingualString(new Language('nl'), 'urlLabel'),
             '0123456789',
             'foo@bar.com',
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-01T00:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-31T00:00:00+01:00')
+            DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
         );
 
         $this->updateBookingInfo = $this->getMockForAbstractClass(
@@ -56,8 +57,8 @@ class AbstractUpdateBookingInfoTest extends TestCase
             new MultilingualString(new Language('nl'), 'urlLabel'),
             '0123456789',
             'foo@bar.com',
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-01T00:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-31T00:00:00+01:00')
+            DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
         );
 
         $this->assertEquals($expectedBookingInfo, $bookingInfo);

--- a/tests/Offer/Commands/Moderation/AbstractPublishTest.php
+++ b/tests/Offer/Commands/Moderation/AbstractPublishTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\Commands\Moderation;
 
 use Cake\Chronos\Chronos;
+use CultuurNet\UDB3\DateTimeFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -15,10 +16,7 @@ class AbstractPublishTest extends TestCase
      */
     public function it_can_store_a_future_publication_date(): void
     {
-        $futurePublicationDate = \DateTimeImmutable::createFromFormat(
-            DATE_ATOM,
-            Chronos::now()->addWeek()->format(DATE_ATOM)
-        );
+        $futurePublicationDate = DateTimeFactory::fromAtom(Chronos::now()->addWeek()->toAtomString());
 
         /** @var AbstractPublish&MockObject $publishCommand */
         $publishCommand = $this->getMockForAbstractClass(

--- a/tests/Offer/Events/AbstractBookingInfoEventTest.php
+++ b/tests/Offer/Events/AbstractBookingInfoEventTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\Events;
 
 use CultuurNet\UDB3\BookingInfo;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
@@ -34,8 +35,8 @@ class AbstractBookingInfoEventTest extends TestCase
             new MultilingualString(new Language('nl'), 'urlLabel'),
             '0123456789',
             'foo@bar.com',
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-01T00:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-31T00:00:00+01:00')
+            DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
         );
         $this->abstractBookingInfoEvent = new MockAbstractBookingInfoEvent(
             $this->itemId,
@@ -54,8 +55,8 @@ class AbstractBookingInfoEventTest extends TestCase
             new MultilingualString(new Language('nl'), 'urlLabel'),
             '0123456789',
             'foo@bar.com',
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-01T00:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-31T00:00:00+01:00')
+            DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
         );
         $expectedAbstractBookingInfoEvent = new MockAbstractBookingInfoEvent(
             $expectedItemId,
@@ -76,8 +77,8 @@ class AbstractBookingInfoEventTest extends TestCase
             new MultilingualString(new Language('nl'), 'urlLabel'),
             '0123456789',
             'foo@bar.com',
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-01T00:00:00+01:00'),
-            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-31T00:00:00+01:00')
+            DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
+            DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
         );
 
         $itemId = $this->abstractBookingInfoEvent->getItemId();
@@ -140,8 +141,8 @@ class AbstractBookingInfoEventTest extends TestCase
                         new MultilingualString(new Language('nl'), 'urlLabel'),
                         '0123456789',
                         'foo@bar.com',
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-01T00:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-01-31T00:00:00+01:00')
+                        DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
+                        DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
                     )
                 ),
             ],

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -109,8 +109,8 @@ abstract class OfferLDProjectorTestBase extends TestCase
         $urlLabel = new MultilingualString(new Language('nl'), 'Google');
         $phone = '045';
         $email = 'test@test.com';
-        $availabilityStarts = \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T00:00:00+01:00');
-        $availabilityEnds = \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-31T00:00:00+01:00');
+        $availabilityStarts = DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00');
+        $availabilityEnds = DateTimeFactory::fromAtom('2018-01-31T00:00:00+01:00');
         $bookingInfo = new BookingInfo($url, $urlLabel, $phone, $email, $availabilityStarts, $availabilityEnds);
         $eventClass = $this->getEventClass('BookingInfoUpdated');
         $bookingInfoUpdated = new $eventClass($id, $bookingInfo);

--- a/tests/Place/Events/CalendarUpdatedTest.php
+++ b/tests/Place/Events/CalendarUpdatedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Place\Events;
 
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
-use DateTimeInterface;
+use CultuurNet\UDB3\DateTimeFactory;
 use PHPUnit\Framework\TestCase;
 
 class CalendarUpdatedTest extends TestCase
@@ -37,8 +37,8 @@ class CalendarUpdatedTest extends TestCase
 
         $this->calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
+            DateTimeFactory::fromAtom('2020-01-26T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2020-01-27T12:12:12+01:00')
         );
 
         $this->calendarUpdatedAsArray = [

--- a/tests/Place/Events/PlaceCreatedTest.php
+++ b/tests/Place/Events/PlaceCreatedTest.php
@@ -10,13 +10,13 @@ use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\EventSourcing\ConvertsToGranularEvents;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use DateTimeImmutable;
-use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class PlaceCreatedTest extends TestCase
@@ -281,10 +281,7 @@ class PlaceCreatedTest extends TestCase
                     new Calendar(
                         CalendarType::PERMANENT()
                     ),
-                    DateTimeImmutable::createFromFormat(
-                        DateTimeInterface::ATOM,
-                        '2016-08-01T00:00:00+02:00'
-                    )
+                    DateTimeFactory::fromAtom('2016-08-01T00:00:00+02:00')
                 ),
             ],
         ];

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
 use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Place\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Place\Events\PriceInfoUpdated;
@@ -38,7 +39,6 @@ use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
-use DateTimeInterface;
 use Money\Currency;
 use Money\Money;
 
@@ -167,8 +167,8 @@ class PlaceTest extends AggregateRootScenarioTestCase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
+            DateTimeFactory::fromAtom('2020-01-26T11:11:11+01:00'),
+            DateTimeFactory::fromAtom('2020-01-27T12:12:12+01:00')
         );
 
         $cdbXml = $this->getCdbXML('/ReadModel/JSONLD/place_with_long_description.cdbxml.xml');

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -8,6 +8,7 @@ use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\Serializer\Serializable;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
@@ -76,7 +77,6 @@ use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use DateTimeImmutable;
-use DateTimeInterface;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
@@ -833,10 +833,7 @@ class HistoryProjectorTest extends TestCase
     {
         $event = new Published(
             'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
-            DateTimeImmutable::createFromFormat(
-                DateTimeInterface::ATOM,
-                '2015-04-30T02:00:00+02:00'
-            )
+            DateTimeFactory::fromAtom('2015-04-30T02:00:00+02:00')
         );
 
         $domainMessage = $this->aDomainMessageForEvent($event->getItemId(), $event);

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Cdb\CdbXmlPriceInfoParser;
 use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Completeness\CompletenessFromWeights;
 use CultuurNet\UDB3\Completeness\Weights;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
@@ -47,7 +48,6 @@ use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use CultuurNet\UDB3\Place\Events\PlaceUpdatedFromUDB2;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
-use DateTimeInterface;
 use stdClass;
 
 class PlaceLDProjectorTest extends OfferLDProjectorTestBase
@@ -670,8 +670,8 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $eventType = new EventType('0.50.4.0.1', 'concertnew');
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-02-26T13:25:21+01:00')
+            DateTimeFactory::fromAtom('2015-01-26T13:25:21+01:00'),
+            DateTimeFactory::fromAtom('2015-02-26T13:25:21+01:00')
         );
         $majorInfoUpdated = new MajorInfoUpdated($id, $title, $eventType, $this->address, $calendar);
 


### PR DESCRIPTION
### Changed
- Used factory method to create ATOM date time. This method always has a single return type of `DateTimeImmutable` object and throws in case of invalid format instead of returning false.

---
Ticket: https://jira.uitdatabank.be/browse/III-3558
