### PR TITLE
III-6373 Allow searching ownerships on ownerId

### DIFF
--- a/features/ownership/search.feature
+++ b/features/ownership/search.feature
@@ -43,6 +43,24 @@ Feature: Test searching ownerships
     And the JSON response at "member/1/ownerId" should be "auth0|631748dba64ea78e3983b203"
     And the JSON response at "member/1/state" should be "approved"
 
+  Scenario: Searching ownership of an organizer by ownerId
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
+    And I create a random name of 10 characters and keep it as "ownerId"
+    And I request ownership for "%{ownerId}" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
+    And I create a minimal organizer and save the "id" as "anotherOrganizerId"
+    And I request ownership for "%{ownerId}" on the organizer with organizerId "%{anotherOrganizerId}" and save the "id" as "ownershipId3"
+    When I send a GET request to '/ownerships/?ownerId=%{ownerId}'
+    Then the response status should be 200
+    And the JSON response at "itemsPerPage" should be 2
+    And the JSON response at "totalItems" should be 2
+    And the JSON response at "member/0/id" should be "%{ownershipId2}"
+    And the JSON response at "member/0/ownerId" should be "%{ownerId}"
+    And the JSON response at "member/0/state" should be "requested"
+    And the JSON response at "member/1/id" should be "%{ownershipId3}"
+    And the JSON response at "member/1/ownerId" should be "%{ownerId}"
+    And the JSON response at "member/1/state" should be "requested"
+
   Scenario: Searching ownership of an organizer by state and with offset and limit
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"

--- a/src/Http/Ownership/Search/SearchParameter.php
+++ b/src/Http/Ownership/Search/SearchParameter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Ownership\Search;
 
 final class SearchParameter
 {
-    public const SUPPORTED_URL_PARAMETERS = ['itemId', 'state'];
+    public const SUPPORTED_URL_PARAMETERS = ['itemId', 'state', 'ownerId'];
 
     private string $urlParameter;
     private string $value;

--- a/src/Ownership/Repositories/Search/DBALOwnershipSearchRepository.php
+++ b/src/Ownership/Repositories/Search/DBALOwnershipSearchRepository.php
@@ -20,6 +20,7 @@ final class DBALOwnershipSearchRepository implements OwnershipSearchRepository
     private const URL_PARAMETER_TO_COLUMN = [
         'itemId' => 'item_id',
         'state' => 'state',
+        'ownerId' => 'owner_id',
     ];
 
     public function __construct(Connection $connection)

--- a/tests/Ownership/Repositories/Search/DBALOwnershipSearchRepositoryTest.php
+++ b/tests/Ownership/Repositories/Search/DBALOwnershipSearchRepositoryTest.php
@@ -214,6 +214,39 @@ class DBALOwnershipSearchRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_can_search_ownership_items_by_owner_id(): void
+    {
+        $ownershipItem = new OwnershipItem(
+            'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+            '9e68dafc-01d8-4c1c-9612-599c918b981d',
+            'organizer',
+            'auth0|63e22626e39a8ca1264bd29b',
+            OwnershipState::requested()->toString()
+        );
+        $this->ownershipSearchRepository->save($ownershipItem);
+
+        $anotherOwnershipItem = new OwnershipItem(
+            '672265b6-d4d0-416e-9b0b-c29de7d18125',
+            '9e68dafc-01d8-4c1c-9612-599c918b981d',
+            'organizer',
+            'a75aa571-8131-4fd6-ab9b-59c7672095e5',
+            OwnershipState::approved()->toString()
+        );
+        $this->ownershipSearchRepository->save($anotherOwnershipItem);
+
+        $this->assertEquals(
+            new OwnershipItemCollection($ownershipItem),
+            $this->ownershipSearchRepository->search(
+                new SearchQuery([
+                    new SearchParameter('ownerId', 'auth0|63e22626e39a8ca1264bd29b'),
+                ])
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_takes_into_account_offset_when_searching(): void
     {
         $ownershipItem = new OwnershipItem(


### PR DESCRIPTION
### Added
- Added `ownerId` as a valid query parameter when searching ownerships

---

Ticket: https://jira.uitdatabank.be/browse/III-6373
