### PR TITLE
III-6307/bugfix escape chars duplicate place

### DIFF
--- a/features/Steps/UtilitySteps.php
+++ b/features/Steps/UtilitySteps.php
@@ -9,6 +9,14 @@ trait UtilitySteps
     private bool $initialPreventDuplicatePlaceCreationValue;
 
     /**
+     * @Given /^I create a name that includes special characters and keep it as "([^"]*)"$/
+     */
+    public function iCreateANameOfCharactersThatIncludesSpecialCharactersAndKeepItAs(string $variableName)
+    {
+        $this->variableState->setVariable($variableName, '(a)![a]' . uniqid('', true));
+    }
+
+    /**
      * @Given I create a random name of :nrOfCharacters characters
      */
     public function iCreateARandomNameOfCharacters(int $nrOfCharacters): void

--- a/features/place/duplicate.feature
+++ b/features/place/duplicate.feature
@@ -34,3 +34,21 @@ Feature: Test creating places
     }
     """
     Then I restore the duplicate configuration
+
+    Scenario: Be prevented from creating a new place if we already have one on that address when the the address contains special chars
+        Given I prevent duplicate place creation
+        Given I create a name that includes special characters and keep it as "name"
+        Given I create a minimal place and save the "id" as "originalPlaceId" then I should get a "201" response code
+        Then I wait for the place with url "/places/%{originalPlaceId}" to be indexed
+        Given I create a minimal place then I should get a "409" response code
+        Then the JSON response should be:
+    """
+    {
+        "type": "https://api.publiq.be/probs/uitdatabank/duplicate-place",
+        "title": "Duplicate place",
+        "status": 409,
+        "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
+        "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
+    }
+    """
+    Then I restore the duplicate configuration

--- a/src/Place/ReadModel/Duplicate/UniqueAddressIdentifierFactory.php
+++ b/src/Place/ReadModel/Duplicate/UniqueAddressIdentifierFactory.php
@@ -15,7 +15,7 @@ class UniqueAddressIdentifierFactory
             $this->getParts($title, $address, $currentUserId)
         );
 
-        return mb_strtolower(implode('_', array_filter($parts)));
+        return mb_strtolower($this->escapeQueryChars(implode('_', array_filter($parts))));
     }
 
     private function getParts(string $title, Address $address, string $currentUserId): array
@@ -28,5 +28,24 @@ class UniqueAddressIdentifierFactory
             $address->getCountryCode()->toString(),
             $currentUserId,
         ];
+    }
+
+    /**
+     * Escape special characters in the query string for Elasticsearch.
+     *
+     * @param string $query The raw query string.
+     * @return string The escaped query string.
+     */
+    private function escapeQueryChars(string $query): string
+    {
+        // List of special characters that need escaping
+        $specialChars = ['\\', '+', '-', '=', '&&', '||', '>', '<', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '/'];
+
+        // Escape each character
+        foreach ($specialChars as $char) {
+            $query = str_replace($char, '\\' . $char, $query);
+        }
+
+        return $query;
     }
 }

--- a/tests/Place/ReadModel/Duplicate/LookupDuplicatePlaceWithSapi3Test.php
+++ b/tests/Place/ReadModel/Duplicate/LookupDuplicatePlaceWithSapi3Test.php
@@ -76,7 +76,7 @@ class LookupDuplicatePlaceWithSapi3Test extends TestCase
             ItemType::place()
         ));
 
-        $query = '(workflowStatus:DRAFT OR workflowStatus:READY_FOR_VALIDATION OR workflowStatus:APPROVED) AND unique_address_identifier:online_kerkstraat_1_2000_antwerpen_be_current-user-id';
+        $query = '(workflowStatus:DRAFT OR workflowStatus:READY_FOR_VALIDATION OR workflowStatus:APPROVED) AND unique_address_identifier:online_kerkstraat_1_2000_antwerpen_be_current\-user\-id';
 
         $this->sapi3SearchService->expects($this->once())
             ->method('search')

--- a/tests/Place/ReadModel/Duplicate/UniqueAddressIdentifierFactoryTest.php
+++ b/tests/Place/ReadModel/Duplicate/UniqueAddressIdentifierFactoryTest.php
@@ -51,6 +51,17 @@ class UniqueAddressIdentifierFactoryTest extends TestCase
                 'user123',
                 'kerkstraat_1_2000_antwerpen_be_user123',
             ],
+            'address with special chars' => [
+                '',
+                new Udb3Address(
+                    new Udb3Street('Kerkstraat 1!'),
+                    new Udb3PostalCode('2000'),
+                    new Udb3Locality('Antwerpen(Berchem)'),
+                    new CountryCode('BE')
+                ),
+                'user123',
+                'kerkstraat_1\!_2000_antwerpen\(berchem\)_be_user123',
+            ],
         ];
     }
 }


### PR DESCRIPTION
### Fixed
Added escaping of special chars for the query of duplicate places

Bonus: a feature test to prove it works
---

Ticket: https://jira.uitdatabank.be/browse/III-6307
