### PR TITLE
III-6346 Use organizer name for role name

### DIFF
--- a/app/Ownership/OwnershipServiceProvider.php
+++ b/app/Ownership/OwnershipServiceProvider.php
@@ -8,6 +8,7 @@ use Broadway\EventHandling\EventBus;
 use CultuurNet\UDB3\AggregateType;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
+use CultuurNet\UDB3\Ownership\Readmodels\Name\DocumentItemNameResolver;
 use CultuurNet\UDB3\Ownership\Readmodels\OwnershipLDProjector;
 use CultuurNet\UDB3\Ownership\Readmodels\OwnershipPermissionProjector;
 use CultuurNet\UDB3\Ownership\Readmodels\OwnershipSearchProjector;
@@ -77,7 +78,8 @@ final class OwnershipServiceProvider extends AbstractServiceProvider
             fn () => new OwnershipPermissionProjector(
                 $container->get('authorized_command_bus'),
                 $container->get(OwnershipSearchRepository::class),
-                new UuidFactory()
+                new UuidFactory(),
+                new DocumentItemNameResolver($container->get('organizer_jsonld_repository'))
             )
         );
     }

--- a/src/Ownership/Readmodels/Name/DocumentItemNameResolver.php
+++ b/src/Ownership/Readmodels/Name/DocumentItemNameResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\Readmodels\Name;
+
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\Offer\ExtractOfferName;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+
+final class DocumentItemNameResolver implements ItemNameResolver
+{
+    private DocumentRepository $organizerDocumentRepository;
+
+    public function __construct(DocumentRepository $organizerDocumentRepository)
+    {
+        $this->organizerDocumentRepository = $organizerDocumentRepository;
+    }
+
+    public function resolve(string $itemId): string
+    {
+        $organizerDocument = $this->organizerDocumentRepository->fetch($itemId);
+
+        $organizer = Json::decodeAssociatively($organizerDocument->getRawBody());
+
+        return (new ExtractOfferName())->extract($organizer);
+    }
+}

--- a/src/Ownership/Readmodels/Name/ItemNameResolver.php
+++ b/src/Ownership/Readmodels/Name/ItemNameResolver.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\Readmodels\Name;
+
+interface ItemNameResolver
+{
+    public function resolve(string $itemId): string;
+}

--- a/src/Ownership/Readmodels/OwnershipPermissionProjector.php
+++ b/src/Ownership/Readmodels/OwnershipPermissionProjector.php
@@ -151,7 +151,7 @@ final class OwnershipPermissionProjector implements EventListener
         $this->commandBus->dispatch(
             new CreateRole(
                 $roleId,
-                'Beheerders ' . $this->itemNameResolver->resolve($ownershipItem->getItemId())
+                'Beheerders organisatie ' . $this->itemNameResolver->resolve($ownershipItem->getItemId())
             )
         );
 

--- a/src/Ownership/Readmodels/OwnershipPermissionProjector.php
+++ b/src/Ownership/Readmodels/OwnershipPermissionProjector.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Http\Ownership\Search\SearchQuery;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
 use CultuurNet\UDB3\Ownership\Events\OwnershipDeleted;
+use CultuurNet\UDB3\Ownership\Readmodels\Name\ItemNameResolver;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
 use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
 use CultuurNet\UDB3\Role\Commands\AddConstraint;
@@ -33,15 +34,18 @@ final class OwnershipPermissionProjector implements EventListener
     private AuthorizedCommandBusInterface $commandBus;
     private OwnershipSearchRepository $ownershipSearchRepository;
     private UuidFactoryInterface $uuidFactory;
