### PR TITLE
III-6310 Refactor `UpdateContactPoint` to new `ContactPoint`

### DIFF
--- a/features/event/contact-point.feature
+++ b/features/event/contact-point.feature
@@ -129,17 +129,4 @@ Feature: Test the UDB3 events API
     And I send a PUT request to "%{eventUrl}/contact-point"
     Then the response status should be "204"
     When I get the event at "%{eventUrl}"
-    And the JSON response at "contactPoint" should be:
-    """
-    {
-      "email": [
-        ""
-      ],
-      "phone": [
-        ""
-      ],
-      "url": [
-        ""
-      ]
-    }
-    """
+    Then the JSON response should not have contactPoint

--- a/features/organizer/contact-point.feature
+++ b/features/organizer/contact-point.feature
@@ -88,3 +88,17 @@ Feature: Test organizer contactPoint property
     """
     [ "http://www.testurl.be" ]
     """
+
+  Scenario: Clear organizer contact point information via contact-point endpoint
+    When I set the JSON request payload to:
+    """
+    {
+      "url": [],
+      "email": [],
+      "phone": []
+    }
+    """
+    And I send a PUT request to "%{organizerUrl}/contact-point"
+    Then the response status should be "204"
+    When I get the organizer at "%{organizerUrl}"
+    Then the JSON response should not have contactPoint

--- a/features/place/contact-point.feature
+++ b/features/place/contact-point.feature
@@ -119,17 +119,4 @@ Feature: Test place contactPoint property
     And I send a PUT request to "%{placeUrl}/contact-point"
     Then the response status should be "204"
     When I get the place at "%{placeUrl}"
-    And the JSON response at "contactPoint" should be:
-    """
-    {
-      "email": [
-        ""
-      ],
-      "phone": [
-        ""
-      ],
-      "url": [
-        ""
-      ]
-    }
-    """
+    Then the JSON response should not have contactPoint

