### PR TITLE
III-6345 Reuse existing role

### DIFF
--- a/app/Migrations/Version20241015103145.php
+++ b/app/Migrations/Version20241015103145.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241015103145 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('ownership_search');
+
+        $table->addColumn('role_id', Types::GUID)
+            ->setLength(36)
+            ->setNotnull(false)
+            ->setDefault(null);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('ownership_search');
+
+        $table->dropColumn('role_id');
+    }
+}

--- a/app/Ownership/OwnershipServiceProvider.php
+++ b/app/Ownership/OwnershipServiceProvider.php
@@ -77,8 +77,7 @@ final class OwnershipServiceProvider extends AbstractServiceProvider
             fn () => new OwnershipPermissionProjector(
                 $container->get('authorized_command_bus'),
                 $container->get(OwnershipSearchRepository::class),
-                new UuidFactory(),
-                $container->get('role_search_v3_repository')
+                new UuidFactory()
             )
         );
     }

--- a/src/Ownership/Readmodels/OwnershipPermissionProjector.php
+++ b/src/Ownership/Readmodels/OwnershipPermissionProjector.php
@@ -8,6 +8,8 @@ use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListener;
 use CultuurNet\UDB3\CommandHandling\AuthorizedCommandBusInterface;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
+use CultuurNet\UDB3\Http\Ownership\Search\SearchParameter;
+use CultuurNet\UDB3\Http\Ownership\Search\SearchQuery;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
 use CultuurNet\UDB3\Ownership\Events\OwnershipDeleted;
@@ -17,8 +19,7 @@ use CultuurNet\UDB3\Role\Commands\AddConstraint;
 use CultuurNet\UDB3\Role\Commands\AddPermission;
 use CultuurNet\UDB3\Role\Commands\AddUser;
 use CultuurNet\UDB3\Role\Commands\CreateRole;
-use CultuurNet\UDB3\Role\Commands\DeleteRole;
-use CultuurNet\UDB3\Role\ReadModel\Search\RepositoryInterface;
+use CultuurNet\UDB3\Role\Commands\RemoveUser;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
 use Ramsey\Uuid\UuidFactoryInterface;
@@ -32,18 +33,15 @@ final class OwnershipPermissionProjector implements EventListener
     private AuthorizedCommandBusInterface $commandBus;
     private OwnershipSearchRepository $ownershipSearchRepository;
     private UuidFactoryInterface $uuidFactory;
-    private RepositoryInterface $roleSearchRepository;
 
     public function __construct(
         AuthorizedCommandBusInterface $commandBus,
         OwnershipSearchRepository $ownershipSearchRepository,
-        UuidFactoryInterface $uuidFactory,
-        RepositoryInterface $roleSearchRepository
+        UuidFactoryInterface $uuidFactory
     ) {
         $this->commandBus = $commandBus;
         $this->ownershipSearchRepository = $ownershipSearchRepository;
         $this->uuidFactory = $uuidFactory;
-        $this->roleSearchRepository = $roleSearchRepository;
     }
 
     public function handle(DomainMessage $domainMessage): void
@@ -60,32 +58,46 @@ final class OwnershipPermissionProjector implements EventListener
 
     protected function applyOwnershipApproved(OwnershipApproved $ownershipApproved): void
     {
-        $ownershipItem = $this->ownershipSearchRepository->getById($ownershipApproved->getId());
-
         $this->commandBus->disableAuthorization();
 
-        $roleId = $this->createRole($ownershipItem);
+        $ownershipItem = $this->ownershipSearchRepository->getById($ownershipApproved->getId());
+        $roleId = $this->getExistingRoleId($ownershipItem->getItemId());
 
-        $this->commandBus->dispatch(
-            new AddConstraint(
-                $roleId,
-                new Query('(id:' . $ownershipItem->getItemId() . ' OR (organizer.id:' . $ownershipItem->getItemId() . ' AND _type:event))')
-            )
-        );
+        if ($roleId !== null) {
+            $this->commandBus->dispatch(
+                new AddUser(
+                    $roleId,
+                    $ownershipItem->getOwnerId()
+                )
+            );
+        }
 
-        $this->commandBus->dispatch(
-            new AddPermission(
-                $roleId,
-                Permission::organisatiesBewerken()
-            )
-        );
+        if ($roleId === null) {
+            $roleId = $this->createRole($ownershipItem);
 
-        $this->commandBus->dispatch(
-            new AddPermission(
-                $roleId,
-                Permission::aanbodBewerken()
-            )
-        );
+            $this->commandBus->dispatch(
+                new AddConstraint(
+                    $roleId,
+                    new Query('(id:' . $ownershipItem->getItemId() . ' OR (organizer.id:' . $ownershipItem->getItemId() . ' AND _type:event))')
+                )
+            );
+
+            $this->commandBus->dispatch(
+                new AddPermission(
+                    $roleId,
+                    Permission::organisatiesBewerken()
+                )
+            );
+
+            $this->commandBus->dispatch(
+                new AddPermission(
+                    $roleId,
+                    Permission::aanbodBewerken()
+                )
+            );
+        }
+
+        $this->ownershipSearchRepository->updateRoleId($ownershipItem->getId(), $roleId);
 
         $this->commandBus->enableAuthorization();
     }