+    private ItemNameResolver $itemNameResolver;
 
     public function __construct(
         AuthorizedCommandBusInterface $commandBus,
         OwnershipSearchRepository $ownershipSearchRepository,
-        UuidFactoryInterface $uuidFactory
+        UuidFactoryInterface $uuidFactory,
+        ItemNameResolver $itemNameResolver
     ) {
         $this->commandBus = $commandBus;
         $this->ownershipSearchRepository = $ownershipSearchRepository;
         $this->uuidFactory = $uuidFactory;
+        $this->itemNameResolver = $itemNameResolver;
     }
 
     public function handle(DomainMessage $domainMessage): void
@@ -147,7 +151,7 @@ final class OwnershipPermissionProjector implements EventListener
         $this->commandBus->dispatch(
             new CreateRole(
                 $roleId,
-                $this->createRoleName($ownershipItem->getId())
+                'Beheerders ' . $this->itemNameResolver->resolve($ownershipItem->getItemId())
             )
         );
 
@@ -159,10 +163,5 @@ final class OwnershipPermissionProjector implements EventListener
         );
 
         return $roleId;
-    }
-
-    private function createRoleName(string $ownershipId): string
-    {
-        return 'Ownership ' . $ownershipId;
     }
 }

--- a/tests/Ownership/Readmodels/Name/DocumentItemNameResolverTest.php
+++ b/tests/Ownership/Readmodels/Name/DocumentItemNameResolverTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Ownership\Readmodels\Name;
+
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\TestCase;
+
+class DocumentItemNameResolverTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_resolve_the_name_of_an_organization(): void
+    {
+        $organizerId = '9e68dafc-01d8-4c1c-9612-599c918b981d';
+
+        $documentRepository = $this->createMock(DocumentRepository::class);
+        $documentRepository->expects($this->once())
+            ->method('fetch')
+            ->with($organizerId)
+            ->willReturn(
+                new JsonDocument(
+                    $organizerId,
+                    Json::encode([
+                        'name' => [
+                            'nl' => 'publiq vzw',
+                            'fr' => 'publiq asbl',
+                        ],
+                        'mainLanguage' => 'fr',
+                    ])
+                )
+            );
+
+        $resolver = new DocumentItemNameResolver($documentRepository);
+
+        $this->assertEquals('publiq asbl', $resolver->resolve($organizerId));
+    }
+}

--- a/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
+++ b/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
@@ -125,7 +125,7 @@ class OwnershipPermissionProjectorTest extends TestCase
             [
                 new CreateRole(
                     $roleId,
-                    'Beheerders publiq vzw'
+                    'Beheerders organisatie publiq vzw'
                 ),
                 new AddUser(
                     $roleId,

--- a/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
+++ b/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
 use CultuurNet\UDB3\Ownership\Events\OwnershipDeleted;
 use CultuurNet\UDB3\Ownership\OwnershipState;
+use CultuurNet\UDB3\Ownership\Readmodels\Name\ItemNameResolver;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItemCollection;
 use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
@@ -50,11 +51,17 @@ class OwnershipPermissionProjectorTest extends TestCase
 
         $this->uuidFactory = $this->createMock(UuidFactory::class);
 
+        $itemNameResolver = $this->createMock(ItemNameResolver::class);
+        $itemNameResolver->expects($this->any())
+            ->method('resolve')
+            ->with('9e68dafc-01d8-4c1c-9612-599c918b981d')
+            ->willReturn('publiq vzw');
 
         $this->ownershipPermissionProjector = new OwnershipPermissionProjector(
             $this->commandBus,
             $this->ownershipSearchRepository,
-            $this->uuidFactory
+            $this->uuidFactory,
+            $itemNameResolver
         );
     }
 
@@ -118,7 +125,7 @@ class OwnershipPermissionProjectorTest extends TestCase
             [
                 new CreateRole(
                     $roleId,
-                    'Ownership ' . $ownershipId
+                    'Beheerders publiq vzw'
                 ),
                 new AddUser(
                     $roleId,


### PR DESCRIPTION
### Changed
- Used organizer name for role name. Currently, this only works for organizers, but it can be easily extended for places and events.

---

Ticket: https://jira.uitdatabank.be/browse/III-6346
