### PR TITLE
III-6368 finetune ContactPointUpdated: BackwardsCompatiblePayloadSerializerFactory

### DIFF
--- a/src/BackwardsCompatiblePayloadSerializerFactory.php
+++ b/src/BackwardsCompatiblePayloadSerializerFactory.php
@@ -328,7 +328,6 @@ class BackwardsCompatiblePayloadSerializerFactory
         $refactoredEventEvents = [
             EventTypicalAgeRangeDeleted::class,
             EventTypicalAgeRangeUpdated::class,
-            EventContactPointUpdated::class,
             EventOrganizerUpdated::class,
             EventOrganizerDeleted::class,
             EventDescriptionUpdated::class,
@@ -352,7 +351,6 @@ class BackwardsCompatiblePayloadSerializerFactory
             PlaceOrganizerDeleted::class,
             PlaceTypicalAgeRangeDeleted::class,
             PlaceTypicalAgeRangeUpdated::class,
-            PlaceContactPointUpdated::class,
             PlaceDescriptionUpdated::class,
             PlaceDeleted::class,
         ];

--- a/src/BackwardsCompatiblePayloadSerializerFactory.php
+++ b/src/BackwardsCompatiblePayloadSerializerFactory.php
@@ -406,11 +406,11 @@ class BackwardsCompatiblePayloadSerializerFactory
             $payloadManipulatingSerializer->manipulateEventsOfClass(
                 $contactPointUpdatedEvent,
                 function (array $serializedObject) use ($contactPointUpdatedEvent) {
-                    if (isset($serializedObject['payload']['email'])) {
-                        $serializedObject['payload']['email'] = array_map('trim', $serializedObject['payload']['email']);
+                    if (isset($serializedObject['payload']['contactPoint']['email'])) {
+                        $serializedObject['payload']['contactPoint']['email'] = array_map('trim', $serializedObject['payload']['contactPoint']['email']);
                     }
-                    if (isset($serializedObject['payload']['url'])) {
-                        $serializedObject['payload']['url'] = array_map('trim', $serializedObject['payload']['url']);
+                    if (isset($serializedObject['payload']['contactPoint']['url'])) {
+                        $serializedObject['payload']['contactPoint']['url'] = array_map('trim', $serializedObject['payload']['contactPoint']['url']);
                     }
                     if ($contactPointUpdatedEvent === EventContactPointUpdated::class) {
                         return self::replaceEventIdWithItemId($serializedObject);

--- a/src/BackwardsCompatiblePayloadSerializerFactory.php
+++ b/src/BackwardsCompatiblePayloadSerializerFactory.php
@@ -412,7 +412,7 @@ class BackwardsCompatiblePayloadSerializerFactory
                     if (isset($serializedObject['payload']['url'])) {
                         $serializedObject['payload']['url'] = array_map('trim', $serializedObject['payload']['url']);
                     }
-                    if ($contactPointUpdatedEvent instanceof EventContactPointUpdated::class) {
+                    if ($contactPointUpdatedEvent === EventContactPointUpdated::class) {
                         return self::replaceEventIdWithItemId($serializedObject);
                     }
                     return self::replacePlaceIdWithItemId($serializedObject);

--- a/src/BackwardsCompatiblePayloadSerializerFactory.php
+++ b/src/BackwardsCompatiblePayloadSerializerFactory.php
@@ -396,6 +396,31 @@ class BackwardsCompatiblePayloadSerializerFactory
         }
 
         /**
+         * ContactPointUpdated Events
+         */
+        $contactPointUpdatedEvents = [
+            EventContactPointUpdated::class,
+            PlaceContactPointUpdated::class,
+        ];
+        foreach ($contactPointUpdatedEvents as $contactPointUpdatedEvent) {
+            $payloadManipulatingSerializer->manipulateEventsOfClass(
+                $contactPointUpdatedEvent,
+                function (array $serializedObject) use ($contactPointUpdatedEvent) {
+                    if (isset($serializedObject['payload']['email'])) {
+                        $serializedObject['payload']['email'] = array_map('trim', $serializedObject['payload']['email']);
+                    }
+                    if (isset($serializedObject['payload']['url'])) {
+                        $serializedObject['payload']['url'] = array_map('trim', $serializedObject['payload']['url']);
+                    }
+                    if ($contactPointUpdatedEvent instanceof EventContactPointUpdated::class) {
+                        return self::replaceEventIdWithItemId($serializedObject);
+                    }
+                    return self::replacePlaceIdWithItemId($serializedObject);
+                }
+            );
+        }
+
+        /**
          * Roles
          */
         $payloadManipulatingSerializer->manipulateEventsOfClass(

--- a/tests/samples/serialized_event_contact_point_updated_class_with_spaces.json
+++ b/tests/samples/serialized_event_contact_point_updated_class_with_spaces.json
@@ -1,0 +1,18 @@
+{
+  "class": "CultuurNet\\UDB3\\Event\\Events\\ContactPointUpdated",
+  "payload": {
+    "event_id": "9ee97636-e5bf-4421-b2c1-9f785a1b4d4c",
+    "contactPoint": {
+      "phone": [
+        "0474888888"
+      ],
+      "email": [
+        " willem@willem.com "
+      ],
+      "url": [
+        "http:\/\/test.com  "
+      ],
+      "type": ""
+    }
+  }
+}


### PR DESCRIPTION
### Changed

- `BackwardsCompatiblePayloadSerializerFactory`: Handle `email` & `urls` with leading & trailing spaces.
- `BackwardsCompatiblePayloadSerializerFactoryTest`: Add unit test to check for trimming `ContactPoints`.
- `serialized_event_contact_point_updated_class_with_spaces.json`: Sample file for Unit Test

### Fixed

- `Urls` & `emails` with leading & trailing spaces can be taken from the event_store without issue.

---

Ticket: https://jira.publiq.be/browse/III-6368
