### PR TITLE
III-6273 improve invalid url

### DIFF
--- a/features/event/booking-info.feature
+++ b/features/event/booking-info.feature
@@ -51,6 +51,29 @@ Feature: Test the UDB3 events API
     }
     """
 
+  Scenario: Update bookingInfo with malformed url
+    Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
+    And I set the JSON request payload to:
+    """
+    {
+      "url": "https://www.arboretumkalmthout.be%20",
+      "urlLabel": {
+        "nl": "Koop tickets"
+      }
+    }
+    """
+      When I send a PUT request to "%{eventUrl}/booking-info"
+      Then the response status should be "400"
+      And the JSON response should be:
+    """
+    {
+      "type": "https://api.publiq.be/probs/body/invalid-data",
+      "title": "Invalid body data",
+      "status": 400,
+      "detail": "Given string is not a valid url."
+    }
+    """
+
   Scenario: Update bookingInfo with url but missing urlLabel
     Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
     And I set the JSON request payload to:

--- a/src/Model/ValueObject/Web/InvalidUrl.php
+++ b/src/Model/ValueObject/Web/InvalidUrl.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Web;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
+use Exception;
+
+final class InvalidUrl extends Exception implements ConvertsToApiProblem
+{
+    public function toApiProblem(): ApiProblem
+    {
+        return ApiProblem::bodyInvalidDataWithDetail($this->getMessage());
+    }
+}

--- a/src/Model/ValueObject/Web/Url.php
+++ b/src/Model/ValueObject/Web/Url.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Web;
 
 use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\IsString;
 use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\MatchesRegexPattern;
+use InvalidArgumentException;
 
 class Url
 {
@@ -14,10 +15,14 @@ class Url
 
     public function __construct(string $value)
     {
-        $this->guardRegexPattern('/\\Ahttp[s]?:\\/\\//', strtolower($value));
+        try {
+            $this->guardRegexPattern('/\\Ahttp[s]?:\\/\\//', strtolower($value));
+        } catch (InvalidArgumentException $exception) {
+            throw new InvalidUrl('Given string is not a valid url.');
+        }
 
         if (filter_var($value, FILTER_VALIDATE_URL) === false) {
-            throw new \InvalidArgumentException('Given string is not a valid url.');
+            throw new InvalidUrl('Given string is not a valid url.');
         }
 
         $this->setValue($value);

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -68,6 +68,7 @@ use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Online\AttendanceMode;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
+use CultuurNet\UDB3\Model\ValueObject\Web\InvalidUrl;
 use CultuurNet\UDB3\Model\ValueObject\Web\TranslatedWebsiteLabel;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
@@ -1802,7 +1803,7 @@ class EventDenormalizerTest extends TestCase
             ],
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidUrl::class);
 
         $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
     }

--- a/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
+++ b/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
@@ -67,6 +67,7 @@ use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
+use CultuurNet\UDB3\Model\ValueObject\Web\InvalidUrl;
 use CultuurNet\UDB3\Model\ValueObject\Web\TranslatedWebsiteLabel;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
@@ -1001,7 +1002,7 @@ class PlaceDenormalizerTest extends TestCase
             ],
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidUrl::class);
 
         $this->denormalizer->denormalize($placeData, ImmutablePlace::class);
     }

--- a/tests/Model/ValueObject/Web/UrlTest.php
+++ b/tests/Model/ValueObject/Web/UrlTest.php
@@ -51,7 +51,7 @@ class UrlTest extends TestCase
      */
     public function it_should_reject_an_invalid_url(string $url): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidUrl::class);
         new Url($url);
     }
 


### PR DESCRIPTION
### Added

- `InvalidUrl`: New exception to throw when `Url` is malformed

### Changed

- `Url`: throw `InvalidUrl` instead of `InvalidArgumentException`
- `EventDenormalizerTest`, `PlaceDenormalizerTest` & `UrlTest`: update tests
- `event/booking-info.feature`: Add acceptance test.

---

Ticket: https://jira.publiq.be/browse/III-6273 
