### PR TITLE
III-6184 remove feature flag

### DIFF
--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -482,8 +482,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
                             )
                         ),
                         $container->get('config')['kinepolis']['trailers']['channel_id'],
-                        new Version4Generator(),
-                        $container->get('config')['kinepolis']['trailers']['enabled'],
+                        new Version4Generator()
                     ),
                     $container->get(ProductionRepository::class),
                     LoggerFactory::create(

--- a/src/Kinepolis/Trailer/YoutubeTrailerRepository.php
+++ b/src/Kinepolis/Trailer/YoutubeTrailerRepository.php
@@ -18,7 +18,7 @@ final class YoutubeTrailerRepository implements TrailerRepository
 
     private UuidGeneratorInterface $uuidGenerator;
 
-    public function __construct(Google_Service_YouTube $youTubeClient, string $channelId, UuidGeneratorInterface $uuidGenerator, bool $enabled = true)
+    public function __construct(Google_Service_YouTube $youTubeClient, string $channelId, UuidGeneratorInterface $uuidGenerator)
     {
         $this->channelId = $channelId;
         $this->uuidGenerator = $uuidGenerator;

--- a/src/Kinepolis/Trailer/YoutubeTrailerRepository.php
+++ b/src/Kinepolis/Trailer/YoutubeTrailerRepository.php
@@ -18,22 +18,15 @@ final class YoutubeTrailerRepository implements TrailerRepository
 
     private UuidGeneratorInterface $uuidGenerator;
 
-    private bool $enabled;
-
     public function __construct(Google_Service_YouTube $youTubeClient, string $channelId, UuidGeneratorInterface $uuidGenerator, bool $enabled = true)
     {
         $this->channelId = $channelId;
         $this->uuidGenerator = $uuidGenerator;
         $this->youTubeClient = $youTubeClient;
-        $this->enabled = $enabled;
     }
 
     public function findMatchingTrailer(string $title): ?Video
     {
-        if (!$this->enabled) {
-            return null;
-        }
-
         $response = $this->youTubeClient->search->listSearch('id,snippet', [
             'channelId' => $this->channelId,
             'q' => urlencode($title),

--- a/tests/Kinepolis/Trailer/YoutubeTrailerRepositoryTest.php
+++ b/tests/Kinepolis/Trailer/YoutubeTrailerRepositoryTest.php
@@ -55,23 +55,6 @@ final class YoutubeTrailerRepositoryTest extends TestCase
     /**
      * @test
      */
-    public function it_will_only_search_when_enabled(): void
-    {
-        $disabledTrailerRepository = new YoutubeTrailerRepository(
-            $this->youtubeClient,
-            $this->channelId,
-            $this->uuidGenerator,
-            false
-        );
-        $this->search->expects($this->never())->method('listSearch');
-
-        $video = $disabledTrailerRepository->findMatchingTrailer('Het Smelt');
-        $this->assertNull($video);
-    }
-
-    /**
-     * @test
-     */
     public function it_will_return_null_if_no_trailer_was_found(): void
     {
         $this->search->expects($this->once())->method('listSearch')->with('id,snippet', [

--- a/tests/Kinepolis/Trailer/YoutubeTrailerRepositoryTest.php
+++ b/tests/Kinepolis/Trailer/YoutubeTrailerRepositoryTest.php
@@ -47,8 +47,7 @@ final class YoutubeTrailerRepositoryTest extends TestCase
         $this->trailerRepository = new YoutubeTrailerRepository(
             $this->youtubeClient,
             $this->channelId,
-            $this->uuidGenerator,
-            true
+            $this->uuidGenerator
         );
     }
 

--- a/tests/Kinepolis/Trailer/YoutubeTrailerRepositoryTest.php
+++ b/tests/Kinepolis/Trailer/YoutubeTrailerRepositoryTest.php
@@ -19,11 +19,6 @@ final class YoutubeTrailerRepositoryTest extends TestCase
 {
     private TrailerRepository $trailerRepository;
 
-    /**
-     * @var Google_Service_YouTube&MockObject
-     */
-    private $youtubeClient;
-
     private string $channelId;
 
     /**
@@ -39,13 +34,13 @@ final class YoutubeTrailerRepositoryTest extends TestCase
     public function setUp(): void
     {
         $this->search = $this->createMock(Search::class);
-        $this->youtubeClient = $this->createMock(Google_Service_YouTube::class);
-        $this->youtubeClient->search = $this->search;
+        $youtubeClient = $this->createMock(Google_Service_YouTube::class);
+        $youtubeClient->search = $this->search;
         $this->channelId = 'mockChannelId';
         $this->uuidGenerator = $this->createMock(UuidGeneratorInterface::class);
 
         $this->trailerRepository = new YoutubeTrailerRepository(
-            $this->youtubeClient,
+            $youtubeClient,
             $this->channelId,
             $this->uuidGenerator
         );


### PR DESCRIPTION
### Changed

- `YoutubeTrailerRepository`: removed feature-flag to enable/disable trailers on `mvoviefetcher`
- `YoutubeTrailerRepositoryTest`: removed no longer needed test & moved property inline

### Fixed

- Since the  trailers added by the `movie-fetcher` are OK, a feature-flag to quickly disable it, is no longer needed. Henceforth all movies imported by the movie-fetcher will automatically get a trailer(if one is available on Youtube).

### Related PR

- https://github.com/cultuurnet/appconfig/pull/753

---
Ticket: https://jira.publiq.be/browse/III-6184