--- a/src/ContactPoint.php
+++ b/src/ContactPoint.php
@@ -7,8 +7,11 @@ namespace CultuurNet\UDB3;
 use Broadway\Serializer\Serializable;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint as Udb3ModelContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 
 /**
  * @deprecated
@@ -93,5 +96,35 @@ final class ContactPoint implements Serializable, JsonLdSerializableInterface
         );
 
         return new self($phones, $emails, $urls);
+    }
+
+    public function toUdb3ModelContactPoint(): Udb3ModelContactPoint
+    {
+        $phones = new TelephoneNumbers(...array_map(
+            function (string $phone) {
+                return new TelephoneNumber($phone);
+            },
+            $this->phones
+        ));
+
+        $emails = new EmailAddresses(...array_map(
+            function (string $email) {
+                return new EmailAddress($email);
+            },
+            $this->emails
+        ));
+
+        $urls = new Urls(...array_map(
+            function (string $url) {
+                return new Url($url);
+            },
+            $this->urls
+        ));
+
+        return new Udb3ModelContactPoint(
+            $phones,
+            $emails,
+            $urls
+        );
     }
 }

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Calendar\CalendarFactory;
 use CultuurNet\UDB3\Cdb\CdbXmlPriceInfoParser;
 use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
-use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\ContactPoint as LegacyContactPoint;
 use CultuurNet\UDB3\Description;
 use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\AudienceUpdated;
@@ -75,6 +75,7 @@ use CultuurNet\UDB3\Media\Properties\Description as ImageDescription;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEventUpdate;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Video;
@@ -644,7 +645,7 @@ final class Event extends Offer
 
     protected function createContactPointUpdatedEvent(ContactPoint $contactPoint): ContactPointUpdated
     {
-        return new ContactPointUpdated($this->eventId, $contactPoint);
+        return new ContactPointUpdated($this->eventId, LegacyContactPoint::fromUdb3ModelContactPoint($contactPoint));
     }
 
     protected function createGeoCoordinatesUpdatedEvent(Coordinates $coordinates): GeoCoordinatesUpdated

--- a/src/Http/Deserializer/Offer/UpdateContactPointDenormalizer.php
+++ b/src/Http/Deserializer/Offer/UpdateContactPointDenormalizer.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Deserializer\Offer;
 
-use CultuurNet\UDB3\ContactPoint;
 use CultuurNet\UDB3\Event\Commands\UpdateContactPoint as EventUpdateContactPoint;
+use CultuurNet\UDB3\Model\Serializer\ValueObject\Contact\ContactPointDenormalizer;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Offer\Commands\AbstractUpdateContactPoint;
 use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Place\Commands\UpdateContactPoint as PlaceUpdateContactPoint;
@@ -14,22 +15,22 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 final class UpdateContactPointDenormalizer implements DenormalizerInterface
 {
     private OfferType $offerType;
-
     private string $offerId;
+    private ContactPointDenormalizer $contactPointDenormalizer;
 
-    public function __construct(OfferType $offerType, string $offerId)
-    {
+    public function __construct(
+        OfferType $offerType,
+        string $offerId,
+        ContactPointDenormalizer $contactPointDenormalizer
+    ) {
         $this->offerType = $offerType;
         $this->offerId = $offerId;
+        $this->contactPointDenormalizer = $contactPointDenormalizer;
     }
 
     public function denormalize($data, $class, $format = null, array $context = []): AbstractUpdateContactPoint
     {
-        $contactPoint = new ContactPoint(
-            $data['phone'],
-            $data['email'],
-            $data['url'],
-        );
+        $contactPoint = $this->contactPointDenormalizer->denormalize($data, ContactPoint::class, $format, $context);
 
         if ($this->offerType->sameAs(OfferType::event())) {
             return new EventUpdateContactPoint(

--- a/src/Http/Event/ImportEventRequestHandler.php
+++ b/src/Http/Event/ImportEventRequestHandler.php
@@ -228,8 +228,7 @@ final class ImportEventRequestHandler implements RequestHandlerInterface
         $bookingInfo = $eventAdapter->getBookingInfo();
         $commands[] = new UpdateBookingInfo($eventId, $bookingInfo);
 
-        $contactPoint = $eventAdapter->getContactPoint();
-        $commands[] = new UpdateContactPoint($eventId, $contactPoint);
+        $commands[] = new UpdateContactPoint($eventId, $event->getContactPoint());
 
         $description = $eventAdapter->getDescription();
         if ($description) {

--- a/src/Http/Offer/UpdateContactPointRequestHandler.php
+++ b/src/Http/Offer/UpdateContactPointRequestHandler.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Model\Serializer\ValueObject\Contact\ContactPointDenormalizer;
 use CultuurNet\UDB3\Offer\Commands\AbstractUpdateContactPoint;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -42,7 +43,11 @@ final class UpdateContactPointRequestHandler implements RequestHandlerInterface
                 )
             ),
             new DenormalizingRequestBodyParser(
-                new UpdateContactPointDenormalizer($offerType, $offerId),
+                new UpdateContactPointDenormalizer(
+                    $offerType,
+                    $offerId,
+                    new ContactPointDenormalizer()
+                ),
                 AbstractUpdateContactPoint::class,
             ),
         );

--- a/src/Http/Place/ImportPlaceRequestHandler.php
+++ b/src/Http/Place/ImportPlaceRequestHandler.php
@@ -192,8 +192,7 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
         $bookingInfo = $placeAdapter->getBookingInfo();
         $commands[] = new UpdateBookingInfo($placeId, $bookingInfo);
 
-        $contactPoint = $placeAdapter->getContactPoint();
-        $commands[] = new UpdateContactPoint($placeId, $contactPoint);
+        $commands[] = new UpdateContactPoint($placeId, $place->getContactPoint());
 
         $description = $placeAdapter->getDescription();
         if ($description) {

--- a/src/Offer/Commands/AbstractUpdateContactPoint.php
+++ b/src/Offer/Commands/AbstractUpdateContactPoint.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 
 abstract class AbstractUpdateContactPoint extends AbstractCommand
 {

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -9,7 +9,6 @@ use CultureFeed_Cdb_Item_Base;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Collection\Exception\CollectionItemNotFoundException;
-use CultuurNet\UDB3\ContactPoint;
 use CultuurNet\UDB3\Description;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
@@ -20,6 +19,7 @@ use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Properties\Description as ImageDescription;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Video;
@@ -445,7 +445,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     protected function applyContactPointUpdated(AbstractContactPointUpdated $contactPointUpdated): void
     {
-        $this->contactPoint = $contactPointUpdated->getContactPoint();
+        $this->contactPoint = $contactPointUpdated->getContactPoint()->toUdb3ModelContactPoint();
     }
 
     public function updateGeoCoordinates(Coordinates $coordinates): void

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarFactory;
 use CultuurNet\UDB3\Cdb\ActorItemFactory;
-use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\ContactPoint as LegacyContactPoint;
 use CultuurNet\UDB3\Description;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Properties\Description as ImageDescription;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -445,7 +446,7 @@ class Place extends Offer
 
     protected function createContactPointUpdatedEvent(ContactPoint $contactPoint): ContactPointUpdated
     {
-        return new ContactPointUpdated($this->placeId, $contactPoint);
+        return new ContactPointUpdated($this->placeId, LegacyContactPoint::fromUdb3ModelContactPoint($contactPoint));
     }
 
     protected function createGeoCoordinatesUpdatedEvent(Coordinates $coordinates): GeoCoordinatesUpdated

--- a/tests/Event/Commands/UpdateContactPointTest.php
+++ b/tests/Event/Commands/UpdateContactPointTest.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\Commands;
 
-use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use PHPUnit\Framework\TestCase;
 
 class UpdateContactPointTest extends TestCase
@@ -16,9 +22,9 @@ class UpdateContactPointTest extends TestCase
         $this->updateContactPoint = new UpdateContactPoint(
             'id',
             new ContactPoint(
-                ['0123456789'],
-                ['foo@bar.com'],
-                ['http://foo.bar']
+                new TelephoneNumbers(new TelephoneNumber('0123456789')),
+                new EmailAddresses(new EmailAddress('foo@bar.com')),
+                new Urls(new Url('http://foo.bar'))
             )
         );
     }
@@ -31,9 +37,9 @@ class UpdateContactPointTest extends TestCase
         $expectedUpdateContactPoint = new UpdateContactPoint(
             'id',
             new ContactPoint(
-                ['0123456789'],
-                ['foo@bar.com'],
-                ['http://foo.bar']
+                new TelephoneNumbers(new TelephoneNumber('0123456789')),
+                new EmailAddresses(new EmailAddress('foo@bar.com')),
+                new Urls(new Url('http://foo.bar'))
             )
         );
 

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -9,7 +9,7 @@ use Broadway\EventSourcing\Testing\AggregateRootScenarioTestCase;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
-use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\ContactPoint as LegacyContactPoint;
 use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\AudienceUpdated;
@@ -43,6 +43,9 @@ use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Price\Tariff;
@@ -54,7 +57,10 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Online\AttendanceMode;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
@@ -465,9 +471,9 @@ class EventTest extends AggregateRootScenarioTestCase
         $createEvent = $this->getCreationEvent();
 
         $contactPoint = new ContactPoint(
-            ['016/101010'],
-            ['test@2dotstwice.be', 'admin@2dotstwice.be'],
-            ['http://www.2dotstwice.be']
+            new TelephoneNumbers(new TelephoneNumber('016/101010')),
+            new EmailAddresses(new EmailAddress('test@2dotstwice.be'), new EmailAddress('admin@2dotstwice.be')),
+            new Urls(new Url('http://www.2dotstwice.be'))
         );
 
         $xmlData = $this->getSample('EventTest.cdbxml.xml');
@@ -477,7 +483,7 @@ class EventTest extends AggregateRootScenarioTestCase
             ->given(
                 [
                     $createEvent,
-                    new ContactPointUpdated($eventId, $contactPoint),
+                    new ContactPointUpdated($eventId, LegacyContactPoint::fromUdb3ModelContactPoint($contactPoint)),
                     new EventUpdatedFromUDB2($eventId, $xmlData, $xmlNamespace),
                 ]
             )
@@ -488,7 +494,7 @@ class EventTest extends AggregateRootScenarioTestCase
             )
             ->then(
                 [
-                    new ContactPointUpdated($eventId, $contactPoint),
+                    new ContactPointUpdated($eventId, LegacyContactPoint::fromUdb3ModelContactPoint($contactPoint)),
                 ]
             );
     }

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -11,7 +11,6 @@ use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
-use CultuurNet\UDB3\ContactPoint;
 use CultuurNet\UDB3\Description as LegacyDescription;
 use CultuurNet\UDB3\Event\Commands\DeleteOnlineUrl;
 use CultuurNet\UDB3\Event\Commands\DeleteTypicalAgeRange;
@@ -44,6 +43,9 @@ use CultuurNet\UDB3\Model\Import\Event\EventCategoryResolver;
 use CultuurNet\UDB3\Model\Import\MediaObject\ImageCollectionFactory;
 use CultuurNet\UDB3\Model\Serializer\Event\EventDenormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Video;
@@ -59,7 +61,10 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Online\AttendanceMode;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\Offer\Commands\DeleteCurrentOrganizer;
 use CultuurNet\UDB3\Offer\Commands\DeleteOffer;
@@ -678,18 +683,18 @@ final class ImportEventRequestHandlerTest extends TestCase
                 new UpdateContactPoint(
                     $eventId,
                     new ContactPoint(
-                        [
-                            '016 12 34 56',
-                            '0497 11 22 33',
-                        ],
-                        [
-                            'info@publiq.be',
-                            'contact@publiq.be',
-                        ],
-                        [
-                            'https://www.publiq.be',
-                            'https://www.publiq.com',
-                        ]
+                        new TelephoneNumbers(
+                            new TelephoneNumber('016 12 34 56'),
+                            new TelephoneNumber('0497 11 22 33'),
+                        ),
+                        new EmailAddresses(
+                            new EmailAddress('info@publiq.be'),
+                            new EmailAddress('contact@publiq.be'),
+                        ),
+                        new Urls(
+                            new Url('https://www.publiq.be'),
+                            new Url('https://www.publiq.com'),
+                        )
                     )
                 ),
                 new UpdateDescription(
@@ -4381,7 +4386,14 @@ final class ImportEventRequestHandlerTest extends TestCase
                 new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
-                new UpdateContactPoint($eventId, new ContactPoint([], ['info@publiq.be'], [])),
+                new UpdateContactPoint(
+                    $eventId,
+                    new ContactPoint(
+                        new TelephoneNumbers(),
+                        new EmailAddresses(new EmailAddress('info@publiq.be')),
+                        new Urls()
+                    )
+                ),
                 new DeleteTypicalAgeRange($eventId),
                 new ImportLabels($eventId, new Labels()),
                 new ImportImages($eventId, new ImageCollection()),

--- a/tests/Http/Offer/UpdateContactPointRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateContactPointRequestHandlerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
-use CultuurNet\UDB3\ContactPoint;
 use CultuurNet\UDB3\Event\Commands\UpdateContactPoint as EventUpdateContactPoint;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
@@ -13,6 +12,13 @@ use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Offer\Commands\AbstractUpdateContactPoint;
 use CultuurNet\UDB3\Place\Commands\UpdateContactPoint as PlaceUpdateContactPoint;
 use Iterator;
@@ -141,9 +147,12 @@ final class UpdateContactPointRequestHandlerTest extends TestCase
                 'expectedCommand' => new $offerCommand(
                     self::OFFER_ID,
                     new ContactPoint(
-                        ['0475/123123', '02/123123'],
-                        [],
-                        ['https://www.publiq.be/']
+                        new TelephoneNumbers(
+                            new TelephoneNumber('0475/123123'),
+                            new TelephoneNumber('02/123123')
+                        ),
+                        new EmailAddresses(),
+                        new Urls(new Url('https://www.publiq.be/'))
                     )
                 ),
             ];
@@ -157,7 +166,7 @@ final class UpdateContactPointRequestHandlerTest extends TestCase
                 ],
                 'expectedCommand' => new $offerCommand(
                     self::OFFER_ID,
-                    new ContactPoint([], [], []),
+                    new ContactPoint(),
                 ),
             ];
 
@@ -170,7 +179,7 @@ final class UpdateContactPointRequestHandlerTest extends TestCase
                 ],
                 'expectedCommand' => new $offerCommand(
                     self::OFFER_ID,
-                    new ContactPoint([''], [''], ['']),
+                    new ContactPoint()
                 ),
             ];
 
@@ -184,9 +193,9 @@ final class UpdateContactPointRequestHandlerTest extends TestCase
                 'expectedCommand' => new $offerCommand(
                     self::OFFER_ID,
                     new ContactPoint(
-                        ['0475/123123'],
-                        ['info@publiq.be'],
-                        ['https://www.publiq.be/']
+                        new TelephoneNumbers(new TelephoneNumber('0475/123123')),
+                        new EmailAddresses(new EmailAddress('info@publiq.be')),
+                        new Urls(new Url('https://www.publiq.be/'))
                     )
                 ),
             ];
@@ -201,9 +210,18 @@ final class UpdateContactPointRequestHandlerTest extends TestCase
                 'expectedCommand' => new $offerCommand(
                     self::OFFER_ID,
                     new ContactPoint(
-                        ['0475/123123', '0473/123456'],
-                        ['info@publiq.be', 'info@madewithlove.com'],
-                        ['https://www.publiq.be/', 'https://madewithlove.com'],
+                        new TelephoneNumbers(
+                            new TelephoneNumber('0475/123123'),
+                            new TelephoneNumber('0473/123456')
+                        ),
+                        new EmailAddresses(
+                            new EmailAddress('info@publiq.be'),
+                            new EmailAddress('info@madewithlove.com')
+                        ),
+                        new Urls(
+                            new Url('https://www.publiq.be/'),
+                            new Url('https://madewithlove.com')
+                        )
                     )
                 ),
             ];

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -18,7 +18,6 @@ use CultuurNet\UDB3\Calendar\DayOfWeek;
 use CultuurNet\UDB3\Calendar\DayOfWeekCollection;
 use CultuurNet\UDB3\Calendar\OpeningHour;
 use CultuurNet\UDB3\Calendar\OpeningTime;
-use CultuurNet\UDB3\ContactPoint;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
@@ -44,6 +43,9 @@ use CultuurNet\UDB3\Model\Serializer\Place\PlaceDenormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoDenormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -59,7 +61,10 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Offer\Commands\DeleteCurrentOrganizer;
 use CultuurNet\UDB3\Offer\Commands\DeleteOffer;
 use CultuurNet\UDB3\Offer\Commands\ImportLabels;
@@ -872,9 +877,9 @@ final class ImportPlaceRequestHandlerTest extends TestCase
                 new UpdateContactPoint(
                     $placeId,
                     new ContactPoint(
-                        ['016 10 20 30'],
-                        ['info@dehel.be'],
-                        ['https://www.dehel.be']
+                        new TelephoneNumbers(new TelephoneNumber('016 10 20 30')),
+                        new EmailAddresses(new EmailAddress('info@dehel.be')),
+                        new Urls(new Url('https://www.dehel.be'))
                     )
                 ),
                 new DeleteTypicalAgeRange($placeId),
@@ -3911,7 +3916,14 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateBookingInfo($placeId, new BookingInfo()),
-                new UpdateContactPoint($placeId, new ContactPoint([], ['info@publiq.be'], [])),
+                new UpdateContactPoint(
+                    $placeId,
+                    new ContactPoint(
+                        null,
+                        new EmailAddresses(new EmailAddress('info@publiq.be')),
+                        null
+                    )
+                ),
                 new DeleteTypicalAgeRange($placeId),
                 new ImportLabels($placeId, new Labels()),
                 new ImportImages($placeId, new ImageCollection()),

--- a/tests/Offer/Commands/AbstractUpdateContactPointTest.php
+++ b/tests/Offer/Commands/AbstractUpdateContactPointTest.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -23,9 +29,9 @@ class AbstractUpdateContactPointTest extends TestCase
     {
         $this->itemId = 'Foo';
         $this->contactPoint = new ContactPoint(
-            ['0123456789'],
-            ['foo@bar.com'],
-            ['http://foo.bar']
+            new TelephoneNumbers(new TelephoneNumber('0123456789')),
+            new EmailAddresses(new EmailAddress('foo@bar.com')),
+            new Urls(new Url('http://foo.bar'))
         );
 
         $this->updateContactPoint = $this->getMockForAbstractClass(
@@ -41,9 +47,9 @@ class AbstractUpdateContactPointTest extends TestCase
     {
         $contactPoint = $this->updateContactPoint->getContactPoint();
         $expectedContactPoint = new ContactPoint(
-            ['0123456789'],
-            ['foo@bar.com'],
-            ['http://foo.bar']
+            new TelephoneNumbers(new TelephoneNumber('0123456789')),
+            new EmailAddresses(new EmailAddress('foo@bar.com')),
+            new Urls(new Url('http://foo.bar'))
         );
 
         $this->assertEquals($expectedContactPoint, $contactPoint);

--- a/tests/Offer/Item/Item.php
+++ b/tests/Offer/Item/Item.php
@@ -7,12 +7,13 @@ namespace CultuurNet\UDB3\Offer\Item;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar\Calendar;
-use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\ContactPoint as LegacyContactPoint;
 use CultuurNet\UDB3\Description;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Properties\Description as ImageDescription;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -213,7 +214,7 @@ final class Item extends Offer
 
     protected function createContactPointUpdatedEvent(ContactPoint $contactPoint): ContactPointUpdated
     {
-        return new ContactPointUpdated($this->id, $contactPoint);
+        return new ContactPointUpdated($this->id, LegacyContactPoint::fromUdb3ModelContactPoint($contactPoint));
     }
 
     protected function createGeoCoordinatesUpdatedEvent(Coordinates $coordinates): GeoCoordinatesUpdated

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Offer;
 
 use Broadway\EventSourcing\Testing\AggregateRootScenarioTestCase;
 use CultuurNet\UDB3\BookingInfo;
-use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\ContactPoint as LegacyContactPoint;
 use CultuurNet\UDB3\Description as LegacyDescription;
 use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Language as LegacyLanguage;
@@ -15,6 +15,9 @@ use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Video;
@@ -23,7 +26,10 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Offer\Item\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\ContactPointUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\DescriptionDeleted;
@@ -272,21 +278,30 @@ class OfferTest extends AggregateRootScenarioTestCase
         $itemId = 'c25e603a-19dd-48e4-94d9-893484402189';
 
         $contactPoint = new ContactPoint(
-            ['016/101010'],
-            ['test@2dotstwice.be', 'admin@2dotstwice.be'],
-            ['http://www.2dotstwice.be']
+            new TelephoneNumbers(new TelephoneNumber('016/101010')),
+            new EmailAddresses(
+                new EmailAddress('test@2dotstwice.be'),
+                new EmailAddress('admin@2dotstwice.be')
+            ),
+            new Urls(new Url('http://www.2dotstwice.be'))
         );
 
         $sameContactPoint = new ContactPoint(
-            ['016/101010'],
-            ['test@2dotstwice.be', 'admin@2dotstwice.be'],
-            ['http://www.2dotstwice.be']
+            new TelephoneNumbers(new TelephoneNumber('016/101010')),
+            new EmailAddresses(
+                new EmailAddress('test@2dotstwice.be'),
+                new EmailAddress('admin@2dotstwice.be')
+            ),
+            new Urls(new Url('http://www.2dotstwice.be'))
         );
 
         $otherContactPoint = new ContactPoint(
-            ['02/101010'],
-            ['admin@public.be', 'test@public.be'],
-            ['http://www.public.be']
+            new TelephoneNumbers(new TelephoneNumber('02/101010')),
+            new EmailAddresses(
+                new EmailAddress('admin@public.b'),
+                new EmailAddress('test@public.be')
+            ),
+            new Urls(new Url('http://www.publiq.be'))
         );
 
         $this->scenario
@@ -305,8 +320,8 @@ class OfferTest extends AggregateRootScenarioTestCase
                 }
             )
             ->then([
-                new ContactPointUpdated($itemId, $contactPoint),
-                new ContactPointUpdated($itemId, $otherContactPoint),
+                new ContactPointUpdated($itemId, LegacyContactPoint::fromUdb3ModelContactPoint($contactPoint)),
+                new ContactPointUpdated($itemId, LegacyContactPoint::fromUdb3ModelContactPoint($otherContactPoint)),
             ]);
     }
 

--- a/tests/OfferCommandHandlerTestTrait.php
+++ b/tests/OfferCommandHandlerTestTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3;
 
+use CultuurNet\UDB3\ContactPoint as LegacyContactPoint;
 use Broadway\Repository\Repository;
 use Broadway\CommandHandling\Testing\Scenario;
 use CultuurNet\UDB3\Language as LegacyLanguage;
@@ -13,6 +14,9 @@ use CultuurNet\UDB3\Media\MediaManagerInterface;
 use CultuurNet\UDB3\Media\Properties\Description as MediaDescription;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
@@ -77,7 +81,11 @@ trait OfferCommandHandlerTestTrait
     public function it_can_update_contact_point_of_an_offer(): void
     {
         $id = '1';
-        $contactPoint = new ContactPoint(['016102030']);
+        $contactPoint = new ContactPoint(
+            new TelephoneNumbers(new TelephoneNumber('016102030')),
+            null,
+            null
+        );
         $commandClass = $this->getCommandClass('UpdateContactPoint');
         $eventClass = $this->getEventClass('ContactPointUpdated');
 
@@ -89,7 +97,7 @@ trait OfferCommandHandlerTestTrait
             ->when(
                 new $commandClass($id, $contactPoint)
             )
-            ->then([new $eventClass($id, $contactPoint)]);
+            ->then([new $eventClass($id, LegacyContactPoint::fromUdb3ModelContactPoint($contactPoint))]);
     }
 
     /**

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -13,9 +13,16 @@ use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
-use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\ContactPoint as LegacyContactPoint;
 use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Place\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Place\Events\PriceInfoUpdated;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeDeleted;
@@ -130,9 +137,12 @@ class PlaceTest extends AggregateRootScenarioTestCase
         $placeId = $placeCreated->getPlaceId();
 
         $contactPoint = new ContactPoint(
-            ['016/101010'],
-            ['test@2dotstwice.be', 'admin@2dotstwice.be'],
-            ['http://www.2dotstwice.be']
+            new TelephoneNumbers(new TelephoneNumber('016/101010')),
+            new EmailAddresses(
+                new EmailAddress('test@2dotstwice.be'),
+                new EmailAddress('admin@2dotstwice.be')
+            ),
+            new Urls(new Url('http://www.2dotstwice.be'))
         );
 
         $cdbXml = $this->getCdbXML('/ReadModel/JSONLD/place_with_long_description.cdbxml.xml');
@@ -142,7 +152,7 @@ class PlaceTest extends AggregateRootScenarioTestCase
             ->given(
                 [
                     $placeCreated,
-                    new ContactPointUpdated($placeId, $contactPoint),
+                    new ContactPointUpdated($placeId, LegacyContactPoint::fromUdb3ModelContactPoint($contactPoint)),
                     new PlaceUpdatedFromUDB2($placeId, $cdbXml, $cdbXmlNamespace),
                 ]
             )
@@ -153,7 +163,7 @@ class PlaceTest extends AggregateRootScenarioTestCase
             )
             ->then(
                 [
-                    new ContactPointUpdated($placeId, $contactPoint),
+                    new ContactPointUpdated($placeId, LegacyContactPoint::fromUdb3ModelContactPoint($contactPoint)),
                 ]
             );
     }


### PR DESCRIPTION
### Added
- Added feature test to update an organizer with an empty contact point values which results in removal of the contactPoint property
- Added method to convert the legacy contact point to a new contact point

### Changed
- Changed the `UpdateContactPoint` command to work with the new `ContactPoint`

---

Ticket: https://jira.uitdatabank.be/browse/III-6310
