### PR TITLE
III-6347 BUGFIX Keycloak id token was wrongly classified as access token

### DIFF
--- a/src/Http/Auth/Jwt/JsonWebToken.php
+++ b/src/Http/Auth/Jwt/JsonWebToken.php
@@ -63,7 +63,7 @@ final class JsonWebToken
             return self::UIT_ID_V2_JWT_PROVIDER_TOKEN;
         }
 
-        // This is a check for Keycloak tokens, auth0 does not have this field
+        // Keycloak ID Tokens have a claim `typ` with a value of ID
         if ($this->token->claims()->get('typ', '') === 'ID') {
             return self::UIT_ID_V2_JWT_PROVIDER_TOKEN;
         }

--- a/src/Http/Auth/Jwt/JsonWebToken.php
+++ b/src/Http/Auth/Jwt/JsonWebToken.php
@@ -63,6 +63,11 @@ final class JsonWebToken
             return self::UIT_ID_V2_JWT_PROVIDER_TOKEN;
         }
 
+        // This is a check for Keycloak tokens, auth0 does not have this field
+        if ($this->token->claims()->get('typ', '') === 'ID') {
+            return self::UIT_ID_V2_JWT_PROVIDER_TOKEN;
+        }
+
         // V2 client access tokens are always requested using the client-credentials grant type (gty)
         // @see https://stackoverflow.com/questions/49492471/whats-the-meaning-of-the-gty-claim-in-a-jwt-token/49492971
         if ($this->token->claims()->get('gty', '') === 'client-credentials') {

--- a/src/Http/Auth/Jwt/UitIdV2JwtValidator.php
+++ b/src/Http/Auth/Jwt/UitIdV2JwtValidator.php
@@ -29,6 +29,7 @@ final class UitIdV2JwtValidator implements JwtValidator
 
         if ($tokenType === JsonWebToken::UIT_ID_V2_JWT_PROVIDER_TOKEN) {
             $this->validateIdTokenFromJwtProvider($token);
+            return;
         }
 
         if ($tokenType === JsonWebToken::UIT_ID_V2_USER_ACCESS_TOKEN ||

--- a/tests/Http/Auth/Jwt/JsonWebTokenTest.php
+++ b/tests/Http/Auth/Jwt/JsonWebTokenTest.php
@@ -134,6 +134,18 @@ class JsonWebTokenTest extends TestCase
     /**
      * @test
      */
+    public function it_returns_v2_jwt_provider_token_type_when_typ_is_id(): void
+    {
+        $jwt = JsonWebTokenFactory::createWithClaims([
+            'azp' => 'mock-client',
+            'typ' => 'ID',
+        ]);
+        $this->assertEquals(JsonWebToken::UIT_ID_V2_JWT_PROVIDER_TOKEN, $jwt->getType());
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_v2_client_access_token_type_if_the_gty_claim_is_set_to_client_credentials(): void
     {
         $jwt = JsonWebTokenFactory::createWithClaims(


### PR DESCRIPTION
### Fixed
Keycloak tokens always have an AZP field, auth0 does not.
This tripped up our code to identify if it is a provider token (a token with an api key).
We added an extra check to typ, a field that only exists in Keycloak.

---

Ticket: https://jira.uitdatabank.be/browse/III-6347
