### PR TITLE
III-6264 acceptance test default filter from UiTID

### DIFF
--- a/features/search/default-queries-uitid.feature
+++ b/features/search/default-queries-uitid.feature
@@ -1,6 +1,7 @@
 @sapi3
 Feature: Test the Search API v3 default queries from UiTID
 
+  # sapi3KeyWithUitIdFilterForDiest has a default filter with 'regions:nis-24020' on UiTidV1
   Background:
     Given I am using the UDB3 base URL
     And I am using an UiTID v1 API key of consumer "uitdatabank"

--- a/features/search/default-queries-uitid.feature
+++ b/features/search/default-queries-uitid.feature
@@ -11,7 +11,7 @@ Feature: Test the Search API v3 default queries from UiTID
     Given I create a place from "places/hemmekes.json" and save the "id" as "placeId"
     And I am using the Search API v3 base URL
     And I am not authorized
-    And I am using an UiTID v1 API key of consumer "regionFilterDiest"
+    And I am using an UiTID v1 API key of consumer "sapi3KeyWithUitIdFilterForDiest"
     And I am not using a x-client-id header
     And I wait 2 seconds
     When I send a GET request to "/places" with parameters:
@@ -26,7 +26,7 @@ Feature: Test the Search API v3 default queries from UiTID
     And I create an event from "events/event-minimal-permanent.json" and save the "id" as "eventId"
     And I am using the Search API v3 base URL
     And I am not authorized
-    And I am using an UiTID v1 API key of consumer "regionFilterDiest"
+    And I am using an UiTID v1 API key of consumer "sapi3KeyWithUitIdFilterForDiest"
     And I am not using a x-client-id header
     And I wait 2 seconds
     When I send a GET request to "/events" with parameters:
@@ -40,7 +40,7 @@ Feature: Test the Search API v3 default queries from UiTID
     Given I create a place from "places/citadel.json" and save the "id" as "placeId"
     And I am using the Search API v3 base URL
     And I am not authorized
-    And I am using an UiTID v1 API key of consumer "regionFilterDiest"
+    And I am using an UiTID v1 API key of consumer "sapi3KeyWithUitIdFilterForDiest"
     And I am not using a x-client-id header
     And I wait 2 seconds
     When I send a GET request to "/places" with parameters:
@@ -55,7 +55,7 @@ Feature: Test the Search API v3 default queries from UiTID
     And I create an event from "events/event-minimal-permanent.json" and save the "id" as "eventId"
     And I am using the Search API v3 base URL
     And I am not authorized
-    And I am using an UiTID v1 API key of consumer "regionFilterDiest"
+    And I am using an UiTID v1 API key of consumer "sapi3KeyWithUitIdFilterForDiest"
     And I am not using a x-client-id header
     And I wait 2 seconds
     When I send a GET request to "/events" with parameters:

--- a/features/search/default-queries-uitid.feature
+++ b/features/search/default-queries-uitid.feature
@@ -7,7 +7,7 @@ Feature: Test the Search API v3 default queries from UiTID
     And I am authorized as JWT provider v1 user "centraal_beheerder"
     And I send and accept "application/json"
 
-  Scenario: Search for a place blocked by the default query
+  Scenario: Search for a place that will be filtered out by the default query
     Given I create a place from "places/hemmekes.json" and save the "id" as "placeId"
     And I am using the Search API v3 base URL
     And I am not authorized
@@ -20,7 +20,7 @@ Feature: Test the Search API v3 default queries from UiTID
       | q                     | id:%{placeId} |
     Then the JSON response at "totalItems" should be 0
 
-  Scenario: Search for an event blocked by the default query
+  Scenario: Search for an event that will be filtered out by the default query
     Given I create a place from "places/hemmekes.json" and save the "url" as "placeUrl"
     And I create an event from "events/event-minimal-permanent.json" and save the "id" as "eventId"
     And I am using the Search API v3 base URL

--- a/features/search/default-queries-uitid.feature
+++ b/features/search/default-queries-uitid.feature
@@ -16,7 +16,6 @@ Feature: Test the Search API v3 default queries from UiTID
     And I wait 2 seconds
     When I send a GET request to "/places" with parameters:
       | limit                 | 1 |
