### PR TITLE
III-6273 InvalidArgumentException: Given string is not a valid url.

### DIFF
--- a/src/InvalidUrl.php
+++ b/src/InvalidUrl.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
+use Exception;
+
+final class InvalidUrl extends Exception implements ConvertsToApiProblem
+{
+    public function toApiProblem(): ApiProblem
+    {
+        return ApiProblem::bodyInvalidDataWithDetail('The url should match pattern: /\\Ahttp[s]?:\\/\\//');
+    }
+}

--- a/src/Model/Serializer/ValueObject/Contact/BookingInfoDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Contact/BookingInfoDenormalizer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Model\Serializer\ValueObject\Contact;
 
 use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\InvalidUrl;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Web\TranslatedWebsiteLabelDenormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingInfo;
@@ -59,8 +60,12 @@ class BookingInfoDenormalizer implements DenormalizerInterface
         }
 
         if (isset($data['url']) && isset($data['urlLabel'])) {
+            try {
+                $url = new Url($data['url']);
+            } catch (\InvalidArgumentException $exception) {
+                throw new InvalidUrl($exception->getMessage());
+            }
             /* @var TranslatedWebsiteLabel $label */
-            $url = new Url($data['url']);
             $label = $this->websiteLabelDenormalizer->denormalize(
                 $data['urlLabel'],
                 TranslatedWebsiteLabel::class,

--- a/tests/Model/Serializer/ValueObject/Contact/BookingInfoDenormalizerTest.php
+++ b/tests/Model/Serializer/ValueObject/Contact/BookingInfoDenormalizerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\Serializer\ValueObject\Contact;
+
+use CultuurNet\UDB3\InvalidUrl;
+use CultuurNet\UDB3\Model\ValueObject\Contact\BookingInfo;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\TranslatedWebsiteLabel;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\WebsiteLabel;
+use CultuurNet\UDB3\Model\ValueObject\Web\WebsiteLink;
+use PHPUnit\Framework\TestCase;
+
+final class BookingInfoDenormalizerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_serialize(): void
+    {
+        $bookingInfo = new BookingInfo(
+            new WebsiteLink(
+                new Url('https://www.arboretumkalmthout.be'),
+                new TranslatedWebsiteLabel(
+                    new Language('nl'),
+                    new WebsiteLabel('Koop tickets')
+                )
+            )
+        );
+
+        $bookingInfoArray = [
+            'url' => 'https://www.arboretumkalmthout.be',
+            'telephoneNumber' => null,
+            'emailAddress' => null,
+            'availability' => null,
+            'urlLabel' => [
+                'nl' => 'Koop tickets',
+            ],
+        ];
+
+
+        $this->assertEquals(
+            $bookingInfo,
+            (new BookingInfoDenormalizer())->denormalize($bookingInfoArray, BookingInfo::class)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throw_on_malformed_urls(): void
+    {
+        $bookingInfoArray = [
+            'url' => 'https://www.arboretumkalmthout.be%20',
+            'urlLabel' => [
+                'nl' => 'Koop tickets',
+            ],
+        ];
+
+        $this->expectException(InvalidUrl::class);
+        $this->expectExceptionMessage('The url should match pattern: /\\Ahttp[s]?:\\/\\//');
+
+        (new BookingInfoDenormalizer())->denormalize($bookingInfoArray, BookingInfo::class);
+    }
+}


### PR DESCRIPTION
### Added

- `InvalidUrl`: Added new `ConvertsToApiProblem`-exception to catch malformed urls.
- `BookingInfoDenormalizerTest`: UnitTest for `BookingInfoDenormalizer`

### Changed

- `BookingInfoDenormalizer`: throw new `InvalidUrl`, when `Url` is malformed

### Fixed

- no more ServerErrors, when a malformed `Url` like `https://www.arboretumkalmthout.be%20` is used.

---

Ticket: https://jira.publiq.be/browse/III-6273
