### PR TITLE
III-6308 Remove unneeded inheritdoc comments

### DIFF
--- a/app/Migrations/Version20150817113039.php
+++ b/app/Migrations/Version20150817113039.php
@@ -9,9 +9,6 @@ use Doctrine\Migrations\AbstractMigration;
 
 class Version20150817113039 extends AbstractMigration
 {
-    /**
-     * @inheritdoc
-     */
     public function up(Schema $schema): void
     {
         $table = $schema->createTable('index_readmodel');
@@ -48,9 +45,6 @@ class Version20150817113039 extends AbstractMigration
         $table->setPrimaryKey(['entity_id', 'entity_type']);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function down(Schema $schema): void
     {
         $schema->dropTable('index_readmodel');

--- a/src/CommandHandling/Udb3CommandHandler.php
+++ b/src/CommandHandling/Udb3CommandHandler.php
@@ -11,9 +11,6 @@ use Broadway\CommandHandling\CommandHandler;
  */
 abstract class Udb3CommandHandler implements CommandHandler
 {
-    /**
-     * {@inheritDoc}
-     */
     public function handle($command): void
     {
         $method = $this->getHandleMethod($command);

--- a/src/Event/EventFacilityResolver.php
+++ b/src/Event/EventFacilityResolver.php
@@ -9,9 +9,6 @@ use CultuurNet\UDB3\Offer\OfferFacilityResolver;
 
 class EventFacilityResolver extends OfferFacilityResolver
 {
-    /**
-     * @inheritdoc
-     */
     final protected function getFacilities(): array
     {
         return [

--- a/src/History/Log.php
+++ b/src/History/Log.php
@@ -77,9 +77,6 @@ class Log implements JsonSerializable
         return $log;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function jsonSerialize(): array
     {
         $log = [

--- a/src/Http/Deserializer/Event/CreateEventDataValidator.php
+++ b/src/Http/Deserializer/Event/CreateEventDataValidator.php
@@ -23,9 +23,6 @@ class CreateEventDataValidator implements DataValidatorInterface
             ->withValidator(new RequiredPropertiesDataValidator(['mainLanguage']));
     }
 
-    /**
-     * @inheritdoc
-     */
     public function validate(array $data): void
     {
         $this->validator->validate($data);

--- a/src/Http/Deserializer/Place/CreatePlaceDataValidator.php
+++ b/src/Http/Deserializer/Place/CreatePlaceDataValidator.php
@@ -23,9 +23,6 @@ class CreatePlaceDataValidator implements DataValidatorInterface
             ->withValidator(new RequiredPropertiesDataValidator(['mainLanguage']));
     }
 
-    /**
-     * @inheritdoc
-     */
     public function validate(array $data): void
     {
         $this->validator->validate($data);

--- a/src/Http/Response/JsonLdResponse.php
+++ b/src/Http/Response/JsonLdResponse.php
@@ -9,9 +9,6 @@ use Slim\Psr7\Interfaces\HeadersInterface;
 
 class JsonLdResponse extends JsonResponse
 {
-    /**
-     * @inheritdoc
-     */
     public function __construct($data = null, $status = 200, ?HeadersInterface $headers = null)
     {
         if (!($headers instanceof HeadersInterface)) {

--- a/src/Label/ReadModels/JSON/Repository/Entity.php
+++ b/src/Label/ReadModels/JSON/Repository/Entity.php
@@ -65,9 +65,6 @@ class Entity implements \JsonSerializable
         return $this->excluded;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function jsonSerialize(): array
     {
         return [

--- a/src/Log/ContextEnrichingLogger.php
+++ b/src/Log/ContextEnrichingLogger.php
@@ -25,9 +25,6 @@ class ContextEnrichingLogger implements LoggerInterface
         $this->context = $context;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function log($level, $message, array $context = []): void
     {
         $enrichedContext = $this->context + $context;

--- a/src/Log/SocketIOEmitterHandler.php
+++ b/src/Log/SocketIOEmitterHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Log;
 
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\NormalizerFormatter;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
@@ -27,10 +28,7 @@ class SocketIOEmitterHandler extends AbstractProcessingHandler
         $this->emitter = $emitter;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         $event = $record['formatted']['message'];
         $data = $record['formatted']['context'];
@@ -38,10 +36,7 @@ class SocketIOEmitterHandler extends AbstractProcessingHandler
         $this->emitter->emit($event, $data);
     }
 
-    /**
-     * @inheritdoc
-     */
-    protected function getDefaultFormatter()
+    protected function getDefaultFormatter(): FormatterInterface
     {
         return new NormalizerFormatter();
     }

--- a/src/Model/Event/ImmutableEvent.php
+++ b/src/Model/Event/ImmutableEvent.php
@@ -97,9 +97,6 @@ class ImmutableEvent extends ImmutableOffer implements Event
         return $c;
     }
 
-    /**
-     * @inheritdoc
-     */
     protected function guardCalendarType(Calendar $calendar): void
     {
         // Any calendar is fine for events.

--- a/src/Model/Place/ImmutablePlace.php
+++ b/src/Model/Place/ImmutablePlace.php
@@ -138,9 +138,6 @@ final class ImmutablePlace extends ImmutableOffer implements Place
         return new UUID('00000000-0000-0000-0000-000000000000');
     }
 
-    /**
-     * @inheritdoc
-     */
     protected function guardCalendarType(Calendar $calendar): void
     {
         if (!($calendar instanceof CalendarWithOpeningHours)) {

--- a/src/Model/Serializer/ValueObject/Audience/AgeRangeDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Audience/AgeRangeDenormalizer.php
@@ -50,9 +50,6 @@ class AgeRangeDenormalizer implements DenormalizerInterface
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public function supportsDenormalization($data, $type, $format = null): bool
     {
         return $type === AgeRange::class;

--- a/src/Model/ValueObject/Calendar/CalendarType.php
+++ b/src/Model/ValueObject/Calendar/CalendarType.php
@@ -14,9 +14,6 @@ use CultuurNet\UDB3\Model\ValueObject\String\Enum;
  */
 class CalendarType extends Enum
 {
-    /**
-     * @inheritdoc
-     */
     public static function getAllowedValues(): array
     {
         return [

--- a/src/Model/ValueObject/Calendar/OpeningHours/Day.php
+++ b/src/Model/ValueObject/Calendar/OpeningHours/Day.php
@@ -17,9 +17,6 @@ use CultuurNet\UDB3\Model\ValueObject\String\Enum;
  */
 class Day extends Enum
 {
-    /**
-     * @inheritdoc
-     */
     public static function getAllowedValues(): array
     {
         return [

--- a/src/Model/ValueObject/Calendar/StatusType.php
+++ b/src/Model/ValueObject/Calendar/StatusType.php
@@ -13,9 +13,6 @@ use CultuurNet\UDB3\Model\ValueObject\String\Enum;
  */
 class StatusType extends Enum
 {
-    /**
-     * @inheritdoc
-     */
     public static function getAllowedValues(): array
     {
         return [

--- a/src/Offer/OfferCommandHandler.php
+++ b/src/Offer/OfferCommandHandler.php
@@ -43,9 +43,6 @@ abstract class OfferCommandHandler extends Udb3CommandHandler
         $this->mediaManager = $mediaManager;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handle($command): void
     {
         $commandName = get_class($command);

--- a/src/Offer/ReadModel/JSONLD/CdbXmlContactInfoImporter.php
+++ b/src/Offer/ReadModel/JSONLD/CdbXmlContactInfoImporter.php
@@ -10,9 +10,6 @@ class CdbXmlContactInfoImporter implements CdbXmlContactInfoImporterInterface
 {
     use MultilingualJsonLDProjectorTrait;
 
-    /**
-     * @inheritdoc
-     */
     public function importBookingInfo(
         \stdClass $jsonLD,
         \CultureFeed_Cdb_Data_ContactInfo $contactInfo,
@@ -77,9 +74,6 @@ class CdbXmlContactInfoImporter implements CdbXmlContactInfoImporterInterface
         }
     }
 
-    /**
-     * @inheritdoc
-     */
     public function importContactPoint(
         \stdClass $jsonLD,
         \CultureFeed_Cdb_Data_ContactInfo $contactInfo

--- a/src/Role/Events/AbstractEvent.php
+++ b/src/Role/Events/AbstractEvent.php
@@ -23,9 +23,6 @@ abstract class AbstractEvent implements Serializable
         return $this->uuid;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function serialize(): array
     {
         return ['uuid' => $this->getUuid()->toString()];

--- a/src/SavedSearches/UDB3SavedSearchRepository.php
+++ b/src/SavedSearches/UDB3SavedSearchRepository.php
@@ -99,9 +99,6 @@ class UDB3SavedSearchRepository implements SavedSearchReadModelRepositoryInterfa
         $queryBuilder->execute();
     }
 
-    /**
-     * @inheritdoc
-     */
     public function ownedByCurrentUser(): array
     {
         $queryBuilder = $this->connection->createQueryBuilder()

--- a/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
+++ b/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
@@ -511,9 +511,6 @@ final class HTMLFileWriterTest extends TestCase
         $this->assertEquals($html, SampleFiles::read($filePath));
     }
 
-    /**
-     * @inheritdoc
-     */
     public function tearDown(): void
     {
         if ($this->filePath && file_exists($this->filePath)) {

--- a/tests/Label/CommandHandlerTest.php
+++ b/tests/Label/CommandHandlerTest.php
@@ -57,9 +57,6 @@ final class CommandHandlerTest extends CommandHandlerScenarioTestCase
         parent::setUp();
     }
 
-    /**
-     * @inheritdoc
-     */
     protected function createCommandHandler(
         EventStore $eventStore,
         EventBus $eventBus

--- a/tests/Model/Offer/MockImmutableOffer.php
+++ b/tests/Model/Offer/MockImmutableOffer.php
@@ -8,11 +8,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 
 class MockImmutableOffer extends ImmutableOffer
 {
-    /**
-     * @inheritdoc
-     */
     protected function guardCalendarType(Calendar $calendar): void
     {
-        return;
     }
 }

--- a/tests/StringFilter/StringFilterTest.php
+++ b/tests/StringFilter/StringFilterTest.php
@@ -20,9 +20,6 @@ abstract class StringFilterTest extends TestCase
 
     protected StringFilterInterface $filter;
 
-    /**
-     * {@inheritdoc}
-     */
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/StringFilter/StripSourceStringFilterTest.php
+++ b/tests/StringFilter/StripSourceStringFilterTest.php
@@ -6,9 +6,6 @@ namespace CultuurNet\UDB3\StringFilter;
 
 class StripSourceStringFilterTest extends StringFilterTest
 {
-    /**
-     * {@inheritdoc}
-     */
     protected string $filterClass = StripSourceStringFilter::class;
 
     /**

--- a/tests/StringFilter/TidyStringFilterTest.php
+++ b/tests/StringFilter/TidyStringFilterTest.php
@@ -6,9 +6,6 @@ namespace CultuurNet\UDB3\StringFilter;
 
 class TidyStringFilterTest extends StringFilterTest
 {
-    /**
-     * {@inheritdoc}
-     */
     protected string $filterClass = TidyStringFilter::class;
 
     /**


### PR DESCRIPTION
### Removed
- Removed unneeded inheritdoc comments

### Note
- The functions with a `static` return type are not changed/removed, this is only meaningful when running on PHP 8

---

Ticket: https://jira.uitdatabank.be/browse/III-6308
