### PR TITLE
III-6154 make place duplication more robust

### DIFF
--- a/features/Bootstrap/FeatureContext.php
+++ b/features/Bootstrap/FeatureContext.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\AfterFeatureScope;
+use Behat\Behat\Hook\Scope\BeforeFeatureScope;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use CultuurNet\UDB3\State\RequestState;
 use CultuurNet\UDB3\State\ResponseState;
@@ -97,6 +99,23 @@ final class FeatureContext implements Context
      */
     public static function beforeSuite(BeforeSuiteScope $scope): void
     {
+        self::disablePreventDuplicatePlaceCreation();
+    }
+
+    /**
+     * @BeforeFeature @duplicate
+     */
+    public static function beforeFeatureDuplicate(BeforeFeatureScope $scope): void
+    {
+        self::enablePreventDuplicatePlaceCreation();
+    }
+
+    /**
+     * @AfterFeature @duplicate
+     */
+    public static function afterFeatureDuplicate(AfterFeatureScope $scope): void
+    {
+        self::disablePreventDuplicatePlaceCreation();
     }
 
     /**

--- a/features/Bootstrap/FeatureContext.php
+++ b/features/Bootstrap/FeatureContext.php
@@ -66,6 +66,32 @@ final class FeatureContext implements Context
         );
     }
 
+    private static function disablePreventDuplicatePlaceCreation(): void
+    {
+        $configFile = file_get_contents('config.php');
+
+        $configFile = str_replace(
+            "'prevent_duplicate_places_creation' => true",
+            "'prevent_duplicate_places_creation' => false",
+            $configFile
+        );
+
+        file_put_contents('config.php', $configFile);
+    }
+
+    private static function enablePreventDuplicatePlaceCreation(): void
+    {
+        $configFile = file_get_contents('config.php');
+
+        $configFile = str_replace(
+            "'prevent_duplicate_places_creation' => false",
+            "'prevent_duplicate_places_creation' => true",
+            $configFile
+        );
+
+        file_put_contents('config.php', $configFile);
+    }
+
     /**
      * @BeforeSuite
      */

--- a/features/Steps/UtilitySteps.php
+++ b/features/Steps/UtilitySteps.php
@@ -6,8 +6,6 @@ namespace CultuurNet\UDB3\Steps;
 
 trait UtilitySteps
 {
-    private bool $initialPreventDuplicatePlaceCreationValue;
-
     /**
      * @Given /^I create a name that includes special characters of elastic search and keep it as "([^"]*)"$/
      */
@@ -46,45 +44,5 @@ trait UtilitySteps
     public function iWaitSeconds(int $seconds): void
     {
         sleep($seconds);
-    }
-
-    /**
-     * @Given /^I prevent duplicate place creation$/
-     */
-    public function iPreventDuplicatePlaceCreation(): void
-    {
-        $configFile = file_get_contents('config.php');
-
-        if (str_contains($configFile, "'prevent_duplicate_places_creation' => true")) {
-            // The config was already on true, so no further changes are required
-            $this->initialPreventDuplicatePlaceCreationValue = true;
-            return;
-        }
-
-        $configFile = str_replace(
-            "'prevent_duplicate_places_creation' => false",
-            "'prevent_duplicate_places_creation' => true",
-            $configFile
-        );
-
-        file_put_contents('config.php', $configFile);
-
-        $this->initialPreventDuplicatePlaceCreationValue = false;
-    }
-
-    /**
-     * @Then /^I restore the duplicate configuration/
-     */
-    public function iRestoreTheDuplicateConfigurationOption(): void
-    {
-        $configFile = file_get_contents('config.php');
-
-        $configFile = str_replace(
-            "'prevent_duplicate_places_creation' => true",
-            "'prevent_duplicate_places_creation' => " . ($this->initialPreventDuplicatePlaceCreationValue ? 'true' : 'false'),
-            $configFile
-        );
-
-        file_put_contents('config.php', $configFile);
     }
 }

--- a/features/place/duplicate.feature
+++ b/features/place/duplicate.feature
@@ -21,15 +21,15 @@ Feature: Test creating places
     Then I wait for the place with url "/places/%{originalPlaceId}" to be indexed
     Given I create a minimal place then I should get a "409" response code
     Then the JSON response should be:
-  """
-  {
-    "type": "https://api.publiq.be/probs/uitdatabank/duplicate-place",
-    "title": "Duplicate place",
-    "status": 409,
-    "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
-    "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
-  }
-  """
+    """
+    {
+      "type": "https://api.publiq.be/probs/uitdatabank/duplicate-place",
+      "title": "Duplicate place",
+      "status": 409,
+      "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
+      "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
+    }
+    """
 
   Scenario: Be prevented from creating a new place if we already have one on that address when the the address contains special chars
     Given I create a name that includes special characters of elastic search and keep it as "name"