@@ -94,17 +106,43 @@ final class OwnershipPermissionProjector implements EventListener
     {
         $this->commandBus->disableAuthorization();
 
-        $roles = $this->roleSearchRepository->search(
-            $this->createRoleName($ownershipDeleted->getId())
-        );
+        $ownershipItem = $this->ownershipSearchRepository->getById($ownershipDeleted->getId());
 
-        foreach ($roles->getMember() as $role) {
+        if ($ownershipItem->getRoleId()) {
             $this->commandBus->dispatch(
-                new DeleteRole(new UUID($role['uuid']))
+                new RemoveUser(
+                    $ownershipItem->getRoleId(),
+                    $ownershipItem->getOwnerId()
+                )
             );
         }
 
+        $this->ownershipSearchRepository->updateRoleId($ownershipItem->getId(), null);
+
         $this->commandBus->enableAuthorization();
+    }
+
+    private function getExistingRoleId(string $itemId): ?UUID
+    {
+        $existingOwnerships = $this->ownershipSearchRepository->search(
+            new SearchQuery(
+                [
+                    new SearchParameter('itemId', $itemId),
+                ],
+                0,
+                1
+            )
+        );
+
+        if ($existingOwnerships->count() < 1) {
+            return null;
+        }
+
+        if ($existingOwnerships->getFirst()->getRoleId() === null) {
+            return null;
+        }
+
+        return $existingOwnerships->getFirst()->getRoleId();
     }
 
     private function createRole(OwnershipItem $ownershipItem): UUID

--- a/src/Ownership/Readmodels/OwnershipPermissionProjector.php
+++ b/src/Ownership/Readmodels/OwnershipPermissionProjector.php
@@ -104,19 +104,20 @@ final class OwnershipPermissionProjector implements EventListener
 
     protected function applyOwnershipDeleted(OwnershipDeleted $ownershipDeleted): void
     {
-        $this->commandBus->disableAuthorization();
-
         $ownershipItem = $this->ownershipSearchRepository->getById($ownershipDeleted->getId());
 
-        if ($ownershipItem->getRoleId()) {
-            $this->commandBus->dispatch(
-                new RemoveUser(
-                    $ownershipItem->getRoleId(),
-                    $ownershipItem->getOwnerId()
-                )
-            );
+        if ($ownershipItem->getRoleId() === null) {
+            return;
         }
 
+        $this->commandBus->disableAuthorization();
+
+        $this->commandBus->dispatch(
+            new RemoveUser(
+                $ownershipItem->getRoleId(),
+                $ownershipItem->getOwnerId()
+            )
+        );
         $this->ownershipSearchRepository->updateRoleId($ownershipItem->getId(), null);
 
         $this->commandBus->enableAuthorization();

--- a/src/Ownership/Readmodels/OwnershipPermissionProjector.php
+++ b/src/Ownership/Readmodels/OwnershipPermissionProjector.php
@@ -139,10 +139,6 @@ final class OwnershipPermissionProjector implements EventListener
             return null;
         }
 
-        if ($existingOwnerships->getFirst()->getRoleId() === null) {
-            return null;
-        }
-
         return $existingOwnerships->getFirst()->getRoleId();
     }
 

--- a/src/Ownership/Readmodels/OwnershipPermissionProjector.php
+++ b/src/Ownership/Readmodels/OwnershipPermissionProjector.php
@@ -70,9 +70,7 @@ final class OwnershipPermissionProjector implements EventListener
                     $ownershipItem->getOwnerId()
                 )
             );
-        }
-
-        if ($roleId === null) {
+        } else {
             $roleId = $this->createRole($ownershipItem);
 
             $this->commandBus->dispatch(

--- a/src/Ownership/Repositories/OwnershipItem.php
+++ b/src/Ownership/Repositories/OwnershipItem.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Ownership\Repositories;
 
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+
 final class OwnershipItem
 {
     private string $id;
@@ -11,6 +13,7 @@ final class OwnershipItem
     private string $itemType;
     private string $ownerId;
     private string $state;
+    private ?UUID $roleId;
 
     public function __construct(
         string $id,
@@ -24,6 +27,14 @@ final class OwnershipItem
         $this->itemType = $itemType;
         $this->ownerId = $ownerId;
         $this->state = $state;
+        $this->roleId = null;
+    }
+
+    public function withRoleId(UUID $roleId): self
+    {
+        $ownershipItem = clone $this;
+        $ownershipItem->roleId = $roleId;
+        return $ownershipItem;
     }
 
     public function getId(): string
@@ -49,5 +60,10 @@ final class OwnershipItem
     public function getState(): string
     {
         return $this->state;
+    }
+
+    public function getRoleId(): ?UUID
+    {
+        return $this->roleId;
     }
 }

--- a/src/Ownership/Repositories/Search/DBALOwnershipSearchRepository.php
+++ b/src/Ownership/Repositories/Search/DBALOwnershipSearchRepository.php
@@ -48,6 +48,15 @@ final class DBALOwnershipSearchRepository implements OwnershipSearchRepository
         );
     }
 
