### PR TITLE
III-6310 Handle update with empty description

### DIFF
--- a/src/Http/Offer/UpdateDescriptionRequestHandler.php
+++ b/src/Http/Offer/UpdateDescriptionRequestHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\CommandBus;
-use CultuurNet\UDB3\Description;
+use CultuurNet\UDB3\Description as LegacyDescription;
 use CultuurNet\UDB3\Event\Commands\UpdateDescription as EventUpdateDescription;
 use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
@@ -13,6 +13,9 @@ use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Text\DescriptionShouldNotBeEmpty;
+use CultuurNet\UDB3\Offer\Commands\DeleteDescription;
 use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Offer\Serializers\DescriptionDenormalizer;
 use CultuurNet\UDB3\Place\Commands\UpdateDescription as PlaceUpdateDescription;
@@ -47,26 +50,35 @@ final class UpdateDescriptionRequestHandler implements RequestHandlerInterface
             new DenormalizingRequestBodyParser(new DescriptionDenormalizer(), Description::class)
         );
 
-        $request = $requestBodyParser->parse($request);
+        try {
+            $request = $requestBodyParser->parse($request);
 
-        /** @var Description $description */
-        $description = $request->getParsedBody();
+            /** @var Description $description */
+            $description = $request->getParsedBody();
 
-        if ($offerType->sameAs(OfferType::event())) {
-            $updateDescription = new EventUpdateDescription(
+            if ($offerType->sameAs(OfferType::event())) {
+                $updateDescription = new EventUpdateDescription(
+                    $offerId,
+                    $language,
+                    LegacyDescription::fromUdb3ModelDescription($description)
+                );
+            } else {
+                $updateDescription = new PlaceUpdateDescription(
+                    $offerId,
+                    $language,
+                    LegacyDescription::fromUdb3ModelDescription($description)
+                );
+            }
+
+            $this->commandBus->dispatch($updateDescription);
+        } catch (DescriptionShouldNotBeEmpty $exception) {
+            $deleteDescription = new DeleteDescription(
                 $offerId,
                 $language,
-                $description
             );
-        } else {
-            $updateDescription = new PlaceUpdateDescription(
-                $offerId,
-                $language,
-                $description,
-            );
+            $this->commandBus->dispatch($deleteDescription);
         }
 
-        $this->commandBus->dispatch($updateDescription);
         return new NoContentResponse();
     }
 }

--- a/src/Model/ValueObject/Text/Description.php
+++ b/src/Model/ValueObject/Text/Description.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Text;
 use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\IsNotEmpty;
 use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\IsString;
 use CultuurNet\UDB3\Model\ValueObject\String\Behaviour\Trims;
+use InvalidArgumentException;
 
 class Description
 {
@@ -17,7 +18,11 @@ class Description
     public function __construct(string $value)
     {
         $value = $this->trim($value);
-        $this->guardNotEmpty($value);
+        try {
+            $this->guardNotEmpty($value);
+        } catch (InvalidArgumentException $e) {
+            throw new DescriptionShouldNotBeEmpty();
+        }
         $this->setValue($value);
     }
 }

--- a/src/Model/ValueObject/Text/DescriptionShouldNotBeEmpty.php
+++ b/src/Model/ValueObject/Text/DescriptionShouldNotBeEmpty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Text;
+
+use InvalidArgumentException;
+
+final class DescriptionShouldNotBeEmpty extends InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('Description should not be empty.');
+    }
+}

--- a/src/Offer/Serializers/DescriptionDenormalizer.php
+++ b/src/Offer/Serializers/DescriptionDenormalizer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Serializers;
 
-use CultuurNet\UDB3\Description;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
 use Symfony\Component\Serializer\Exception\UnsupportedException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 

--- a/tests/Http/Offer/UpdateDescriptionRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateDescriptionRequestHandlerTest.php
@@ -15,6 +15,7 @@ use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Offer\Commands\AbstractUpdateDescription;
+use CultuurNet\UDB3\Offer\Commands\DeleteDescription;
 use CultuurNet\UDB3\Place\Commands\UpdateDescription as PlaceUpdateDescription;
 use PHPUnit\Framework\TestCase;
 
@@ -45,11 +46,12 @@ final class UpdateDescriptionRequestHandlerTest extends TestCase
     /**
      * @test
      * @dataProvider validRequestsProvider
+     * @param AbstractUpdateDescription|DeleteDescription $descriptionCommand
      */
     public function it_handles_updating_the_description_of_an_offer(
         string $offerType,
         string $request,
-        AbstractUpdateDescription $updateDescription
+        $descriptionCommand
     ): void {
         $updateDescriptionRequest = $this->psr7RequestBuilder
             ->withRouteParameter('offerType', $offerType)
@@ -62,7 +64,7 @@ final class UpdateDescriptionRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
-                $updateDescription,
+                $descriptionCommand,
             ],
             $this->commandBus->getRecordedCommands()
         );
@@ -97,19 +99,17 @@ final class UpdateDescriptionRequestHandlerTest extends TestCase
             [
                 'offerType' => 'events',
                 'request' => '{"description": ""}',
-                'updateDescription' => new EventUpdateDescription(
+                'updateDescription' => new DeleteDescription(
                     self::OFFER_ID,
-                    new Language('en'),
-                    new Description('')
+                    new Language('en')
                 ),
             ],
             [
                 'offerType' => 'places',
                 'request' => '{"description": ""}',
-                'updateDescription' => new PlaceUpdateDescription(
+                'updateDescription' => new DeleteDescription(
                     self::OFFER_ID,
-                    new Language('en'),
-                    new Description('')
+                    new Language('en')
                 ),
             ],
         ];

--- a/tests/Model/ValueObject/Text/DescriptionTest.php
+++ b/tests/Model/ValueObject/Text/DescriptionTest.php
@@ -13,8 +13,8 @@ class DescriptionTest extends TestCase
      */
     public function it_should_not_be_empty(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Given string should not be empty.');
+        $this->expectException(DescriptionShouldNotBeEmpty::class);
+        $this->expectExceptionMessage('Description should not be empty.');
 
         new Description('');
     }


### PR DESCRIPTION
### Added
- Added new exception `DescriptionShouldNotBeEmpty`

### Changed
- Handle an empty description and dispatch a `DeleteDescription` for this

---

Ticket: https://jira.uitdatabank.be/browse/III-6310