-      | embed                 | true |
       | disableDefaultFilters | true |
       | q                     | id:%{placeId} |
     Then the JSON response at "totalItems" should be 0
@@ -31,7 +30,6 @@ Feature: Test the Search API v3 default queries from UiTID
     And I wait 2 seconds
     When I send a GET request to "/events" with parameters:
       | limit                 | 1 |
-      | embed                 | true |
       | disableDefaultFilters | true |
       | q                     | id:%{eventId} |
     Then the JSON response at "totalItems" should be 0
@@ -45,7 +43,6 @@ Feature: Test the Search API v3 default queries from UiTID
     And I wait 2 seconds
     When I send a GET request to "/places" with parameters:
       | limit                 | 1 |
-      | embed                 | true |
       | disableDefaultFilters | true |
       | q                     | id:%{placeId} |
     Then the JSON response at "totalItems" should be 1
@@ -60,7 +57,6 @@ Feature: Test the Search API v3 default queries from UiTID
     And I wait 2 seconds
     When I send a GET request to "/events" with parameters:
       | limit                 | 1 |
-      | embed                 | true |
       | disableDefaultFilters | true |
       | q                     | id:%{eventId} |
     Then the JSON response at "totalItems" should be 1

--- a/features/search/default-queries-uitid.feature
+++ b/features/search/default-queries-uitid.feature
@@ -1,0 +1,36 @@
+@sapi3
+Feature: Test the Search API v3 default queries from UiTID
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I send and accept "application/json"
+
+  Scenario: Search for a place blocked by the default query
+    Given I create a place from "places/hemmekes.json" and save the "id" as "placeId"
+    And I am using the Search API v3 base URL
+    And I am not authorized
+    And I am using an UiTID v1 API key of consumer "regionFilterDiest"
+    And I am not using a x-client-id header
+    And I wait 2 seconds
+    When I send a GET request to "/places" with parameters:
+      | limit                 | 1 |
+      | embed                 | true |
+      | disableDefaultFilters | true |
+      | q                     | id:%{placeId} |
+    Then the JSON response at "totalItems" should be 0
+
+  Scenario: Search for a place within by the default query
+    Given I create a place from "places/citadel.json" and save the "id" as "placeId"
+    And I am using the Search API v3 base URL
+    And I am not authorized
+    And I am using an UiTID v1 API key of consumer "regionFilterDiest"
+    And I am not using a x-client-id header
+    And I wait 2 seconds
+    When I send a GET request to "/places" with parameters:
+      | limit                 | 1 |
+      | embed                 | true |
+      | disableDefaultFilters | true |
+      | q                     | id:%{placeId} |
+    Then the JSON response at "totalItems" should be 1

--- a/features/search/default-queries-uitid.feature
+++ b/features/search/default-queries-uitid.feature
@@ -50,7 +50,7 @@ Feature: Test the Search API v3 default queries from UiTID
       | q                     | id:%{placeId} |
     Then the JSON response at "totalItems" should be 1
 
-  Scenario: Search for an event bwithin by the default query
+  Scenario: Search for an event within by the default query
     Given I create a place from "places/citadel.json" and save the "url" as "placeUrl"
     And I create an event from "events/event-minimal-permanent.json" and save the "id" as "eventId"
     And I am using the Search API v3 base URL

--- a/features/search/default-queries-uitid.feature
+++ b/features/search/default-queries-uitid.feature
@@ -10,11 +10,11 @@ Feature: Test the Search API v3 default queries from UiTID
 
   Scenario: Search for a place that will be filtered out by the default query
     Given I create a place from "places/hemmekes.json" and save the "id" as "placeId"
+    And I wait for the place with url "/places/%{placeId}" to be indexed
     And I am using the Search API v3 base URL
     And I am not authorized
     And I am using an UiTID v1 API key of consumer "sapi3KeyWithUitIdFilterForDiest"
     And I am not using a x-client-id header
-    And I wait 2 seconds
     When I send a GET request to "/places" with parameters:
       | limit                 | 1 |
       | disableDefaultFilters | true |
