### PR TITLE
III-6329 log as error

### DIFF
--- a/src/Offer/AbstractGeoCoordinatesCommandHandler.php
+++ b/src/Offer/AbstractGeoCoordinatesCommandHandler.php
@@ -86,7 +86,7 @@ abstract class AbstractGeoCoordinatesCommandHandler extends Udb3CommandHandler i
         }
 
         if ($coordinates === null) {
-            $this->logger->debug('Could not find coordinates for fallback address for offer id ' . $offerId);
+            $this->logger->error('Could not find coordinates for fallback address for offer id ' . $offerId);
             return;
         }
 


### PR DESCRIPTION
### Changed

- `AbstractGeoCoordinatesCommandHandler`: log final fail as `error` instead of `debug`

---

Ticket: https://jira.publiq.be/browse/III-6329