+    public function updateRoleId(string $id, ?UUID $roleId): void
+    {
+        $this->connection->update(
+            'ownership_search',
+            ['role_id' => $roleId ? $roleId->toString() : null],
+            ['id' => $id]
+        );
+    }
+
     public function getById(string $id): OwnershipItem
     {
         $ownershipSearchRow = $this->connection->createQueryBuilder()

--- a/src/Ownership/Repositories/Search/DBALOwnershipSearchRepository.php
+++ b/src/Ownership/Repositories/Search/DBALOwnershipSearchRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Ownership\Repositories\Search;
 
 use CultuurNet\UDB3\Http\Ownership\Search\SearchQuery;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\OwnershipState;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItemCollection;
@@ -34,6 +35,7 @@ final class DBALOwnershipSearchRepository implements OwnershipSearchRepository
             'item_type' => $ownershipSearchItem->getItemType(),
             'owner_id' => $ownershipSearchItem->getOwnerId(),
             'state' => $ownershipSearchItem->getState(),
+            'role_id' => $ownershipSearchItem->getRoleId() ? $ownershipSearchItem->getRoleId()->toString() : null,
         ]);
     }
 
@@ -137,12 +139,18 @@ final class DBALOwnershipSearchRepository implements OwnershipSearchRepository
 
     private function createOwnershipSearchItem(array $ownershipSearchRow): OwnershipItem
     {
-        return new OwnershipItem(
+        $ownershipItem = new OwnershipItem(
             $ownershipSearchRow['id'],
             $ownershipSearchRow['item_id'],
             $ownershipSearchRow['item_type'],
             $ownershipSearchRow['owner_id'],
             $ownershipSearchRow['state']
         );
+
+        if ($ownershipSearchRow['role_id']) {
+            $ownershipItem = $ownershipItem->withRoleId(new UUID($ownershipSearchRow['role_id']));
+        }
+
+        return $ownershipItem;
     }
 }

--- a/src/Ownership/Repositories/Search/OwnershipSearchRepository.php
+++ b/src/Ownership/Repositories/Search/OwnershipSearchRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Ownership\Repositories\Search;
 
 use CultuurNet\UDB3\Http\Ownership\Search\SearchQuery;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\OwnershipState;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItemCollection;
@@ -14,6 +15,8 @@ interface OwnershipSearchRepository
     public function save(OwnershipItem $ownershipSearchItem): void;
 
     public function updateState(string $id, OwnershipState $state): void;
+
+    public function updateRoleId(string $id, ?UUID $roleId): void;
 
     public function getById(string $id): OwnershipItem;
 

--- a/tests/Ownership/Repositories/Search/DBALOwnershipSearchRepositoryTest.php
+++ b/tests/Ownership/Repositories/Search/DBALOwnershipSearchRepositoryTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Ownership\Repositories\Search;
 use CultuurNet\UDB3\DBALTestConnectionTrait;
 use CultuurNet\UDB3\Http\Ownership\Search\SearchParameter;
 use CultuurNet\UDB3\Http\Ownership\Search\SearchQuery;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\OwnershipState;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItemCollection;
@@ -90,6 +91,37 @@ class DBALOwnershipSearchRepositoryTest extends TestCase
             [OwnershipState::rejected()],
             [OwnershipState::deleted()],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_update_the_role_id(): void
+    {
+        $roleId = new UUID('a75aa571-8131-4fd6-ab9b-59c7672095e5');
+        $ownershipItem = new OwnershipItem(
+            'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+            '9e68dafc-01d8-4c1c-9612-599c918b981d',
+            'organizer',
+            'auth0|63e22626e39a8ca1264bd29b',
+            OwnershipState::requested()->toString()
+        );
+        $this->ownershipSearchRepository->save($ownershipItem);
+
+        $this->ownershipSearchRepository->updateRoleId($ownershipItem->getId(), $roleId);
+
+        $updatedOwnershipItem = (new OwnershipItem(
+            $ownershipItem->getId(),
+            $ownershipItem->getItemId(),
+            $ownershipItem->getItemType(),
+            $ownershipItem->getOwnerId(),
+            OwnershipState::requested()->toString()
+        ))->withRoleId($roleId);
+
+        $this->assertEquals(
+            $updatedOwnershipItem,
+            $this->ownershipSearchRepository->getById('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
+        );
     }
 
     /**


### PR DESCRIPTION
### Added
- Added `role_id` to table `ownership_search`
- Added method `updateRoleId` to set the link between an ownership and a role

### Changed
- When approving an ownership check for an existing role for the organizer, if this exists add the user to this role
- When deleting an ownership delete the user from the linked role

---

Ticket: https://jira.uitdatabank.be/browse/III-6345