@@ -24,11 +24,11 @@ Feature: Test the Search API v3 default queries from UiTID
   Scenario: Search for an event that will be filtered out by the default query
     Given I create a place from "places/hemmekes.json" and save the "url" as "placeUrl"
     And I create an event from "events/event-minimal-permanent.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
     And I am using the Search API v3 base URL
     And I am not authorized
     And I am using an UiTID v1 API key of consumer "sapi3KeyWithUitIdFilterForDiest"
     And I am not using a x-client-id header
-    And I wait 2 seconds
     When I send a GET request to "/events" with parameters:
       | limit                 | 1 |
       | disableDefaultFilters | true |
@@ -37,11 +37,11 @@ Feature: Test the Search API v3 default queries from UiTID
 
   Scenario: Search for a place within by the default query
     Given I create a place from "places/citadel.json" and save the "id" as "placeId"
+    And I wait for the place with url "/places/%{placeId}" to be indexed
     And I am using the Search API v3 base URL
     And I am not authorized
     And I am using an UiTID v1 API key of consumer "sapi3KeyWithUitIdFilterForDiest"
     And I am not using a x-client-id header
-    And I wait 2 seconds
     When I send a GET request to "/places" with parameters:
       | limit                 | 1 |
       | disableDefaultFilters | true |
@@ -51,11 +51,11 @@ Feature: Test the Search API v3 default queries from UiTID
   Scenario: Search for an event within by the default query
     Given I create a place from "places/citadel.json" and save the "url" as "placeUrl"
     And I create an event from "events/event-minimal-permanent.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
     And I am using the Search API v3 base URL
     And I am not authorized
     And I am using an UiTID v1 API key of consumer "sapi3KeyWithUitIdFilterForDiest"
     And I am not using a x-client-id header
-    And I wait 2 seconds
     When I send a GET request to "/events" with parameters:
       | limit                 | 1 |
       | disableDefaultFilters | true |

--- a/features/search/default-queries-uitid.feature
+++ b/features/search/default-queries-uitid.feature
@@ -21,6 +21,21 @@ Feature: Test the Search API v3 default queries from UiTID
       | q                     | id:%{placeId} |
     Then the JSON response at "totalItems" should be 0
 
+  Scenario: Search for an event blocked by the default query
+    Given I create a place from "places/hemmekes.json" and save the "url" as "placeUrl"
+    And I create an event from "events/event-minimal-permanent.json" and save the "id" as "eventId"
+    And I am using the Search API v3 base URL
+    And I am not authorized
+    And I am using an UiTID v1 API key of consumer "regionFilterDiest"
+    And I am not using a x-client-id header
+    And I wait 2 seconds
+    When I send a GET request to "/events" with parameters:
+      | limit                 | 1 |
+      | embed                 | true |
+      | disableDefaultFilters | true |
+      | q                     | id:%{eventId} |
+    Then the JSON response at "totalItems" should be 0
+
   Scenario: Search for a place within by the default query
     Given I create a place from "places/citadel.json" and save the "id" as "placeId"
     And I am using the Search API v3 base URL
@@ -33,4 +48,19 @@ Feature: Test the Search API v3 default queries from UiTID
       | embed                 | true |
       | disableDefaultFilters | true |
       | q                     | id:%{placeId} |
+    Then the JSON response at "totalItems" should be 1
+
+  Scenario: Search for an event bwithin by the default query
+    Given I create a place from "places/citadel.json" and save the "url" as "placeUrl"
+    And I create an event from "events/event-minimal-permanent.json" and save the "id" as "eventId"
+    And I am using the Search API v3 base URL
+    And I am not authorized
+    And I am using an UiTID v1 API key of consumer "regionFilterDiest"
+    And I am not using a x-client-id header
+    And I wait 2 seconds
+    When I send a GET request to "/events" with parameters:
+      | limit                 | 1 |
+      | embed                 | true |
+      | disableDefaultFilters | true |
+      | q                     | id:%{eventId} |
     Then the JSON response at "totalItems" should be 1


### PR DESCRIPTION
### Added

- `default-queries-uitid.feature`: An acceptance test for default queries from `UiTID`

### Related PR

- https://github.com/cultuurnet/appconfig/pull/755

---
Ticket: https://jira.publiq.be/browse/III-6264
