### PR TITLE
III-3558 Replace `DateTime::createFromFormat` with `DateTimeFactory::fromFormat`

### DIFF
--- a/src/Calendar/CalendarFactory.php
+++ b/src/Calendar/CalendarFactory.php
@@ -196,7 +196,7 @@ class CalendarFactory implements CalendarFactoryInterface
                 }
 
                 foreach ($openingTimes as $openingTime) {
-                    $opens = \DateTime::createFromFormat(
+                    $opens = \CultuurNet\UDB3\DateTimeFactory::fromFormat(
                         'H:i:s',
                         $openingTime->getOpenFrom()
                     );

--- a/src/Calendar/OpeningTime.php
+++ b/src/Calendar/OpeningTime.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Calendar;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Time;
@@ -38,7 +39,7 @@ class OpeningTime
     public static function fromNativeString(string $time): OpeningTime
     {
         return self::fromNativeDateTime(
-            \DateTime::createFromFormat('H:i', $time)
+            DateTimeFactory::fromFormat('H:i', $time)
         );
     }
 

--- a/src/Organizer/OrganizerLDProjector.php
+++ b/src/Organizer/OrganizerLDProjector.php
@@ -210,7 +210,7 @@ class OrganizerLDProjector implements EventListener
         $jsonLD->url = $organizerCreated->getUrls();
 
         $recordedOn = $domainMessage->getRecordedOn()->toString();
-        $jsonLD->created = \DateTime::createFromFormat(
+        $jsonLD->created = \CultuurNet\UDB3\DateTimeFactory::fromFormat(
             DateTime::FORMAT_STRING,
             $recordedOn
         )->format('c');
@@ -258,7 +258,7 @@ class OrganizerLDProjector implements EventListener
         ];
 
         $recordedOn = $domainMessage->getRecordedOn()->toString();
-        $jsonLD->created = \DateTime::createFromFormat(
+        $jsonLD->created = \CultuurNet\UDB3\DateTimeFactory::fromFormat(
             DateTime::FORMAT_STRING,
             $recordedOn
         )->format('c');

--- a/src/Ownership/Readmodels/OwnershipLDProjector.php
+++ b/src/Ownership/Readmodels/OwnershipLDProjector.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Ownership\Readmodels;
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListener;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
 use CultuurNet\UDB3\Ownership\Events\OwnershipDeleted;
@@ -60,7 +61,7 @@ final class OwnershipLDProjector implements EventListener
         $body->requesterId = $ownershipRequested->getRequesterId();
         $body->state = OwnershipState::requested()->toString();
 
-        $body->created = \DateTime::createFromFormat(
+        $body->created = DateTimeFactory::fromFormat(
             DateTime::FORMAT_STRING,
             $domainMessage->getRecordedOn()->toString()
         )->format('c');

--- a/src/Place/ReadModel/JSONLD/PlaceLDProjector.php
+++ b/src/Place/ReadModel/JSONLD/PlaceLDProjector.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Cdb\ActorItemFactory;
 use CultuurNet\UDB3\Completeness\Completeness;
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
@@ -207,7 +208,7 @@ class PlaceLDProjector extends OfferLDProjector implements EventListener
         ];
 
         $recordedOn = $domainMessage->getRecordedOn()->toString();
-        $jsonLD->created = \DateTime::createFromFormat(
+        $jsonLD->created = DateTimeFactory::fromFormat(
             DateTime::FORMAT_STRING,
             $recordedOn
         )->format('c');

--- a/src/RecordedOn.php
+++ b/src/RecordedOn.php
@@ -51,7 +51,7 @@ class RecordedOn
      */
     public function toString()
     {
-        return \DateTime::createFromFormat(
+        return DateTimeFactory::fromFormat(
             DateTime::FORMAT_STRING,
             $this->recorded->toString()
         )->format('c');

--- a/tests/Calendar/OpeningTimeTest.php
+++ b/tests/Calendar/OpeningTimeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Calendar;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
 use PHPUnit\Framework\TestCase;
@@ -51,7 +52,7 @@ class OpeningTimeTest extends TestCase
     public function it_can_be_constructed_from_a_native_date_time(): void
     {
         $openingTime = OpeningTime::fromNativeDateTime(
-            \DateTime::createFromFormat('H:i', '9:30')
+            DateTimeFactory::fromFormat('H:i', '9:30')
         );
 
         $this->assertEquals($this->openingTime, $openingTime);

--- a/tests/Log/SocketIOEmitterHandlerTest.php
+++ b/tests/Log/SocketIOEmitterHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Log;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -42,7 +43,7 @@ class SocketIOEmitterHandlerTest extends TestCase
             'level' => $level,
             'level_name' => Logger::getLevelName($level),
             'channel' => 'test',
-            'datetime' => \DateTime::createFromFormat(
+            'datetime' => DateTimeFactory::fromFormat(
                 'U.u',
                 sprintf('%.6F', microtime(true))
             ),


### PR DESCRIPTION
### Changed
- Replaced `DateTime::createFromFormat` with `DateTimeFactory::fromFormat`

### Note
- There are still some occurrences left that use `DateTime` which is normal in the case when the result is validated for either being `false` or a real `DateTime` value.
- There is also a `DateTimeFactory` inside the `Cdb` namespace, it is out of the scope of this change to merge them. For that I created https://jira.publiq.be/browse/III-6246

---
Ticket: https://jira.uitdatabank.be/browse/III-3558