@@ -37,12 +37,12 @@ Feature: Test creating places
     Then I wait for the place with url "/places/%{originalPlaceId}" to be indexed
     Given I create a minimal place then I should get a "409" response code
     Then the JSON response should be:
-  """
-  {
-    "type": "https://api.publiq.be/probs/uitdatabank/duplicate-place",
-    "title": "Duplicate place",
-    "status": 409,
-    "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
-    "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
-  }
-  """
+    """
+    {
+      "type": "https://api.publiq.be/probs/uitdatabank/duplicate-place",
+      "title": "Duplicate place",
+      "status": 409,
+      "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
+      "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
+    }
+    """

--- a/features/place/duplicate.feature
+++ b/features/place/duplicate.feature
@@ -1,3 +1,4 @@
+@duplicate
 Feature: Test creating places
 
   Background:
@@ -6,49 +7,42 @@ Feature: Test creating places
     And I am authorized as JWT provider v1 user "centraal_beheerder"
     And I send and accept "application/json"
 
-
   Scenario: Allow creating a new place, if a "duplicate" place before was rejected
-    Given I prevent duplicate place creation
     Given I create a random name of 6 characters and keep it as "name"
     Given I create a minimal place and save the "id" as "originalPlaceId" then I should get a "201" response code
     When I publish the place at "/places/%{originalPlaceId}"
     And I reject the place at "/places/%{originalPlaceId}" with reason "Rejected"
     Then I wait for the place with url "/places/%{originalPlaceId}" to be indexed
-    Given I create a minimal place then I should get a "201" response code
-    Then I restore the duplicate configuration
+    And I create a minimal place then I should get a "201" response code
 
   Scenario: Be prevented from creating a new place if we already have one on that address
-    Given I prevent duplicate place creation
     Given I create a random name of 6 characters and keep it as "name"
     Given I create a minimal place and save the "id" as "originalPlaceId" then I should get a "201" response code
     Then I wait for the place with url "/places/%{originalPlaceId}" to be indexed
     Given I create a minimal place then I should get a "409" response code
     Then the JSON response should be:
-    """
-    {
-        "type": "https://api.publiq.be/probs/uitdatabank/duplicate-place",
-        "title": "Duplicate place",
-        "status": 409,
-        "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
-        "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
-    }
-    """
-    Then I restore the duplicate configuration
+  """
+  {
+    "type": "https://api.publiq.be/probs/uitdatabank/duplicate-place",
+    "title": "Duplicate place",
+    "status": 409,
+    "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
+    "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
+  }
+  """
 
-    Scenario: Be prevented from creating a new place if we already have one on that address when the the address contains special chars
-        Given I prevent duplicate place creation
-        Given I create a name that includes special characters of elastic search and keep it as "name"
-        Given I create a minimal place and save the "id" as "originalPlaceId" then I should get a "201" response code
-        Then I wait for the place with url "/places/%{originalPlaceId}" to be indexed
-        Given I create a minimal place then I should get a "409" response code
-        Then the JSON response should be:
-    """
-    {
-        "type": "https://api.publiq.be/probs/uitdatabank/duplicate-place",
-        "title": "Duplicate place",
-        "status": 409,
-        "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
-        "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
-    }
-    """
-    Then I restore the duplicate configuration
+  Scenario: Be prevented from creating a new place if we already have one on that address when the the address contains special chars
+    Given I create a name that includes special characters of elastic search and keep it as "name"
+    Given I create a minimal place and save the "id" as "originalPlaceId" then I should get a "201" response code
+    Then I wait for the place with url "/places/%{originalPlaceId}" to be indexed
+    Given I create a minimal place then I should get a "409" response code
+    Then the JSON response should be:
+  """
+  {
+    "type": "https://api.publiq.be/probs/uitdatabank/duplicate-place",
+    "title": "Duplicate place",
+    "status": 409,
+    "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
+    "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
+  }
+  """


### PR DESCRIPTION
### Changed

- `UtilitySteps`: Remove `I prevent duplicate place creation` & `I restore the duplicate configuration` to make this part of the tests more robust.
- FeatureContext`: Added `BeforeScenario` & `BeforeScenario` as a replacement of the previous removed UtilitySteps.

---

Ticket: https://jira.publiq.be/browse/III-6514
