### PR TITLE
III-3558 Replace `file_get_contents`

### DIFF
--- a/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
+++ b/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
@@ -76,7 +76,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
         string $sampleFile,
         Language $expectedMainLanguage
     ): void {
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         /** @var EventCreated|PlaceCreated|OrganizerCreatedWithUniqueWebsite $created */
@@ -125,7 +125,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
      */
     public function it_transforms_a_serialized_event_created_location_to_an_id(): void
     {
-        $serialized = file_get_contents(__DIR__ . '/samples/serialized_event_event_created_class.json');
+        $serialized = SampleFiles::read(__DIR__ . '/samples/serialized_event_event_created_class.json');
         $decoded = Json::decodeAssociatively($serialized);
 
         /** @var EventCreated $created */
@@ -139,7 +139,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
      */
     public function it_transforms_a_serialized_major_info_updated_location_to_an_id(): void
     {
-        $serialized = file_get_contents(__DIR__ . '/samples/serialized_event_major_info_updated_class.json');
+        $serialized = SampleFiles::read(__DIR__ . '/samples/serialized_event_major_info_updated_class.json');
         $decoded = Json::decodeAssociatively($serialized);
 
         /** @var MajorInfoUpdated $majorInfoUpdated */
@@ -257,7 +257,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
         $this->labelRepository->expects($this->never())
             ->method('getByUuid');
 
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
         $this->serializer->deserialize($decoded);
     }
@@ -363,7 +363,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
      */
     public function it_knows_the_new_namespace_of_event_imported_from_udb2_class(): void
     {
-        $serialized = file_get_contents($this->sampleDir . 'serialized_event_imported_from_udb2_class.json');
+        $serialized = SampleFiles::read($this->sampleDir . 'serialized_event_imported_from_udb2_class.json');
         $decoded = Json::decodeAssociatively($serialized);
 
         $importedFromUDB2 = $this->serializer->deserialize($decoded);
@@ -378,7 +378,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
     {
         $sampleFile = $this->sampleDir . 'serialized_event_booking_info_updated_class.json';
 
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         /* @var BookingInfoUpdated $bookingInfoUpdated */
@@ -397,7 +397,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
     {
         $sampleFile = $this->sampleDir . 'serialized_event_booking_info_updated_with_deprecated_availability.json';
 
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         /* @var BookingInfoUpdated $bookingInfoUpdated */
@@ -421,7 +421,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
     {
         $sampleFile = $this->sampleDir . 'serialized_event_booking_info_updated_with_invalid_availability.json';
 
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         /* @var BookingInfoUpdated $bookingInfoUpdated */
@@ -438,7 +438,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
     {
         $sampleFile = $this->sampleDir . 'serialized_event_booking_info_updated_with_deprecated_url_label.json';
 
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         /* @var BookingInfoUpdated $bookingInfoUpdated */
@@ -457,7 +457,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
     {
         $sampleFile = $this->sampleDir . 'serialized_event_booking_info_updated_with_valid_availability.json';
 
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         /* @var BookingInfoUpdated $bookingInfoUpdated */
@@ -481,7 +481,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
     {
         $sampleFile = $this->sampleDir . 'serialized_event_booking_info_updated_without_availability.json';
 
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         /* @var BookingInfoUpdated $bookingInfoUpdated */
@@ -602,7 +602,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
     public function it_should_replace_string_names_with_translatable_objects_in_price_info_updated(): void
     {
         $sampleFile = $this->sampleDir . 'serialized_event_price_info_updated_class.json';
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         $expectedPriceInfo = new PriceInfo(
@@ -647,7 +647,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
     {
         $sampleFile = $this->sampleDir . 'serialized_event_constraint_created.json';
 
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         /* @var ConstraintAdded $constraintAdded */
@@ -668,7 +668,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
 
     private function assertTypedIdReplacedWithItemId(string $type, string $sampleFile): void
     {
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
         $typedId = $decoded['payload'][$type . '_id'];
 
@@ -683,7 +683,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
 
     private function assertKeywordReplacedWithLabel(string $sampleFile): void
     {
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
         $keyword = $decoded['payload']['keyword'];
 
@@ -696,7 +696,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
 
     private function assertClass(string $sampleFile, string $expectedClass): void
     {
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         $newEvent = $this->serializer->deserialize($decoded);
@@ -706,7 +706,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
 
     private function assertLabelNameAdded(string $sampleFile): void
     {
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         /** @var AbstractEvent $labelEvent */
@@ -717,7 +717,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
 
     private function assertOrganizerLabelEventFixed(string $sampleFile): void
     {
-        $serialized = file_get_contents($sampleFile);
+        $serialized = SampleFiles::read($sampleFile);
         $decoded = Json::decodeAssociatively($serialized);
 
         /** @var LabelEventInterface $labelEvent */

--- a/tests/Calendar/CalendarFactoryTest.php
+++ b/tests/Calendar/CalendarFactoryTest.php
@@ -8,6 +8,7 @@ use CultureFeed_Cdb_Data_Calendar_Timestamp;
 use CultureFeed_Cdb_Data_Calendar_TimestampList;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
+use CultuurNet\UDB3\SampleFiles;
 use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
@@ -871,7 +872,7 @@ class CalendarFactoryTest extends TestCase
         return [
             'import event with period: datefrom + dateto, no weekscheme' => [
                 'cdbCalendar' => $this->createPeriodListFromXML(
-                    file_get_contents(__DIR__ . '/samples/periodic/calendar_udb2_import_example_1101.xml')
+                    SampleFiles::read(__DIR__ . '/samples/periodic/calendar_udb2_import_example_1101.xml')
                 ),
                 'expectedCalendar' => new Calendar(
                     CalendarType::PERIODIC(),
@@ -881,7 +882,7 @@ class CalendarFactoryTest extends TestCase
             ],
             'import event with period: datefrom + dateto + weekscheme only openingtimes from' => [
                 'cdbCalendar' => $this->createPeriodListFromXML(
-                    file_get_contents(__DIR__ . '/samples/periodic/calendar_udb2_import_example_1201.xml')
+                    SampleFiles::read(__DIR__ . '/samples/periodic/calendar_udb2_import_example_1201.xml')
                 ),
                 'expectedCalendar' => new Calendar(
                     CalendarType::PERIODIC(),
@@ -911,7 +912,7 @@ class CalendarFactoryTest extends TestCase
             ],
             'import event with period: datefrom + dateto + weekscheme openingtimes from + to' => [
                 'cdbCalendar' => $this->createPeriodListFromXML(
-                    file_get_contents(__DIR__ . '/samples/periodic/calendar_udb2_import_example_1301.xml')
+                    SampleFiles::read(__DIR__ . '/samples/periodic/calendar_udb2_import_example_1301.xml')
                 ),
                 'expectedCalendar' => new Calendar(
                     CalendarType::PERIODIC(),
@@ -941,7 +942,7 @@ class CalendarFactoryTest extends TestCase
             ],
             'import event with period: datefrom + dateto + weekscheme mix openingtimes from + to' => [
                 'cdbCalendar' => $this->createPeriodListFromXML(
-                    file_get_contents(__DIR__ . '/samples/periodic/calendar_udb2_import_example_1401.xml')
+                    SampleFiles::read(__DIR__ . '/samples/periodic/calendar_udb2_import_example_1401.xml')
                 ),
                 'expectedCalendar' => new Calendar(
                     CalendarType::PERIODIC(),
@@ -1003,13 +1004,13 @@ class CalendarFactoryTest extends TestCase
         return [
             'import permanent event, no weekscheme as periodic event' => [
                 'cdbCalendar' => $this->createPermanentCalendarFromXML(
-                    file_get_contents(__DIR__ . '/samples/permanent/calendar_udb2_import_example_1501.xml')
+                    SampleFiles::read(__DIR__ . '/samples/permanent/calendar_udb2_import_example_1501.xml')
                 ),
                 'expectedCalendar' => new Calendar(CalendarType::PERMANENT()),
             ],
             'import permanent event with weekscheme only openingtimes from' => [
                 'cdbCalendar' => $this->createPermanentCalendarFromXML(
-                    file_get_contents(__DIR__ . '/samples/permanent/calendar_udb2_import_example_1601.xml')
+                    SampleFiles::read(__DIR__ . '/samples/permanent/calendar_udb2_import_example_1601.xml')
                 ),
                 'expectedCalendar' => new Calendar(
                     CalendarType::PERMANENT(),
@@ -1039,7 +1040,7 @@ class CalendarFactoryTest extends TestCase
             ],
             'import permanent event with weekscheme openingtimes from + to' => [
                 'cdbCalendar' => $this->createPermanentCalendarFromXML(
-                    file_get_contents(__DIR__ . '/samples/permanent/calendar_udb2_import_example_1701.xml')
+                    SampleFiles::read(__DIR__ . '/samples/permanent/calendar_udb2_import_example_1701.xml')
                 ),
                 'expectedCalendar' => new Calendar(
                     CalendarType::PERMANENT(),
@@ -1069,7 +1070,7 @@ class CalendarFactoryTest extends TestCase
             ],
             'import permanent event with weekscheme mix openingtimes from + to' => [
                 'cdbCalendar' => $this->createPermanentCalendarFromXML(
-                    file_get_contents(__DIR__ . '/samples/permanent/calendar_udb2_import_example_1801.xml')
+                    SampleFiles::read(__DIR__ . '/samples/permanent/calendar_udb2_import_example_1801.xml')
                 ),
                 'expectedCalendar' => new Calendar(
                     CalendarType::PERMANENT(),

--- a/tests/Cdb/ActorItemFactoryTest.php
+++ b/tests/Cdb/ActorItemFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Cdb;
 
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 class ActorItemFactoryTest extends TestCase
@@ -46,7 +47,7 @@ class ActorItemFactoryTest extends TestCase
         );
         $expected->setCategories($categoryList);
 
-        $cdbXml = file_get_contents(__DIR__ . '/samples/actor.xml');
+        $cdbXml = SampleFiles::read(__DIR__ . '/samples/actor.xml');
 
         $this->assertEquals(
             $expected,

--- a/tests/Cdb/EventItemFactoryTest.php
+++ b/tests/Cdb/EventItemFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Cdb;
 
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 class EventItemFactoryTest extends TestCase
@@ -77,7 +78,7 @@ class EventItemFactoryTest extends TestCase
         $location = new \CultureFeed_Cdb_Data_Location($address);
         $expected->setLocation($location);
 
-        $cdbXml = file_get_contents(__DIR__ . '/samples/event.xml');
+        $cdbXml = SampleFiles::read(__DIR__ . '/samples/event.xml');
 
         $this->assertEquals(
             $expected,

--- a/tests/Event/CdbXMLEventFactory.php
+++ b/tests/Event/CdbXMLEventFactory.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;
 use CultuurNet\UDB3\Event\Events\EventUpdatedFromUDB2;
+use CultuurNet\UDB3\SampleFiles;
 
 class CdbXMLEventFactory
 {
@@ -36,7 +37,7 @@ class CdbXMLEventFactory
      */
     private function eventFromFile(string $fileName, string $eventClass)
     {
-        $cdbXml = file_get_contents($this->samplesPath . '/' . $fileName);
+        $cdbXml = SampleFiles::read($this->samplesPath . '/' . $fileName);
 
         $event = new $eventClass(
             self::AN_EVENT_ID,

--- a/tests/Event/CommandHandlers/UpdateAttendanceModeHandlerTest.php
+++ b/tests/Event/CommandHandlers/UpdateAttendanceModeHandlerTest.php
@@ -22,6 +22,7 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Online\AttendanceMode;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\Theme;
 
 final class UpdateAttendanceModeHandlerTest extends CommandHandlerScenarioTestCase
@@ -59,7 +60,7 @@ final class UpdateAttendanceModeHandlerTest extends CommandHandlerScenarioTestCa
                 [
                     new EventImportedFromUDB2(
                         $eventId,
-                        file_get_contents(__DIR__ . '/../samples/EventTest.cdbxml.xml'),
+                        SampleFiles::read(__DIR__ . '/../samples/EventTest.cdbxml.xml'),
                         CultureFeed_Cdb_Xml::namespaceUriForVersion('3.2')
                     ),
                 ]

--- a/tests/Event/EventCommandHandlerTest.php
+++ b/tests/Event/EventCommandHandlerTest.php
@@ -29,6 +29,7 @@ use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Media\MediaManagerInterface;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\OfferCommandHandlerTestTrait;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 
@@ -214,7 +215,7 @@ class EventCommandHandlerTest extends CommandHandlerScenarioTestCase
                 [
                     new EventImportedFromUDB2(
                         $eventId,
-                        file_get_contents(__DIR__ . '/samples/EventTest.cdbxml.xml'),
+                        SampleFiles::read(__DIR__ . '/samples/EventTest.cdbxml.xml'),
                         CultureFeed_Cdb_Xml::namespaceUriForVersion('3.2')
                     ),
                 ]

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -58,6 +58,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
@@ -1283,7 +1284,7 @@ class EventTest extends AggregateRootScenarioTestCase
             new LegacyLanguage('en')
         );
 
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/samples/event_entryapi_valid_with_keywords.xml'
         );
 
@@ -1317,7 +1318,7 @@ class EventTest extends AggregateRootScenarioTestCase
      */
     public function it_removes_images(): void
     {
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/samples/event_entryapi_valid_with_keywords.xml'
         );
 
@@ -1367,7 +1368,7 @@ class EventTest extends AggregateRootScenarioTestCase
      */
     public function it_silently_ignores_an_image_removal_request_when_image_is_not_present(): void
     {
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/samples/event_entryapi_valid_with_keywords.xml'
         );
 
@@ -2046,7 +2047,7 @@ class EventTest extends AggregateRootScenarioTestCase
 
     protected function getSample(string $file): string
     {
-        return file_get_contents(
+        return SampleFiles::read(
             __DIR__ . '/samples/' . $file
         );
     }

--- a/tests/Event/Events/EventImportedFromUDB2Test.php
+++ b/tests/Event/Events/EventImportedFromUDB2Test.php
@@ -27,6 +27,7 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Street;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Calendar\Timestamp;
+use CultuurNet\UDB3\SampleFiles;
 use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
@@ -43,7 +44,7 @@ final class EventImportedFromUDB2Test extends TestCase
     {
         $event = new EventImportedFromUDB2(
             'test 456',
-            file_get_contents(__DIR__ . '/../samples/event_entryapi_valid_with_keywords.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_entryapi_valid_with_keywords.xml'),
             self::NS_CDBXML_3_3
         );
 
@@ -86,7 +87,7 @@ final class EventImportedFromUDB2Test extends TestCase
     {
         $eventImportedFromUDB2 = new EventImportedFromUDB2(
             '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3',
-            file_get_contents(__DIR__ . '/../samples/event_with_udb3_place.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_udb3_place.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -136,7 +137,7 @@ final class EventImportedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventImportedFromUDB2 = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_translations.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_translations.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -186,7 +187,7 @@ final class EventImportedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventImportedFromUDB2 = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_existing_location.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_existing_location.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -224,7 +225,7 @@ final class EventImportedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventImportedFromUDB2 = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -262,7 +263,7 @@ final class EventImportedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventWithExternalIdLocation = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -280,7 +281,7 @@ final class EventImportedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventImportedFromUDB2 = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/calendar/event_with_periodic_calendar_and_week_schema.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/calendar/event_with_periodic_calendar_and_week_schema.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
         );
 
@@ -365,7 +366,7 @@ final class EventImportedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventImportedFromUDB2 = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/calendar/event_with_permanent_calendar_and_opening_hours.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/calendar/event_with_permanent_calendar_and_opening_hours.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
         );
 
@@ -425,7 +426,7 @@ final class EventImportedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventImportedFromUDB2 = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/calendar/event_with_multiple_timestamps_and_start_times.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/calendar/event_with_multiple_timestamps_and_start_times.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
         );
 
@@ -488,7 +489,7 @@ final class EventImportedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventImportedFromUDB2 = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/calendar/event_with_timestamp_and_start_time.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/calendar/event_with_timestamp_and_start_time.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
         );
 
@@ -527,7 +528,7 @@ final class EventImportedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventImportedFromUDB2 = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_workflow_deleted.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_workflow_deleted.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
         );
 
@@ -559,7 +560,7 @@ final class EventImportedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventImportedFromUDB2 = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_workflow_rejected.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_workflow_rejected.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
         );
 
@@ -588,7 +589,7 @@ final class EventImportedFromUDB2Test extends TestCase
 
     public function serializationDataProvider(): array
     {
-        $xml = file_get_contents(__DIR__ . '/../samples/event_entryapi_valid_with_keywords.xml');
+        $xml = SampleFiles::read(__DIR__ . '/../samples/event_entryapi_valid_with_keywords.xml');
 
         return [
             'event' => [

--- a/tests/Event/Events/EventUpdatedFromUDB2Test.php
+++ b/tests/Event/Events/EventUpdatedFromUDB2Test.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Street;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Calendar\Timestamp;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 final class EventUpdatedFromUDB2Test extends TestCase
@@ -57,7 +58,7 @@ final class EventUpdatedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventUpdatedFromUdb2 = new EventUpdatedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_translations.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_translations.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -80,7 +81,7 @@ final class EventUpdatedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventUpdatedFromUdb2 = new EventUpdatedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_existing_location.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_existing_location.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -118,7 +119,7 @@ final class EventUpdatedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventUpdatedFromUdb2 = new EventUpdatedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -156,7 +157,7 @@ final class EventUpdatedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventWithDummyLocation = new EventUpdatedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_dummy_location.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_dummy_location.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -182,7 +183,7 @@ final class EventUpdatedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventWithDummyLocation = new EventUpdatedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_dummy_location_without_street.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_dummy_location_without_street.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -208,7 +209,7 @@ final class EventUpdatedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventWithDummyLocation = new EventUpdatedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_dummy_location_without_number.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_dummy_location_without_number.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -234,7 +235,7 @@ final class EventUpdatedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventWithDummyLocation = new EventUpdatedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_dummy_location_without_street_and_number.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_dummy_location_without_street_and_number.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -260,7 +261,7 @@ final class EventUpdatedFromUDB2Test extends TestCase
         $eventId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $eventWithExternalIdLocation = new EventUpdatedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../samples/event_with_externalid_location.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -272,7 +273,7 @@ final class EventUpdatedFromUDB2Test extends TestCase
 
     public function serializationDataProvider(): array
     {
-        $xml = file_get_contents(__DIR__ . '/../samples/event_entryapi_valid_with_keywords.xml');
+        $xml = SampleFiles::read(__DIR__ . '/../samples/event_entryapi_valid_with_keywords.xml');
 
         return [
             'event' => [

--- a/tests/Event/GeoCoordinatesCommandHandlerTest.php
+++ b/tests/Event/GeoCoordinatesCommandHandlerTest.php
@@ -30,6 +30,7 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\Theme;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -94,7 +95,7 @@ class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
 
         $eventImported = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/samples/event_004aea08-e13d-48c9-b9eb-a18f20e6d44e.xml'),
+            SampleFiles::read(__DIR__ . '/samples/event_004aea08-e13d-48c9-b9eb-a18f20e6d44e.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
         );
 
@@ -135,7 +136,7 @@ class GeoCoordinatesCommandHandlerTest extends CommandHandlerScenarioTestCase
 
         $eventImported = new EventImportedFromUDB2(
             $eventId,
-            file_get_contents(__DIR__ . '/samples/event_004aea08-e13d-48c9-b9eb-a18f20e6d44e.xml'),
+            SampleFiles::read(__DIR__ . '/samples/event_004aea08-e13d-48c9-b9eb-a18f20e6d44e.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
         );
 

--- a/tests/Event/GeoCoordinatesProcessManagerTest.php
+++ b/tests/Event/GeoCoordinatesProcessManagerTest.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Event\Commands\UpdateGeoCoordinatesFromAddress;
 use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;
 use CultuurNet\UDB3\Event\Events\EventUpdatedFromUDB2;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -61,7 +62,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
             new Metadata(),
             new EventImportedFromUDB2(
                 'e3604613-af01-4d2b-8cee-13ab61b89651',
-                file_get_contents(__DIR__ . '/samples/geocoding/event_with_dummy_location.cdbxml.xml'),
+                SampleFiles::read(__DIR__ . '/samples/geocoding/event_with_dummy_location.cdbxml.xml'),
                 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
             )
         );
@@ -94,7 +95,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
             new Metadata(),
             new EventUpdatedFromUDB2(
                 'e3604613-af01-4d2b-8cee-13ab61b89651',
-                file_get_contents(__DIR__ . '/samples/geocoding/event_with_dummy_location.cdbxml.xml'),
+                SampleFiles::read(__DIR__ . '/samples/geocoding/event_with_dummy_location.cdbxml.xml'),
                 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
             )
         );
@@ -127,7 +128,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
             new Metadata(),
             new EventImportedFromUDB2(
                 'e3604613-af01-4d2b-8cee-13ab61b89651',
-                file_get_contents(__DIR__ . '/samples/geocoding/event_with_dummy_location_without_physical_address.cdbxml.xml'),
+                SampleFiles::read(__DIR__ . '/samples/geocoding/event_with_dummy_location_without_physical_address.cdbxml.xml'),
                 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
             )
         );
@@ -149,7 +150,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
             new Metadata(),
             new EventImportedFromUDB2(
                 'e3604613-af01-4d2b-8cee-13ab61b89651',
-                file_get_contents(__DIR__ . '/samples/geocoding/event_with_location.cdbxml.xml'),
+                SampleFiles::read(__DIR__ . '/samples/geocoding/event_with_location.cdbxml.xml'),
                 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
             )
         );
@@ -171,7 +172,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
             new Metadata(),
             new EventImportedFromUDB2(
                 'e3604613-af01-4d2b-8cee-13ab61b89651',
-                file_get_contents(__DIR__ . '/samples/geocoding/event_with_external_location.cdbxml.xml'),
+                SampleFiles::read(__DIR__ . '/samples/geocoding/event_with_external_location.cdbxml.xml'),
                 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
             )
         );
@@ -193,7 +194,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
             new Metadata(),
             new EventImportedFromUDB2(
                 'e3604613-af01-4d2b-8cee-13ab61b89651',
-                file_get_contents(__DIR__ . '/samples/geocoding/event_without_location.cdbxml.xml'),
+                SampleFiles::read(__DIR__ . '/samples/geocoding/event_without_location.cdbxml.xml'),
                 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
             )
         );
@@ -214,7 +215,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
             new Metadata(),
             new EventImportedFromUDB2(
                 'e3604613-af01-4d2b-8cee-13ab61b89651',
-                file_get_contents(__DIR__ . '/samples/geocoding/event_with_dummy_location_without_address.cdbxml.xml'),
+                SampleFiles::read(__DIR__ . '/samples/geocoding/event_with_dummy_location_without_address.cdbxml.xml'),
                 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
             )
         );

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -81,6 +81,7 @@ use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\Theme;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -128,7 +129,7 @@ class HistoryProjectorTest extends TestCase
 
     protected function getEventCdbXml(string $eventId): string
     {
-        return file_get_contents(__DIR__ . '/event-' . $eventId . '.xml');
+        return SampleFiles::read(__DIR__ . '/event-' . $eventId . '.xml');
     }
 
     /**

--- a/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\SluggerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -69,7 +70,7 @@ class CdbXMLImporterTest extends TestCase
 
     private function createEventFromCdbXml(string $fileName, string $version = '3.2'): CultureFeed_Cdb_Item_Event
     {
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/' . $fileName
         );
 
@@ -123,7 +124,7 @@ class CdbXMLImporterTest extends TestCase
 
     private function createJsonEventFromCalendarSample(string $fileName): \stdClass
     {
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/../../samples/calendar/' . $fileName
         );
 
@@ -1168,7 +1169,7 @@ class CdbXMLImporterTest extends TestCase
         $jsonEvent = $this->createJsonEventFromCdbXml($cdbxmlFile, $schemaVersion);
 
         $this->assertEquals(
-            file_get_contents(__DIR__ . '/' . $expectedDescriptionFile),
+            SampleFiles::read(__DIR__ . '/' . $expectedDescriptionFile),
             $jsonEvent->description['nl']
         );
     }

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -68,6 +68,7 @@ use CultuurNet\UDB3\OfferLDProjectorTestBase;
 use CultuurNet\UDB3\Place\LocalPlaceService;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Calendar\Timestamp;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -266,7 +267,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $recordedOn = '2022-01-20T13:25:21+01:00';
 
-        $jsonLD = Json::decode(file_get_contents(__DIR__ . '/copied_event_with_place_type.json'));
+        $jsonLD = Json::decode(SampleFiles::read(__DIR__ . '/copied_event_with_place_type.json'));
         $jsonLD->created = $recordedOn;
         $jsonLD->modified = $recordedOn;
         $jsonLD->playhead = 1;
@@ -487,7 +488,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             DateTime::fromString($recordedOn)
         );
 
-        $expectedJsonLD = Json::decode(file_get_contents(__DIR__ . '/copied_event.json'));
+        $expectedJsonLD = Json::decode(SampleFiles::read(__DIR__ . '/copied_event.json'));
         $expectedJsonLD->created = $recordedOn;
         $expectedJsonLD->modified = $recordedOn;
         $expectedJsonLD->creator = '20a72430-7e3e-4b75-ab59-043156b3169c';
@@ -524,7 +525,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             DateTime::fromString($recordedOn)
         );
 
-        $expectedJsonLD = Json::decode(file_get_contents(__DIR__ . '/copied_event_without_working_hours.json'));
+        $expectedJsonLD = Json::decode(SampleFiles::read(__DIR__ . '/copied_event_without_working_hours.json'));
         $expectedJsonLD->created = $recordedOn;
         $expectedJsonLD->modified = $recordedOn;
         $expectedJsonLD->creator = $userId;
@@ -766,7 +767,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         // add the event json to memory
         $this->documentRepository->save(new JsonDocument(
             CdbXMLEventFactory::AN_EVENT_ID,
-            file_get_contents(
+            SampleFiles::read(
                 __DIR__ . '/../../samples/event_with_udb3_place.json'
             )
         ));
@@ -1879,7 +1880,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $eventUpdatedFromUDB2 = new EventUpdatedFromUDB2(
             'foo',
-            file_get_contents(__DIR__ . '/../../samples/event_with_photo.cdbxml.xml'),
+            SampleFiles::read(__DIR__ . '/../../samples/event_with_photo.cdbxml.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 

--- a/tests/Event/ReadModel/JSONLD/Specifications/EventSpecificationTestTrait.php
+++ b/tests/Event/ReadModel/JSONLD/Specifications/EventSpecificationTestTrait.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Event\ReadModel\JSONLD\Specifications;
 
 use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\SampleFiles;
 
 trait EventSpecificationTestTrait
 {
     protected function getEventLdFromFile(string $fileName): \stdClass
     {
-        $jsonEvent = file_get_contents(
+        $jsonEvent = SampleFiles::read(
             __DIR__ . '/../../../samples/' . $fileName
         );
 

--- a/tests/Event/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Event/ReadModel/Permission/ProjectorTest.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Event\Events\OwnerChanged;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -50,7 +51,7 @@ final class ProjectorTest extends TestCase
      */
     public function it_adds_permission_to_the_user_identified_by_the_createdby_element_for_events_imported_from_udb2(): void
     {
-        $cdbXml = file_get_contents(__DIR__ . '/../../samples/event_with_photo.cdbxml.xml');
+        $cdbXml = SampleFiles::read(__DIR__ . '/../../samples/event_with_photo.cdbxml.xml');
         $cdbXmlNamespaceUri = \CultureFeed_Cdb_Xml::namespaceUriForVersion('3.2');
 
         $payload = new EventImportedFromUDB2(
@@ -87,7 +88,7 @@ final class ProjectorTest extends TestCase
      */
     public function it_does_not_add_any_permissions_for_events_imported_from_udb2_with_unresolvable_createdby_value(): void
     {
-        $cdbXml = file_get_contents(__DIR__ . '/../../samples/event_with_photo.cdbxml.xml');
+        $cdbXml = SampleFiles::read(__DIR__ . '/../../samples/event_with_photo.cdbxml.xml');
         $cdbXmlNamespaceUri = \CultureFeed_Cdb_Xml::namespaceUriForVersion('3.2');
 
         $payload = new EventImportedFromUDB2(

--- a/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
+++ b/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\RDF\JsonDataCouldNotBeConverted;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\SampleFiles;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -168,7 +169,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event.ttl'), $turtle);
     }
 
     /**
@@ -184,7 +185,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-description.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-description.ttl'), $turtle);
     }
 
     /**
@@ -206,7 +207,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-translations.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-translations.ttl'), $turtle);
     }
 
     /**
@@ -236,7 +237,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-calendar-permanent-and-opening-hours.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-calendar-permanent-and-opening-hours.ttl'), $turtle);
     }
 
     /**
@@ -252,7 +253,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-calendar-periodic.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-calendar-periodic.ttl'), $turtle);
     }
 
     /**
@@ -294,7 +295,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-calendar-periodic-and-opening-hours.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-calendar-periodic-and-opening-hours.ttl'), $turtle);
     }
 
     /**
@@ -310,7 +311,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-calendar-single.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-calendar-single.ttl'), $turtle);
     }
 
     /**
@@ -336,7 +337,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-calendar-multiple.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-calendar-multiple.ttl'), $turtle);
     }
 
     /**
@@ -372,7 +373,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/' . $file), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/' . $file), $turtle);
     }
 
     public function workflowStatusDataProvider(): array
@@ -413,7 +414,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-publication-date.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-publication-date.ttl'), $turtle);
     }
 
     /**
@@ -436,7 +437,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-dummy-location.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-dummy-location.ttl'), $turtle);
     }
 
     /**
@@ -482,7 +483,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-dummy-location-name.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-dummy-location-name.ttl'), $turtle);
     }
 
     /**
@@ -508,7 +509,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-dummy-location.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-dummy-location.ttl'), $turtle);
     }
 
     /**
@@ -544,7 +545,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-dummy-location-and-multiple-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-dummy-location-and-multiple-calendar.ttl'), $turtle);
     }
 
     /**
@@ -583,7 +584,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-dummy-location-name-and-multiple-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-dummy-location-name-and-multiple-calendar.ttl'), $turtle);
     }
 
     /**
@@ -609,7 +610,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-dummy-location-and-single-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-dummy-location-and-single-calendar.ttl'), $turtle);
     }
 
     /**
@@ -638,7 +639,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-dummy-location-name-and-single-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-dummy-location-name-and-single-calendar.ttl'), $turtle);
     }
 
     /**
@@ -659,7 +660,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/online-event-with-online-url-and-single-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/online-event-with-online-url-and-single-calendar.ttl'), $turtle);
     }
 
     /**
@@ -679,7 +680,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/online-event-with-single-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/online-event-with-single-calendar.ttl'), $turtle);
     }
 
     /**
@@ -710,7 +711,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/online-event-with-online-url-and-multiple-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/online-event-with-online-url-and-multiple-calendar.ttl'), $turtle);
     }
 
     /**
@@ -729,7 +730,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/online-event-with-online-url-and-permanent-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/online-event-with-online-url-and-permanent-calendar.ttl'), $turtle);
     }
 
     /**
@@ -747,7 +748,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/online-event-with-permanent-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/online-event-with-permanent-calendar.ttl'), $turtle);
     }
 
     /**
@@ -765,7 +766,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/mixed-event-with-permanent-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/mixed-event-with-permanent-calendar.ttl'), $turtle);
     }
 
     /**
@@ -785,7 +786,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/mixed-event-with-single-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/mixed-event-with-single-calendar.ttl'), $turtle);
     }
 
     /**
@@ -804,7 +805,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/mixed-event-with-online-url-and-permanent-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/mixed-event-with-online-url-and-permanent-calendar.ttl'), $turtle);
     }
 
     /**
@@ -825,7 +826,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/mixed-event-with-online-url-and-single-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/mixed-event-with-online-url-and-single-calendar.ttl'), $turtle);
     }
 
     /**
@@ -856,7 +857,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/mixed-event-with-online-url-and-multiple-calendar.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/mixed-event-with-online-url-and-multiple-calendar.ttl'), $turtle);
     }
 
     /**
@@ -872,7 +873,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-organizer.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-organizer.ttl'), $turtle);
     }
 
     /**
@@ -888,7 +889,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-dummy-organizer.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-dummy-organizer.ttl'), $turtle);
     }
 
     /**
@@ -907,7 +908,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-dummy-organizer.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-dummy-organizer.ttl'), $turtle);
     }
 
     /**
@@ -929,7 +930,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-dummy-organizer-with-contact-point.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-dummy-organizer-with-contact-point.ttl'), $turtle);
     }
 
     /**
@@ -956,7 +957,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-contact-point.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-contact-point.ttl'), $turtle);
     }
 
     /**
@@ -977,7 +978,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-booking-info.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-booking-info.ttl'), $turtle);
     }
 
     /**
@@ -998,7 +999,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-labels.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-labels.ttl'), $turtle);
     }
 
     /**
@@ -1032,7 +1033,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-price-info.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-price-info.ttl'), $turtle);
     }
 
     /**
@@ -1061,7 +1062,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-videos.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-videos.ttl'), $turtle);
     }
 
     /**
@@ -1085,7 +1086,7 @@ class EventJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/event-with-media-object.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-media-object.ttl'), $turtle);
     }
 
     private function givenThereIsAnEvent(array $extraProperties = []): void

--- a/tests/Event/ReadModel/Relations/EventRelationsProjectorTest.php
+++ b/tests/Event/ReadModel/Relations/EventRelationsProjectorTest.php
@@ -19,6 +19,7 @@ use CultuurNet\UDB3\Event\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Event\Events\OrganizerUpdated;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -83,9 +84,9 @@ class EventRelationsProjectorTest extends TestCase
      */
     public function cdbXmlDataProvider()
     {
-        $withNone = file_get_contents(__DIR__ . '/event_without_placeid_and_without_organiserid.xml');
-        $withPlace = file_get_contents(__DIR__ . '/event_with_placeid_and_without_organiserid.xml');
-        $withBoth = file_get_contents(__DIR__ . '/event_with_placeid_and_organiserid.xml');
+        $withNone = SampleFiles::read(__DIR__ . '/event_without_placeid_and_without_organiserid.xml');
+        $withPlace = SampleFiles::read(__DIR__ . '/event_with_placeid_and_without_organiserid.xml');
+        $withBoth = SampleFiles::read(__DIR__ . '/event_with_placeid_and_organiserid.xml');
 
         return [
             [

--- a/tests/EventExport/Command/ExportEventsAsPDFJSONDeserializerTest.php
+++ b/tests/EventExport/Command/ExportEventsAsPDFJSONDeserializerTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Footer;
 use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Publisher;
 use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Subtitle;
 use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Title;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\Search\Sorting;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use PHPUnit\Framework\TestCase;
@@ -137,6 +138,6 @@ class ExportEventsAsPDFJSONDeserializerTest extends TestCase
 
     private function getJSONStringFromFile(string $fileName): string
     {
-        return file_get_contents(__DIR__ . '/' . $fileName);
+        return SampleFiles::read(__DIR__ . '/' . $fileName);
     }
 }

--- a/tests/EventExport/Command/ExportEventsJSONDeserializerTest.php
+++ b/tests/EventExport/Command/ExportEventsJSONDeserializerTest.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\EventExport\EventExportQuery;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -127,6 +128,6 @@ class ExportEventsJSONDeserializerTest extends TestCase
 
     private function getJsonData(string $fileName): string
     {
-        return file_get_contents(__DIR__ . '/' . $fileName);
+        return SampleFiles::read(__DIR__ . '/' . $fileName);
     }
 }

--- a/tests/EventExport/Format/HTML/HTMLEventFormatterTest.php
+++ b/tests/EventExport/Format/HTML/HTMLEventFormatterTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\EventExport\Format\HTML\Uitpas\Event\EventAdvantage;
 use CultuurNet\UDB3\EventExport\Format\HTML\Uitpas\EventInfo\EventInfo;
 use CultuurNet\UDB3\EventExport\Format\HTML\Uitpas\EventInfo\EventInfoServiceInterface;
 use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -32,7 +33,7 @@ class HTMLEventFormatterTest extends TestCase
 
     protected function getJSONEventFromFile(string $fileName): string
     {
-        return file_get_contents(__DIR__ . '/../../samples/' . $fileName);
+        return SampleFiles::read(__DIR__ . '/../../samples/' . $fileName);
     }
 
     protected function getFormattedEventFromJSONFile(string $fileName): array
@@ -435,7 +436,7 @@ class HTMLEventFormatterTest extends TestCase
 
     private function getExpectedCalendarSummary(string $fileName): string
     {
-        $expected = file_get_contents(__DIR__ . '/../../samples/' . $fileName);
+        $expected = SampleFiles::read(__DIR__ . '/../../samples/' . $fileName);
         return trim($expected);
     }
 

--- a/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
+++ b/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\EventExport\Format\HTML;
 
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 final class HTMLFileWriterTest extends TestCase
@@ -60,7 +61,7 @@ final class HTMLFileWriterTest extends TestCase
 
         $fileWriter->write($this->filePath, new \ArrayIterator($events));
 
-        $expected = file_get_contents($fileWithExpectedContent);
+        $expected = SampleFiles::read($fileWithExpectedContent);
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -115,7 +116,7 @@ final class HTMLFileWriterTest extends TestCase
         );
         $fileWriter->write($this->filePath, new \ArrayIterator([]));
 
-        $expected = file_get_contents(__DIR__ . '/results/export_without_events.html');
+        $expected = SampleFiles::read(__DIR__ . '/results/export_without_events.html');
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -180,7 +181,7 @@ final class HTMLFileWriterTest extends TestCase
         );
         $fileWriter->write($this->filePath, new \ArrayIterator($events));
 
-        $expected = file_get_contents(__DIR__ . '/results/export.html');
+        $expected = SampleFiles::read(__DIR__ . '/results/export.html');
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -214,7 +215,7 @@ final class HTMLFileWriterTest extends TestCase
         );
         $fileWriter->write($this->filePath, new \ArrayIterator($events));
 
-        $expected = file_get_contents(__DIR__ . '/results/export_event_without_image.html');
+        $expected = SampleFiles::read(__DIR__ . '/results/export_event_without_image.html');
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -250,7 +251,7 @@ final class HTMLFileWriterTest extends TestCase
         );
         $fileWriter->write($this->filePath, new \ArrayIterator($events));
 
-        $expected = file_get_contents(__DIR__ . '/results/export_event_with_taaliconen.html');
+        $expected = SampleFiles::read(__DIR__ . '/results/export_event_with_taaliconen.html');
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -286,7 +287,7 @@ final class HTMLFileWriterTest extends TestCase
         );
         $fileWriter->write($this->filePath, new \ArrayIterator($events));
 
-        $expected = file_get_contents(__DIR__ . '/results/export_event_with_four_taaliconen.html');
+        $expected = SampleFiles::read(__DIR__ . '/results/export_event_with_four_taaliconen.html');
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -326,7 +327,7 @@ final class HTMLFileWriterTest extends TestCase
         );
         $fileWriter->write($this->filePath, new \ArrayIterator($events));
 
-        $expected = file_get_contents(__DIR__ . '/results/export_event_with_uitpas_brand.html');
+        $expected = SampleFiles::read(__DIR__ . '/results/export_event_with_uitpas_brand.html');
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -366,7 +367,7 @@ final class HTMLFileWriterTest extends TestCase
         );
         $fileWriter->write($this->filePath, new \ArrayIterator($events));
 
-        $expected = file_get_contents(__DIR__ . '/results/export_event_with_age_range.html');
+        $expected = SampleFiles::read(__DIR__ . '/results/export_event_with_age_range.html');
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -428,7 +429,7 @@ final class HTMLFileWriterTest extends TestCase
         );
         $fileWriter->write($this->filePath, new \ArrayIterator($events));
 
-        $expected = file_get_contents(__DIR__ . '/results/export_event_with_uitpas_info.html');
+        $expected = SampleFiles::read(__DIR__ . '/results/export_event_with_uitpas_info.html');
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -450,7 +451,7 @@ final class HTMLFileWriterTest extends TestCase
 
         $fileWriter->write($this->filePath, new \ArrayIterator($events));
 
-        $expected = file_get_contents(__DIR__ . '/results/export_event_with_uitpas_info_paspartoe_branded.html');
+        $expected = SampleFiles::read(__DIR__ . '/results/export_event_with_uitpas_info_paspartoe_branded.html');
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -488,7 +489,7 @@ final class HTMLFileWriterTest extends TestCase
 
         $fileWriter->write($this->filePath, new \ArrayIterator($events));
 
-        $expected = file_get_contents(__DIR__ . '/results/export_event_with_custom_logo.html');
+        $expected = SampleFiles::read(__DIR__ . '/results/export_event_with_custom_logo.html');
         $this->assertHTMLFileContents($expected, $this->filePath);
     }
 
@@ -507,7 +508,7 @@ final class HTMLFileWriterTest extends TestCase
      */
     protected function assertHTMLFileContents(string $html, string $filePath): void
     {
-        $this->assertEquals($html, file_get_contents($filePath));
+        $this->assertEquals($html, SampleFiles::read($filePath));
     }
 
     /**

--- a/tests/EventExport/Format/JSONLD/JSONLDEventFormatterTest.php
+++ b/tests/EventExport/Format/JSONLD/JSONLDEventFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\EventExport\Format\JSONLD;
 
 use CultuurNet\UDB3\EventExport\CalendarSummary\CalendarSummaryRepositoryInterface;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +24,7 @@ class JSONLDEventFormatterTest extends TestCase
 
     private function getJSONEventFromFile(string $fileName): string
     {
-        return file_get_contents(__DIR__ . '/../../samples/' . $fileName);
+        return SampleFiles::read(__DIR__ . '/../../samples/' . $fileName);
     }
 
     /**

--- a/tests/EventExport/Format/TabularData/TabularDataEventFormatterTest.php
+++ b/tests/EventExport/Format/TabularData/TabularDataEventFormatterTest.php
@@ -11,13 +11,14 @@ use CultuurNet\UDB3\EventExport\Format\HTML\Uitpas\Event\EventAdvantage;
 use CultuurNet\UDB3\EventExport\Format\HTML\Uitpas\EventInfo\EventInfo;
 use CultuurNet\UDB3\EventExport\Format\HTML\Uitpas\EventInfo\EventInfoServiceInterface;
 use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 class TabularDataEventFormatterTest extends TestCase
 {
     private function getJSONEventFromFile(string $fileName): string
     {
-        return file_get_contents(__DIR__ . '/../../samples/' . $fileName);
+        return SampleFiles::read(__DIR__ . '/../../samples/' . $fileName);
     }
 
     /**

--- a/tests/Http/Auth/Jwt/JsonWebTokenFactory.php
+++ b/tests/Http/Auth/Jwt/JsonWebTokenFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Auth\Jwt;
 
+use CultuurNet\UDB3\SampleFiles;
 use DateTimeImmutable;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
@@ -73,6 +74,6 @@ final class JsonWebTokenFactory
 
     public static function getPublicKey(): string
     {
-        return file_get_contents(__DIR__ . '/samples/public.pem');
+        return SampleFiles::read(__DIR__ . '/samples/public.pem');
     }
 }

--- a/tests/Http/Auth/Jwt/UitIdV2JwtValidatorTest.php
+++ b/tests/Http/Auth/Jwt/UitIdV2JwtValidatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Auth\Jwt;
 
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 class UitIdV2JwtValidatorTest extends TestCase
@@ -14,7 +15,7 @@ class UitIdV2JwtValidatorTest extends TestCase
     protected function setUp(): void
     {
         $this->v2Validator = new UitIdV2JwtValidator(
-            file_get_contents(__DIR__ . '/samples/public.pem'),
+            SampleFiles::read(__DIR__ . '/samples/public.pem'),
             ['mock-issuer'],
             'vsCe0hXlLaR255wOrW56Fau7vYO5qvqD'
         );

--- a/tests/Http/Deserializer/Calendar/CalendarForEventDataValidatorTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarForEventDataValidatorTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\Calendar;
 
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 class CalendarForEventDataValidatorTest extends TestCase
@@ -27,7 +28,7 @@ class CalendarForEventDataValidatorTest extends TestCase
     public function it_does_not_throw_for_valid_calendars(string $file): void
     {
         $data = Json::decodeAssociatively(
-            file_get_contents(__DIR__ . '/samples/' . $file)
+            SampleFiles::read(__DIR__ . '/samples/' . $file)
         );
 
         $this->calendarForEventDataValidator->validate($data);

--- a/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
@@ -20,6 +20,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Calendar\Timestamp;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -40,7 +41,7 @@ class CalendarJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_json_to_calendar(): void
     {
-        $calendarAsJsonString = file_get_contents(__DIR__ . '/samples/calendar.json');
+        $calendarAsJsonString = SampleFiles::read(__DIR__ . '/samples/calendar.json');
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),
@@ -98,7 +99,7 @@ class CalendarJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_json_to_calendar_with_status(): void
     {
-        $calendarAsJsonString = file_get_contents(__DIR__ . '/samples/calendar_with_status.json');
+        $calendarAsJsonString = SampleFiles::read(__DIR__ . '/samples/calendar_with_status.json');
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),
@@ -132,7 +133,7 @@ class CalendarJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_json_to_calendar_with_booking_availability(): void
     {
-        $calendarAsJsonString = file_get_contents(__DIR__ . '/samples/calendar_with_booking_availability.json');
+        $calendarAsJsonString = SampleFiles::read(__DIR__ . '/samples/calendar_with_booking_availability.json');
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),
@@ -162,7 +163,7 @@ class CalendarJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_json_to_calendar_with_status_on_time_spans(): void
     {
-        $calendarAsJsonString = file_get_contents(__DIR__ . '/samples/calendar_with_status_on_time_spans.json');
+        $calendarAsJsonString = SampleFiles::read(__DIR__ . '/samples/calendar_with_status_on_time_spans.json');
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),
@@ -230,7 +231,7 @@ class CalendarJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_json_to_calendar_with_booking_availability_on_time_spans(): void
     {
-        $calendarAsJsonString = file_get_contents(__DIR__ . '/samples/calendar_with_booking_availability_on_time_spans.json');
+        $calendarAsJsonString = SampleFiles::read(__DIR__ . '/samples/calendar_with_booking_availability_on_time_spans.json');
 
         $calendarJSONDeserializer = new CalendarJSONDeserializer(
             new CalendarJSONParser(),
@@ -291,23 +292,23 @@ class CalendarJSONDeserializerTest extends TestCase
     {
         return [
             'calendar_of_type_PERMANENT_when_json_only_contains_opening_hours' => [
-                'calendarData' => file_get_contents(__DIR__ . '/samples/calendar_with_opening_hours.json'),
+                'calendarData' => SampleFiles::read(__DIR__ . '/samples/calendar_with_opening_hours.json'),
                 'expectedCalendarType' => CalendarType::PERMANENT(),
             ],
             'calendar_of_type_PERMANENT_when_json_is_empty' => [
-                'calendarData' => file_get_contents(__DIR__ . '/samples/empty_calendar.json'),
+                'calendarData' => SampleFiles::read(__DIR__ . '/samples/empty_calendar.json'),
                 'expectedCalendarType' => CalendarType::PERMANENT(),
             ],
             'calendar_of_type_SINGLE_when_json_contains_a_single_time_span' => [
-                'calendarData' => file_get_contents(__DIR__ . '/samples/calendar_with_single_time_span.json'),
+                'calendarData' => SampleFiles::read(__DIR__ . '/samples/calendar_with_single_time_span.json'),
                 'expectedCalendarType' => CalendarType::SINGLE(),
             ],
             'calendar_of_type_MULTIPLE_when_json_contains_multiple_time_spans' => [
-                'calendarData' => file_get_contents(__DIR__ . '/samples/calendar_with_multiple_time_spans.json'),
+                'calendarData' => SampleFiles::read(__DIR__ . '/samples/calendar_with_multiple_time_spans.json'),
                 'expectedCalendarType' => CalendarType::MULTIPLE(),
             ],
             'calendar_of_type_PERIODIC_when_json_contains_start_and_end_date' => [
-                'calendarData' => file_get_contents(__DIR__ . '/samples/calendar_with_start_and_end_date.json'),
+                'calendarData' => SampleFiles::read(__DIR__ . '/samples/calendar_with_start_and_end_date.json'),
                 'expectedCalendarType' => CalendarType::PERIODIC(),
             ],
         ];

--- a/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Calendar\Timestamp;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 class CalendarJSONParserTest extends TestCase
@@ -34,7 +35,7 @@ class CalendarJSONParserTest extends TestCase
 
     protected function setUp(): void
     {
-        $updateCalendar = file_get_contents(__DIR__ . '/samples/calendar_all_fields.json');
+        $updateCalendar = SampleFiles::read(__DIR__ . '/samples/calendar_all_fields.json');
         $this->updateCalendarAsArray = Json::decodeAssociatively($updateCalendar);
 
         $this->calendarJSONParser = new CalendarJSONParser();
@@ -60,7 +61,7 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_returns_null_when_start_date_is_missing(): void
     {
-        $updateCalendar = file_get_contents(__DIR__ . '/samples/calendar_missing_start_and_end.json');
+        $updateCalendar = SampleFiles::read(__DIR__ . '/samples/calendar_missing_start_and_end.json');
         $updateCalendarAsArray = Json::decodeAssociatively($updateCalendar);
 
         $this->assertNull(
@@ -90,7 +91,7 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_returns_null_when_end_date_is_missing(): void
     {
-        $updateCalendar = file_get_contents(__DIR__ . '/samples/calendar_missing_start_and_end.json');
+        $updateCalendar = SampleFiles::read(__DIR__ . '/samples/calendar_missing_start_and_end.json');
         $updateCalendarAsArray = Json::decodeAssociatively($updateCalendar);
 
         $this->assertNull(
@@ -182,7 +183,7 @@ class CalendarJSONParserTest extends TestCase
     public function it_should_not_create_timestamps_when_json_is_missing_an_end_property(): void
     {
         $calendarData = Json::decodeAssociatively(
-            file_get_contents(__DIR__ . '/samples/calendar_missing_time_span_end.json')
+            SampleFiles::read(__DIR__ . '/samples/calendar_missing_time_span_end.json')
         );
 
         $this->assertEmpty(
@@ -196,7 +197,7 @@ class CalendarJSONParserTest extends TestCase
     public function it_should_not_create_timestamps_when_json_is_missing_a_start_property(): void
     {
         $calendarData = Json::decodeAssociatively(
-            file_get_contents(__DIR__ . '/samples/calendar_missing_time_span_start.json')
+            SampleFiles::read(__DIR__ . '/samples/calendar_missing_time_span_start.json')
         );
 
         $this->assertEmpty(
@@ -255,7 +256,7 @@ class CalendarJSONParserTest extends TestCase
     public function it_should_not_create_opening_hours_when_fields_are_missing(): void
     {
         $calendarData = Json::decodeAssociatively(
-            file_get_contents(__DIR__ . '/samples/calendar_with_opening_hours_but_missing_fields.json')
+            SampleFiles::read(__DIR__ . '/samples/calendar_with_opening_hours_but_missing_fields.json')
         );
 
         $this->assertEmpty(

--- a/tests/Http/Deserializer/Event/CreateEventJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Event/CreateEventJSONDeserializerTest.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 final class CreateEventJSONDeserializerTest extends TestCase
@@ -19,7 +20,7 @@ final class CreateEventJSONDeserializerTest extends TestCase
      */
     public function it_can_serialize_create_event_with_main_language(): void
     {
-        $createEventAsJson = file_get_contents(__DIR__ . '/../samples/event-create-with-main-language.json');
+        $createEventAsJson = SampleFiles::read(__DIR__ . '/../samples/event-create-with-main-language.json');
 
         $createEventJSONDeserializer = new CreateEventJSONDeserializer();
 

--- a/tests/Http/Deserializer/Event/MajorInfoJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Event/MajorInfoJSONDeserializerTest.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Calendar\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 final class MajorInfoJSONDeserializerTest extends TestCase
@@ -18,7 +19,7 @@ final class MajorInfoJSONDeserializerTest extends TestCase
      */
     public function it_can_serialize_major_info(): void
     {
-        $majorInfoAsJson = file_get_contents(__DIR__ . '/../samples/event-major-info.json');
+        $majorInfoAsJson = SampleFiles::read(__DIR__ . '/../samples/event-major-info.json');
 
         $majorInfoJSONDeserializer = new MajorInfoJSONDeserializer();
 
@@ -37,7 +38,7 @@ final class MajorInfoJSONDeserializerTest extends TestCase
      */
     public function it_can_serialize_major_info_with_a_nested_location_id(): void
     {
-        $majorInfoAsJson = file_get_contents(__DIR__ . '/../samples/event-major-info-with-nested-location-id.json');
+        $majorInfoAsJson = SampleFiles::read(__DIR__ . '/../samples/event-major-info-with-nested-location-id.json');
 
         $majorInfoJSONDeserializer = new MajorInfoJSONDeserializer();
 

--- a/tests/Http/Deserializer/Place/CreatePlaceJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Place/CreatePlaceJSONDeserializerTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 final class CreatePlaceJSONDeserializerTest extends TestCase
@@ -23,7 +24,7 @@ final class CreatePlaceJSONDeserializerTest extends TestCase
      */
     public function it_can_serialize_create_place_with_main_language_info(): void
     {
-        $createPlaceAsJson = file_get_contents(__DIR__ . '/../samples/place-create-with-main-language.json');
+        $createPlaceAsJson = SampleFiles::read(__DIR__ . '/../samples/place-create-with-main-language.json');
 
         $createPlaceJSONDeserializer = new CreatePlaceJSONDeserializer();
 

--- a/tests/Http/Deserializer/Place/MajorInfoJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Place/MajorInfoJSONDeserializerTest.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Calendar\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 final class MajorInfoJSONDeserializerTest extends TestCase
@@ -22,7 +23,7 @@ final class MajorInfoJSONDeserializerTest extends TestCase
      */
     public function it_can_serialize_major_info(): void
     {
-        $majorInfoAsJson = file_get_contents(__DIR__ . '/../samples/place-major-info.json');
+        $majorInfoAsJson = SampleFiles::read(__DIR__ . '/../samples/place-major-info.json');
 
         $majorInfoJSONDeserializer = new MajorInfoJSONDeserializer();
 

--- a/tests/Http/Offer/GetDetailRequestHandlerTest.php
+++ b/tests/Http/Offer/GetDetailRequestHandlerTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\OfferJsonDocumentReadRepositoryMockFactory;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\SampleFiles;
 use EasyRdf\Graph;
 use EasyRdf\Serialiser\Turtle;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -94,7 +95,7 @@ class GetDetailRequestHandlerTest extends TestCase
         $response = $this->getDetailRequestHandler->handle($request);
 
         $this->assertEquals(
-            file_get_contents(__DIR__ . '/samples/event.ttl'),
+            SampleFiles::read(__DIR__ . '/samples/event.ttl'),
             $response->getBody()->getContents()
         );
     }
@@ -150,7 +151,7 @@ class GetDetailRequestHandlerTest extends TestCase
         $response = $this->getDetailRequestHandler->handle($request);
 
         $this->assertEquals(
-            file_get_contents(__DIR__ . '/samples/place.ttl'),
+            SampleFiles::read(__DIR__ . '/samples/place.ttl'),
             $response->getBody()->getContents()
         );
     }

--- a/tests/Http/Organizer/GetOrganizerRequestHandlerTest.php
+++ b/tests/Http/Organizer/GetOrganizerRequestHandlerTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\SampleFiles;
 use EasyRdf\Graph;
 use EasyRdf\Serialiser\Turtle;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -102,7 +103,7 @@ class GetOrganizerRequestHandlerTest extends TestCase
         $response = $this->getOrganizerRequestHandler->handle($getOrganizerRequest);
 
         $this->assertEquals(
-            file_get_contents(__DIR__ . '/samples/organizer.ttl'),
+            SampleFiles::read(__DIR__ . '/samples/organizer.ttl'),
             $response->getBody()->getContents()
         );
     }

--- a/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
+++ b/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
@@ -25,6 +25,7 @@ use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
 use CultuurNet\UDB3\Model\ValueObject\Text\Description;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\SampleFiles;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
@@ -222,7 +223,7 @@ final class KinepolisMovieParserTest extends TestCase
                 ))->withDescription(new Description($description)),
             ],
             $this->parser->getParsedMovies(
-                Json::decodeAssociatively(file_get_contents(__DIR__ . '/../samples/KinepolisMovieDetailResponse.json')),
+                Json::decodeAssociatively(SampleFiles::read(__DIR__ . '/../samples/KinepolisMovieDetailResponse.json')),
                 [
                     'KOOST' => new ParsedPriceForATheater(
                         1000,
@@ -372,7 +373,7 @@ final class KinepolisMovieParserTest extends TestCase
                 ),
             ],
             $this->parser->getParsedMovies(
-                Json::decodeAssociatively(file_get_contents(__DIR__ . '/../samples/KinepolisMovieDetailResponseWithEmptyDescription.json')),
+                Json::decodeAssociatively(SampleFiles::read(__DIR__ . '/../samples/KinepolisMovieDetailResponseWithEmptyDescription.json')),
                 [
                     'KOOST' => new ParsedPriceForATheater(
                         1000,

--- a/tests/Label/ReadModels/Relations/ProjectorTest.php
+++ b/tests/Label/ReadModels/Relations/ProjectorTest.php
@@ -34,6 +34,7 @@ use CultuurNet\UDB3\Place\Events\LabelRemoved as LabelRemovedFromPlace;
 use CultuurNet\UDB3\Place\Events\LabelsImported as PlaceLabelsImported;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use CultuurNet\UDB3\Place\Events\PlaceUpdatedFromUDB2;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -303,7 +304,7 @@ final class ProjectorTest extends TestCase
             $itemId,
             new OrganizerUpdatedFromUDB2(
                 $itemId,
-                file_get_contents(__DIR__ . '/Samples/organizer_with_same_label_but_different_casing.xml'),
+                SampleFiles::read(__DIR__ . '/Samples/organizer_with_same_label_but_different_casing.xml'),
                 $cdbXmlNamespaceUri
             )
         );
@@ -343,7 +344,7 @@ final class ProjectorTest extends TestCase
                 $itemId,
                 new EventImportedFromUDB2(
                     $itemId,
-                    file_get_contents(__DIR__ . '/Samples/event.xml'),
+                    SampleFiles::read(__DIR__ . '/Samples/event.xml'),
                     $cdbXmlNamespaceUri
                 ),
                 RelationType::event(),
@@ -352,7 +353,7 @@ final class ProjectorTest extends TestCase
                 $itemId,
                 new PlaceImportedFromUDB2(
                     $itemId,
-                    file_get_contents(__DIR__ . '/Samples/place.xml'),
+                    SampleFiles::read(__DIR__ . '/Samples/place.xml'),
                     $cdbXmlNamespaceUri
                 ),
                 RelationType::place(),
@@ -361,7 +362,7 @@ final class ProjectorTest extends TestCase
                 $itemId,
                 new OrganizerImportedFromUDB2(
                     $itemId,
-                    file_get_contents(__DIR__ . '/Samples/organizer.xml'),
+                    SampleFiles::read(__DIR__ . '/Samples/organizer.xml'),
                     $cdbXmlNamespaceUri
                 ),
                 RelationType::organizer(),
@@ -370,7 +371,7 @@ final class ProjectorTest extends TestCase
                 $itemId,
                 new EventUpdatedFromUDB2(
                     $itemId,
-                    file_get_contents(__DIR__ . '/Samples/event.xml'),
+                    SampleFiles::read(__DIR__ . '/Samples/event.xml'),
                     $cdbXmlNamespaceUri
                 ),
                 RelationType::event(),
@@ -379,7 +380,7 @@ final class ProjectorTest extends TestCase
                 $itemId,
                 new PlaceUpdatedFromUDB2(
                     $itemId,
-                    file_get_contents(__DIR__ . '/Samples/place.xml'),
+                    SampleFiles::read(__DIR__ . '/Samples/place.xml'),
                     $cdbXmlNamespaceUri
                 ),
                 RelationType::place(),
@@ -388,7 +389,7 @@ final class ProjectorTest extends TestCase
                 $itemId,
                 new OrganizerUpdatedFromUDB2(
                     $itemId,
-                    file_get_contents(__DIR__ . '/Samples/organizer.xml'),
+                    SampleFiles::read(__DIR__ . '/Samples/organizer.xml'),
                     $cdbXmlNamespaceUri
                 ),
                 RelationType::organizer(),
@@ -397,7 +398,7 @@ final class ProjectorTest extends TestCase
                 $itemId,
                 new OrganizerUpdatedFromUDB2(
                     $itemId,
-                    file_get_contents(__DIR__ . '/Samples/organizer_with_same_label_but_different_casing.xml'),
+                    SampleFiles::read(__DIR__ . '/Samples/organizer_with_same_label_but_different_casing.xml'),
                     $cdbXmlNamespaceUri
                 ),
                 RelationType::organizer(),
@@ -406,7 +407,7 @@ final class ProjectorTest extends TestCase
                 $itemId,
                 new OrganizerUpdatedFromUDB2(
                     $itemId,
-                    file_get_contents(__DIR__ . '/Samples/organizer_with_same_label_but_different_casing_and_visibility.xml'),
+                    SampleFiles::read(__DIR__ . '/Samples/organizer_with_same_label_but_different_casing_and_visibility.xml'),
                     $cdbXmlNamespaceUri
                 ),
                 RelationType::organizer(),

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -62,6 +62,7 @@ use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
 use CultuurNet\UDB3\RecordedOn;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -125,7 +126,7 @@ final class OrganizerLDProjectorTest extends TestCase
 
     private function organizerImportedFromUDB2(string $fileName): OrganizerImportedFromUDB2
     {
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/Samples/' . $fileName
         );
 
@@ -140,7 +141,7 @@ final class OrganizerLDProjectorTest extends TestCase
 
     private function organizerUpdatedFromUDB2(string $fileName): OrganizerUpdatedFromUDB2
     {
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/Samples/' . $fileName
         );
 
@@ -870,7 +871,7 @@ final class OrganizerLDProjectorTest extends TestCase
         // First make sure there is an already created organizer.
         $organizerId = 'someId';
 
-        $organizerJson = file_get_contents(__DIR__ . '/Samples/organizer_with_main_language.json');
+        $organizerJson = SampleFiles::read(__DIR__ . '/Samples/organizer_with_main_language.json');
         $organizerJson = Json::decode($organizerJson);
         $organizerJson->name->en = 'English name';
         $organizerJson = Json::encode($organizerJson);
@@ -1311,7 +1312,7 @@ final class OrganizerLDProjectorTest extends TestCase
 
     private function mockGet(string $organizerId, string $fileName): void
     {
-        $organizerJson = file_get_contents(__DIR__ . '/Samples/' . $fileName);
+        $organizerJson = SampleFiles::read(__DIR__ . '/Samples/' . $fileName);
         $this->documentRepository->method('fetch')
             ->with($organizerId)
             ->willReturn(new JsonDocument($organizerId, $organizerJson));
@@ -1319,7 +1320,7 @@ final class OrganizerLDProjectorTest extends TestCase
 
     private function expectSave(string $organizerId, string $fileName): void
     {
-        $expectedOrganizerJson = file_get_contents(__DIR__ . '/Samples/' . $fileName);
+        $expectedOrganizerJson = SampleFiles::read(__DIR__ . '/Samples/' . $fileName);
         // The expected organizer json still has newline formatting.
         // The actual organizer json on the other hand has no newlines
         // because it was created by using the withBody method on JsonDocument.

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -49,6 +49,7 @@ use CultuurNet\UDB3\Organizer\Events\OwnerChanged;
 use CultuurNet\UDB3\Organizer\Events\TitleTranslated;
 use CultuurNet\UDB3\Organizer\Events\TitleUpdated;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
+use CultuurNet\UDB3\SampleFiles;
 
 class OrganizerTest extends AggregateRootScenarioTestCase
 {
@@ -1562,6 +1563,6 @@ class OrganizerTest extends AggregateRootScenarioTestCase
 
     private function getCdbXML(string $filename): string
     {
-        return file_get_contents(__DIR__ . '/' . $filename);
+        return SampleFiles::read(__DIR__ . '/' . $filename);
     }
 }

--- a/tests/Organizer/ProcessManager/GeoCoordinatesProcessManagerTest.php
+++ b/tests/Organizer/ProcessManager/GeoCoordinatesProcessManagerTest.php
@@ -19,6 +19,7 @@ use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
 use CultuurNet\UDB3\Organizer\Events\OrganizerImportedFromUDB2;
 use CultuurNet\UDB3\Organizer\Events\OrganizerUpdatedFromUDB2;
+use CultuurNet\UDB3\SampleFiles;
 use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -114,7 +115,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
             new Metadata([]),
             new OrganizerImportedFromUDB2(
                 '318F2ACB-F612-6F75-0037C9C29F44087A',
-                file_get_contents(__DIR__ . '/../Samples/actor.xml'),
+                SampleFiles::read(__DIR__ . '/../Samples/actor.xml'),
                 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
             )
         );
@@ -181,7 +182,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new OrganizerImportedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/../Samples/actor.xml'),
+                        SampleFiles::read(__DIR__ . '/../Samples/actor.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),
@@ -202,7 +203,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new OrganizerUpdatedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/../Samples/actor.xml'),
+                        SampleFiles::read(__DIR__ . '/../Samples/actor.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),
@@ -229,7 +230,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new OrganizerImportedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/../Samples/actor_without_contactinfo.xml'),
+                        SampleFiles::read(__DIR__ . '/../Samples/actor_without_contactinfo.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),
@@ -250,7 +251,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new OrganizerUpdatedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/../Samples/actor_without_contactinfo.xml'),
+                        SampleFiles::read(__DIR__ . '/../Samples/actor_without_contactinfo.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),
@@ -271,7 +272,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new OrganizerImportedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/../Samples/actor_without_physical_address.xml'),
+                        SampleFiles::read(__DIR__ . '/../Samples/actor_without_physical_address.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),
@@ -292,7 +293,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new OrganizerUpdatedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/../Samples/actor_without_physical_address.xml'),
+                        SampleFiles::read(__DIR__ . '/../Samples/actor_without_physical_address.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),

--- a/tests/Organizer/ReadModel/RDF/OrganizerJsonToTurtleConverterTest.php
+++ b/tests/Organizer/ReadModel/RDF/OrganizerJsonToTurtleConverterTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -75,7 +76,7 @@ class OrganizerJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->organizerJsonToTurtleConverter->convert($this->organizerId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/organizer.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/organizer.ttl'), $turtle);
     }
 
     /**
@@ -91,7 +92,7 @@ class OrganizerJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->organizerJsonToTurtleConverter->convert($this->organizerId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/organizer-deleted.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/organizer-deleted.ttl'), $turtle);
     }
 
     /**
@@ -116,7 +117,7 @@ class OrganizerJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->organizerJsonToTurtleConverter->convert($organizerId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/organizer-without-homepage.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/organizer-without-homepage.ttl'), $turtle);
     }
 
     /**
@@ -141,7 +142,7 @@ class OrganizerJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->organizerJsonToTurtleConverter->convert($organizerId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/organizer.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/organizer.ttl'), $turtle);
     }
 
     /**
@@ -168,7 +169,7 @@ class OrganizerJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->organizerJsonToTurtleConverter->convert($this->organizerId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/organizer-with-address.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/organizer-with-address.ttl'), $turtle);
     }
 
     /**
@@ -198,7 +199,7 @@ class OrganizerJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->organizerJsonToTurtleConverter->convert($this->organizerId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/organizer-with-contact-point.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/organizer-with-contact-point.ttl'), $turtle);
     }
 
     /**
@@ -221,7 +222,7 @@ class OrganizerJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->organizerJsonToTurtleConverter->convert($this->organizerId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/organizer-with-labels.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/organizer-with-labels.ttl'), $turtle);
     }
 
     private function givenThereIsAnOrganizer(array $extraProperties = []): void

--- a/tests/Place/Events/PlaceImportedFromUDB2Test.php
+++ b/tests/Place/Events/PlaceImportedFromUDB2Test.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\EventSourcing\MainLanguageDefined;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 final class PlaceImportedFromUDB2Test extends TestCase
@@ -22,7 +23,7 @@ final class PlaceImportedFromUDB2Test extends TestCase
     {
         $event = new PlaceImportedFromUDB2(
             '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3',
-            file_get_contents(__DIR__ . '/../actor.xml'),
+            SampleFiles::read(__DIR__ . '/../actor.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -37,7 +38,7 @@ final class PlaceImportedFromUDB2Test extends TestCase
     {
         $placeImportedFromUDB2 = new PlaceImportedFromUDB2(
             '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3',
-            file_get_contents(__DIR__ . '/../actor.xml'),
+            SampleFiles::read(__DIR__ . '/../actor.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -66,7 +67,7 @@ final class PlaceImportedFromUDB2Test extends TestCase
         $placeId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $placeImportedFromUDB2 = new PlaceImportedFromUDB2(
             $placeId,
-            file_get_contents(__DIR__ . '/../actor_with_translations.xml'),
+            SampleFiles::read(__DIR__ . '/../actor_with_translations.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -97,7 +98,7 @@ final class PlaceImportedFromUDB2Test extends TestCase
         $placeId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $placeImportedFromUDB2 = new PlaceImportedFromUDB2(
             $placeId,
-            file_get_contents(__DIR__ . '/../actor_without_street.xml'),
+            SampleFiles::read(__DIR__ . '/../actor_without_street.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -126,7 +127,7 @@ final class PlaceImportedFromUDB2Test extends TestCase
         $placeId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $placeImportedFromUDB2 = new PlaceImportedFromUDB2(
             $placeId,
-            file_get_contents(__DIR__ . '/../actor_without_housnr.xml'),
+            SampleFiles::read(__DIR__ . '/../actor_without_housnr.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -155,7 +156,7 @@ final class PlaceImportedFromUDB2Test extends TestCase
         $placeId = 'f6dfcd9d-e43a-4e94-a87e-70253ee77689';
         $placeImportedFromUDB2 = new PlaceImportedFromUDB2(
             $placeId,
-            file_get_contents(__DIR__ . '/../actor_without_address.xml'),
+            SampleFiles::read(__DIR__ . '/../actor_without_address.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
         );
 
@@ -201,7 +202,7 @@ final class PlaceImportedFromUDB2Test extends TestCase
                 ],
                 new PlaceImportedFromUDB2(
                     '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3',
-                    file_get_contents(__DIR__ . '/../actor3.3.xml'),
+                    SampleFiles::read(__DIR__ . '/../actor3.3.xml'),
                     'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
                 ),
             ],
@@ -221,7 +222,7 @@ final class PlaceImportedFromUDB2Test extends TestCase
                 ],
                 new PlaceImportedFromUDB2(
                     '782c9792-6067-438d-a246-064bb448f086',
-                    file_get_contents(__DIR__ . '/../actor_with_root_node.xml'),
+                    SampleFiles::read(__DIR__ . '/../actor_with_root_node.xml'),
                     'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL'
                 ),
             ],

--- a/tests/Place/Events/PlaceUpdatedFromUDB2Test.php
+++ b/tests/Place/Events/PlaceUpdatedFromUDB2Test.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 final class PlaceUpdatedFromUDB2Test extends TestCase
@@ -21,7 +22,7 @@ final class PlaceUpdatedFromUDB2Test extends TestCase
     {
         $placeUpdatedFromUDB2 = new PlaceUpdatedFromUDB2(
             '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3',
-            file_get_contents(__DIR__ . '/../actor.xml'),
+            SampleFiles::read(__DIR__ . '/../actor.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -50,7 +51,7 @@ final class PlaceUpdatedFromUDB2Test extends TestCase
         $placeId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $placeUpdatedFromUDB2 = new PlaceUpdatedFromUDB2(
             $placeId,
-            file_get_contents(__DIR__ . '/../actor_with_translations.xml'),
+            SampleFiles::read(__DIR__ . '/../actor_with_translations.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -81,7 +82,7 @@ final class PlaceUpdatedFromUDB2Test extends TestCase
         $placeId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $placeUpdatedFromUDB2 = new PlaceUpdatedFromUDB2(
             $placeId,
-            file_get_contents(__DIR__ . '/../actor_without_street.xml'),
+            SampleFiles::read(__DIR__ . '/../actor_without_street.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 
@@ -110,7 +111,7 @@ final class PlaceUpdatedFromUDB2Test extends TestCase
         $placeId = '0452b4ae-7c18-4b33-a6c6-eba2288c9ac3';
         $placeUpdatedFromUDB2 = new PlaceUpdatedFromUDB2(
             $placeId,
-            file_get_contents(__DIR__ . '/../actor_without_housnr.xml'),
+            SampleFiles::read(__DIR__ . '/../actor_without_housnr.xml'),
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
 

--- a/tests/Place/GeoCoordinatesProcessManagerTest.php
+++ b/tests/Place/GeoCoordinatesProcessManagerTest.php
@@ -29,6 +29,7 @@ use CultuurNet\UDB3\Place\Events\PlaceUpdatedFromUDB2;
 use CultuurNet\UDB3\Place\Events\TitleUpdated;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -137,7 +138,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
             new Metadata([]),
             new PlaceImportedFromUDB2(
                 '318F2ACB-F612-6F75-0037C9C29F44087A',
-                file_get_contents(__DIR__ . '/actor.xml'),
+                SampleFiles::read(__DIR__ . '/actor.xml'),
                 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
             )
         );
@@ -269,7 +270,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new PlaceImportedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/actor.xml'),
+                        SampleFiles::read(__DIR__ . '/actor.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),
@@ -290,7 +291,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new PlaceUpdatedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/actor.xml'),
+                        SampleFiles::read(__DIR__ . '/actor.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),
@@ -320,7 +321,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new PlaceImportedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/actor_without_contactinfo.xml'),
+                        SampleFiles::read(__DIR__ . '/actor_without_contactinfo.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),
@@ -341,7 +342,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new PlaceUpdatedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/actor_without_contactinfo.xml'),
+                        SampleFiles::read(__DIR__ . '/actor_without_contactinfo.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),
@@ -362,7 +363,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new PlaceImportedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/actor_without_physical_address.xml'),
+                        SampleFiles::read(__DIR__ . '/actor_without_physical_address.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),
@@ -383,7 +384,7 @@ class GeoCoordinatesProcessManagerTest extends TestCase
                     new Metadata([]),
                     new PlaceUpdatedFromUDB2(
                         '318F2ACB-F612-6F75-0037C9C29F44087A',
-                        file_get_contents(__DIR__ . '/actor_without_physical_address.xml'),
+                        SampleFiles::read(__DIR__ . '/actor_without_physical_address.xml'),
                         'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
                     )
                 ),

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -38,6 +38,7 @@ use CultuurNet\UDB3\Place\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Money\Currency;
 use Money\Money;
@@ -51,7 +52,7 @@ class PlaceTest extends AggregateRootScenarioTestCase
 
     private function getCdbXML(string $filename): string
     {
-        return file_get_contents(__DIR__ . $filename);
+        return SampleFiles::read(__DIR__ . $filename);
     }
 
     /**

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -76,6 +76,7 @@ use CultuurNet\UDB3\Place\Events\VideoUpdated;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\SampleFiles;
 use DateTimeImmutable;
 use Money\Currency;
 use Money\Money;
@@ -1131,6 +1132,6 @@ class HistoryProjectorTest extends TestCase
 
     private function getActorCdbXml(): string
     {
-        return file_get_contents(__DIR__ . '/actor.xml');
+        return SampleFiles::read(__DIR__ . '/actor.xml');
     }
 }

--- a/tests/Place/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Place/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
+use CultuurNet\UDB3\SampleFiles;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -55,7 +56,7 @@ class CdbXMLImporterTest extends TestCase
      */
     private function createJsonPlaceFromCdbXml($fileName, $version = '3.2')
     {
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/' . $fileName
         );
 
@@ -78,7 +79,7 @@ class CdbXMLImporterTest extends TestCase
      */
     private function createJsonPlaceFromCdbXmlWithWeekScheme($fileName)
     {
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/Calendar/' . $fileName
         );
 

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -48,6 +48,7 @@ use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use CultuurNet\UDB3\Place\Events\PlaceUpdatedFromUDB2;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
+use CultuurNet\UDB3\SampleFiles;
 use stdClass;
 
 class PlaceLDProjectorTest extends OfferLDProjectorTestBase
@@ -542,7 +543,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $placeImportedFromUdb2 = $this->placeImportedFromUDB2('place_with_short_description.cdbxml.xml');
         $actorId = $placeImportedFromUdb2->getActorId();
 
-        $cdbXml = file_get_contents(__DIR__ . '/place_with_short_and_long_description.cdbxml.xml');
+        $cdbXml = SampleFiles::read(__DIR__ . '/place_with_short_and_long_description.cdbxml.xml');
         $placeUpdatedFromUdb2 = new PlaceUpdatedFromUDB2(
             $actorId,
             $cdbXml,
@@ -565,7 +566,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $placeDeleted = new PlaceDeleted($actorId);
         $this->project($placeDeleted, $actorId);
 
-        $cdbXml = file_get_contents(__DIR__ . '/place_with_short_and_long_description.cdbxml.xml');
+        $cdbXml = SampleFiles::read(__DIR__ . '/place_with_short_and_long_description.cdbxml.xml');
         $placeUpdatedFromUdb2 = new PlaceUpdatedFromUDB2(
             $actorId,
             $cdbXml,
@@ -649,7 +650,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
             ],
         ];
 
-        $cdbXml = file_get_contents(__DIR__ . '/place_with_long_description.cdbxml.xml');
+        $cdbXml = SampleFiles::read(__DIR__ . '/place_with_long_description.cdbxml.xml');
         $placeUpdatedFromUdb2 = new PlaceUpdatedFromUDB2(
             '66f30742-dee9-4794-ac92-fa44634692b8',
             $cdbXml,
@@ -979,7 +980,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
 
         $this->documentRepository->save($initialDocument);
 
-        $cdbXml = file_get_contents(__DIR__ . '/place_with_long_description.cdbxml.xml');
+        $cdbXml = SampleFiles::read(__DIR__ . '/place_with_long_description.cdbxml.xml');
         $placeUpdatedFromUdb2 = new PlaceUpdatedFromUDB2(
             '318F2ACB-F612-6F75-0037C9C29F44087A',
             $cdbXml,
@@ -993,7 +994,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
 
     private function placeImportedFromUDB2(string $fileName): PlaceImportedFromUDB2
     {
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/' . $fileName
         );
         $event = new PlaceImportedFromUDB2(
@@ -1007,7 +1008,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
 
     private function placeUpdatedFromUDB2(string $fileName): PlaceUpdatedFromUDB2
     {
-        $cdbXml = file_get_contents(
+        $cdbXml = SampleFiles::read(
             __DIR__ . '/' . $fileName
         );
         $event = new PlaceUpdatedFromUDB2(

--- a/tests/Place/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Place/ReadModel/Permission/ProjectorTest.php
@@ -19,6 +19,7 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Place\Events\OwnerChanged;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -53,7 +54,7 @@ final class ProjectorTest extends TestCase
      */
     public function it_adds_permission_to_the_user_identified_by_the_createdby_element_for_places_imported_from_udb2_actor(): void
     {
-        $cdbXml = file_get_contents(__DIR__ . '/../../actor.xml');
+        $cdbXml = SampleFiles::read(__DIR__ . '/../../actor.xml');
         $cdbXmlNamespaceUri = \CultureFeed_Cdb_Xml::namespaceUriForVersion('3.2');
 
         $payload = new PlaceImportedFromUDB2(
@@ -90,7 +91,7 @@ final class ProjectorTest extends TestCase
      */
     public function it_does_not_add_any_permissions_for_actor_places_imported_from_udb2_with_unresolvable_createdby_value(): void
     {
-        $cdbXml = file_get_contents(__DIR__ . '/../../actor.xml');
+        $cdbXml = SampleFiles::read(__DIR__ . '/../../actor.xml');
         $cdbXmlNamespaceUri = \CultureFeed_Cdb_Xml::namespaceUriForVersion('3.2');
 
         $payload = new PlaceImportedFromUDB2(

--- a/tests/Place/ReadModel/RDF/PlaceJsonToTurtleConverterTest.php
+++ b/tests/Place/ReadModel/RDF/PlaceJsonToTurtleConverterTest.php
@@ -20,6 +20,7 @@ use CultuurNet\UDB3\RDF\JsonDataCouldNotBeConverted;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\SampleFiles;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -178,7 +179,7 @@ class PlaceJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->placeJsonToTurtleConverter->convert($this->placeId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/place.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/place.ttl'), $turtle);
     }
 
     /**
@@ -224,7 +225,7 @@ class PlaceJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->placeJsonToTurtleConverter->convert($this->placeId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/place-with-translations.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/place-with-translations.ttl'), $turtle);
     }
 
     /**
@@ -241,7 +242,7 @@ class PlaceJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->placeJsonToTurtleConverter->convert($this->placeId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/place-with-coordinates.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/place-with-coordinates.ttl'), $turtle);
     }
 
     /**
@@ -256,7 +257,7 @@ class PlaceJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->placeJsonToTurtleConverter->convert($this->placeId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/' . $file), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/' . $file), $turtle);
     }
 
     public function workflowStatusDataProvider(): array
@@ -297,7 +298,7 @@ class PlaceJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->placeJsonToTurtleConverter->convert($this->placeId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/place-with-publication-date.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/place-with-publication-date.ttl'), $turtle);
     }
 
     /**
@@ -318,7 +319,7 @@ class PlaceJsonToTurtleConverterTest extends TestCase
 
         $turtle = $this->placeJsonToTurtleConverter->convert($this->placeId);
 
-        $this->assertEquals(file_get_contents(__DIR__ . '/ttl/place-with-labels.ttl'), $turtle);
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/place-with-labels.ttl'), $turtle);
     }
 
     private function expectParsedAddress(LegacyAddress $address, ParsedAddress $parsedAddress): void

--- a/tests/Place/ReadModel/Relations/PlaceRelationsProjectorTest.php
+++ b/tests/Place/ReadModel/Relations/PlaceRelationsProjectorTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Place\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Place\Events\OrganizerUpdated;
 use CultuurNet\UDB3\Place\Events\PlaceDeleted;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -48,7 +49,7 @@ final class PlaceRelationsProjectorTest extends TestCase
      */
     public function it_stores_empty_relation_when_place_imported_from_udb2(): void
     {
-        $xml = file_get_contents(__DIR__ . '/place_imported_from_udb2.cdbxml.xml');
+        $xml = SampleFiles::read(__DIR__ . '/place_imported_from_udb2.cdbxml.xml');
 
         $placeCreatedFromCdbXml = new PlaceImportedFromUDB2(
             self::PLACE_ID,

--- a/tests/RDF/CacheGraphRepositoryTest.php
+++ b/tests/RDF/CacheGraphRepositoryTest.php
@@ -6,6 +6,7 @@ namespace RDF;
 
 use CultuurNet\UDB3\RDF\CacheGraphRepository;
 use CultuurNet\UDB3\RDF\GraphNotFound;
+use CultuurNet\UDB3\SampleFiles;
 use Doctrine\Common\Cache\Cache;
 use EasyRdf\Graph;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -41,7 +42,7 @@ class CacheGraphRepositoryTest extends TestCase
     {
         $this->cache->expects($this->once())
             ->method('save')
-            ->with($this->uri, file_get_contents(__DIR__ . '/event.ttl'));
+            ->with($this->uri, SampleFiles::read(__DIR__ . '/event.ttl'));
 
         $this->cacheGraphRepository->save($this->uri, $this->graph);
     }
@@ -54,7 +55,7 @@ class CacheGraphRepositoryTest extends TestCase
         $this->cache->expects($this->once())
             ->method('fetch')
             ->with($this->uri)
-            ->willReturn(file_get_contents(__DIR__ . '/event.ttl'));
+            ->willReturn(SampleFiles::read(__DIR__ . '/event.ttl'));
 
         $graph = $this->cacheGraphRepository->get($this->uri);
 

--- a/tests/SampleFiles.php
+++ b/tests/SampleFiles.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3;
+
+final class SampleFiles
+{
+    public static function read(string $filepath): string
+    {
+        $content = file_get_contents($filepath);
+
+        if ($content === false) {
+            throw new \RuntimeException('Failed to read file ' . $filepath);
+        }
+
+        return $content;
+    }
+}

--- a/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
+++ b/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SavedSearches\Command;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use PHPUnit\Framework\TestCase;
 
@@ -73,6 +74,6 @@ final class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
 
     private function getStringFromFile(string $fileName): string
     {
-        return file_get_contents(__DIR__ . '/' . $fileName);
+        return SampleFiles::read(__DIR__ . '/' . $fileName);
     }
 }

--- a/tests/SavedSearches/Command/UpdateSavedSearchJSONDeserializerTest.php
+++ b/tests/SavedSearches/Command/UpdateSavedSearchJSONDeserializerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SavedSearches\Command;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
+use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use PHPUnit\Framework\TestCase;
 
@@ -74,6 +75,6 @@ final class UpdateSavedSearchJSONDeserializerTest extends TestCase
 
     private function getStringFromFile(string $fileName): string
     {
-        return file_get_contents(__DIR__ . '/' . $fileName);
+        return SampleFiles::read(__DIR__ . '/' . $fileName);
     }
 }

--- a/tests/Search/Sapi3SearchServiceTest.php
+++ b/tests/Search/Sapi3SearchServiceTest.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifierFactory;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifiers;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\SampleFiles;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
@@ -44,7 +45,7 @@ class Sapi3SearchServiceTest extends TestCase
      */
     public function it_should_fetch_search_results_from_sapi_3(): void
     {
-        $searchResponse = new Response(200, [], file_get_contents(__DIR__ . '/samples/search-response.json'));
+        $searchResponse = new Response(200, [], SampleFiles::read(__DIR__ . '/samples/search-response.json'));
 
         $expectedRequest = new Request(
             'GET',
@@ -83,7 +84,7 @@ class Sapi3SearchServiceTest extends TestCase
      */
     public function it_should_properly_encode_plus_signs_in_queries(): void
     {
-        $searchResponse = new Response(200, [], file_get_contents(__DIR__ . '/samples/search-response.json'));
+        $searchResponse = new Response(200, [], SampleFiles::read(__DIR__ . '/samples/search-response.json'));
 
         $expectedRequest = new Request(
             'GET',

--- a/tests/SerializableSerializableSimpleXmlElementTest.php
+++ b/tests/SerializableSerializableSimpleXmlElementTest.php
@@ -14,7 +14,7 @@ final class SerializableSerializableSimpleXmlElementTest extends TestCase
     public function it_can_serialize_a_complex_xml(): void
     {
         $cdbXml = new SerializableSimpleXmlElement(
-            file_get_contents(__DIR__ . '/Place/actor.xml'),
+            SampleFiles::read(__DIR__ . '/Place/actor.xml'),
             0,
             false,
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'

--- a/tests/StringFilter/ConsecutiveBlockOfTextStringFilterTest.php
+++ b/tests/StringFilter/ConsecutiveBlockOfTextStringFilterTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\StringFilter;
 
+use CultuurNet\UDB3\SampleFiles;
+
 class ConsecutiveBlockOfTextStringFilterTest extends StringFilterTest
 {
     protected function getFilter(): StringFilterInterface
@@ -17,8 +19,8 @@ class ConsecutiveBlockOfTextStringFilterTest extends StringFilterTest
     public function it_formats_string_as_a_consecutive_single_line_of_text(): void
     {
         $this->assertFilterValue(
-            file_get_contents(__DIR__ . '/text_consecutive_block.txt'),
-            file_get_contents(__DIR__ . '/text_surrounded_by_whitespace.txt')
+            SampleFiles::read(__DIR__ . '/text_consecutive_block.txt'),
+            SampleFiles::read(__DIR__ . '/text_surrounded_by_whitespace.txt')
         );
     }
 }

--- a/tests/StringFilter/StripSurroundingSpaceStringFilterTest.php
+++ b/tests/StringFilter/StripSurroundingSpaceStringFilterTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\StringFilter;
 
+use CultuurNet\UDB3\SampleFiles;
+
 class StripSurroundingSpaceStringFilterTest extends StringFilterTest
 {
     protected function getFilter(): StripSurroundingSpaceStringFilter
@@ -17,8 +19,8 @@ class StripSurroundingSpaceStringFilterTest extends StringFilterTest
     public function it_strips_leading_and_trailing_space_and_tabs(): void
     {
         $this->assertFilterValue(
-            file_get_contents(__DIR__ . '/text_without_surrounding_whitespace.txt'),
-            file_get_contents(__DIR__ . '/text_surrounded_by_whitespace.txt')
+            SampleFiles::read(__DIR__ . '/text_without_surrounding_whitespace.txt'),
+            SampleFiles::read(__DIR__ . '/text_surrounded_by_whitespace.txt')
         );
     }
 }

--- a/tests/UiTPASService/Controller/Response/CardSystemsJsonResponseTest.php
+++ b/tests/UiTPASService/Controller/Response/CardSystemsJsonResponseTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\UiTPASService\Controller\Response;
 use CultureFeed_Uitpas_CardSystem;
 use CultureFeed_Uitpas_DistributionKey;
 use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\SampleFiles;
 use PHPUnit\Framework\TestCase;
 
 class CardSystemsJsonResponseTest extends TestCase
@@ -52,7 +53,7 @@ class CardSystemsJsonResponseTest extends TestCase
 
         $response = new CardSystemsJsonResponse($cardSystems);
 
-        $expected = Json::decode(file_get_contents(__DIR__ . '/data/cardSystems.json'));
+        $expected = Json::decode(SampleFiles::read(__DIR__ . '/data/cardSystems.json'));
         $actual = Json::decode($response->getBody()->getContents());
 
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
### Changed
- Replace `file_get_contents` with a wrapper method that always returns a string in case of error throws. This fixes the warning about the extra boolean return type.

---
Ticket: https://jira.uitdatabank.be/browse/III-3558
