### PR TITLE
III-6154 Update config script

### DIFF
--- a/docker/config.sh
+++ b/docker/config.sh
@@ -1,23 +1,27 @@
 #!/bin/sh
 
-if ! grep -q "host.docker.internal" /etc/hosts; then
+UPDATE_HOSTS=${HAS_SUDO:-true}
+
+if [ "$UPDATE_HOSTS" = "true" ] && ! grep -q "host.docker.internal" /etc/hosts; then
   echo "host.docker.internal has to be in your hosts-file, to add you need sudo privileges"
   sudo sh -c 'echo "127.0.0.1 host.docker.internal" >> /etc/hosts'
 fi
 
-DIR="../appconfig/files/uitdatabank/docker/udb3-backend/"
+APPCONFIG_ROOTDIR=${APPCONFIG:-'../appconfig'}
+
+DIR="${APPCONFIG_ROOTDIR}/files/uitdatabank/docker/udb3-backend/"
 if [ -d "$DIR" ]; then
   cp -R "$DIR"/* .
   cp "$DIR"/.env .
 else
-  echo "Error: missing appconfig. The appconfig and udb3-backend repositories must be cloned into the same parent folder."
+  echo "Error: missing appconfig. The appconfig repository must be cloned at ${APPCONFIG_ROOTDIR}."
   exit 1
 fi
 
-DIR="../appconfig/files/uitdatabank/docker/keys/"
+DIR="${APPCONFIG_ROOTDIR}/files/uitdatabank/docker/keys/"
 if [ -d "$DIR" ]; then
   cp -R "$DIR"/* .
 else
-  echo "Error: missing appconfig. The appconfig and udb3-backend repositories must be cloned into the same parent folder."
+  echo "Error: missing appconfig. The appconfig repository must be cloned at ${APPCONFIG_ROOTDIR}."
   exit 1
 fi


### PR DESCRIPTION
### Changed

- `config.sh`: Updated the `config.sh` to edit `/etc/hosts` based on an `environment variable`. In a later PR `host.docker.internal`

### Fixed

- Developers on `MacOs` can still edit `/etc/hosts`, without affecting the Jenkins-user.

---

Ticket: https://jira.publiq.be/browse/III-6154
