### PR TITLE
III-6339: bugfix PDF export

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,7 +14,7 @@ parameters:
 	scanFiles:
 		- vendor/gridonic/princexml-php/lib/prince.php
 	excludePaths:
-	    - src/EventExport/Format/HTML/TransformingIteratorIterator.php
+		- src/EventExport/Format/HTML/TransformingIteratorIterator.php
 		- tests/Event/Productions/SimilarEventsRepositoryTest.php
 		- tests/Http/Productions/SuggestProductionRequestHandlerTest.php
 		- tests/Offer/Commands/Moderation/AbstractModerationCommandTestBase.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,7 @@ parameters:
 	scanFiles:
 		- vendor/gridonic/princexml-php/lib/prince.php
 	excludePaths:
+	    - src/EventExport/Format/HTML/TransformingIteratorIterator.php
 		- tests/Event/Productions/SimilarEventsRepositoryTest.php
 		- tests/Http/Productions/SuggestProductionRequestHandlerTest.php
 		- tests/Offer/Commands/Moderation/AbstractModerationCommandTestBase.php

--- a/src/EventExport/Format/HTML/TransformingIteratorIterator.php
+++ b/src/EventExport/Format/HTML/TransformingIteratorIterator.php
@@ -23,6 +23,7 @@ class TransformingIteratorIterator extends IteratorIterator
         $this->function = $function;
     }
 
+    // @todo return types for this function can only be added after we are on PHP 8
     public function current()
     {
         $fn = $this->function;

--- a/src/EventExport/Format/HTML/TransformingIteratorIterator.php
+++ b/src/EventExport/Format/HTML/TransformingIteratorIterator.php
@@ -23,7 +23,7 @@ class TransformingIteratorIterator extends IteratorIterator
         $this->function = $function;
     }
 
-    public function current(): int
+    public function current()
     {
         $fn = $this->function;
         $current = parent::current();


### PR DESCRIPTION
### Changed

- `TransformingIteratorIterator`: remove returnType from `current()`
- `phpstan.neon` : ignore TransformingIteratorIterator for the moment, because we can not get phpstan to check it for both PHP 7.4 & PHP 8.1

### Fixed

- PDF exports should work again.

### Follow-up ticket to be done in the future

- https://jira.publiq.be/browse/III-6342

---

Ticket: https://jira.publiq.be/browse/III-6339
