### PR TITLE
III-6372 Improve ownership permission checks

### DIFF
--- a/features/ownership/request.feature
+++ b/features/ownership/request.feature
@@ -2,10 +2,10 @@ Feature: Test requesting ownership
   Background:
     Given I am using the UDB3 base URL
     And I am using an UiTID v1 API key of consumer "uitdatabank"
-    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I am authorized as JWT provider v2 user "invoerder"
     And I send and accept "application/json"
 
-  Scenario: Requesting ownership of an organizer
+  Scenario: Requesting ownership of an organizer as creator of the organizer
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     When I get the ownership with ownershipId "%{ownershipId}"
@@ -14,8 +14,40 @@ Feature: Test requesting ownership
     And the JSON response at "itemType" should be "organizer"
     And the JSON response at "ownerId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
-    And the JSON response at "requesterId" should be "7a583ed3-cbc1-481d-93b1-d80fff0174dd"
+    And the JSON response at "requesterId" should be "d759fd36-fb28-4fe3-8ec6-b4aaf990371d"
     And the JSON response at "state" should be "requested"
+
+  Scenario: Requesting ownership of an organizer for yourself
+    Given I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I create a minimal organizer and save the "id" as "organizerId"
+    And I am authorized as JWT provider v2 user "invoerder"
+    And I request ownership for "d759fd36-fb28-4fe3-8ec6-b4aaf990371d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    When I get the ownership with ownershipId "%{ownershipId}"
+    Then the JSON response at "id" should be "%{ownershipId}"
+
+  Scenario: Requesting ownership of an organizer for someone else is not allowened if you are not an owner
+    Given I am authorized as JWT provider v1 user "centraal_beheerder"
+    And I create a minimal organizer and save the "id" as "organizerId"
+    And I am authorized as JWT provider v2 user "invoerder"
+    And I set the JSON request payload to:
+    """
+    {
+      "itemId": "%{organizerId}",
+      "itemType": "organizer",
+      "ownerId": "auth0|64089494e980aedd96740212"
+    }
+    """
+    When I send a POST request to '/ownerships'
+    Then the response status should be 403
+    And the JSON response should be:
+    """
+    {
+     "type": "https://api.publiq.be/probs/auth/forbidden",
+     "title": "Forbidden",
+     "status": 403,
+     "detail": "You are not allowed to request ownership for this item"
+    }
+    """
 
   Scenario: Requesting the same ownership of an organizer is not allowed
     Given I create a minimal organizer and save the "id" as "organizerId"

--- a/src/Http/Ownership/OwnershipStatusGuard.php
+++ b/src/Http/Ownership/OwnershipStatusGuard.php
@@ -25,6 +25,19 @@ final class OwnershipStatusGuard
         $this->permissionVoter = $permissionVoter;
     }
 
+    public function isAllowedToRequest(string $itemId, string $requesterId, CurrentUser $currentUser): void
+    {
+        $isOwner = $this->permissionVoter->isAllowed(
+            Permission::organisatiesBeheren(),
+            $itemId,
+            $currentUser->getId()
+        );
+
+        if (!$isOwner && $currentUser->getId() !== $requesterId) {
+            throw ApiProblem::forbidden('You are not allowed to request ownership for this item');
+        }
+    }
+
     public function isAllowedToApprove(string $ownershipId, CurrentUser $currentUser): void
     {
         $this->isAllowed($ownershipId, $currentUser, 'approve');


### PR DESCRIPTION
### Changed
- Improved the Ownership request permission checks by using the organizer permission voter which handles:
  - A god user can always request for someone else
  - A creator can always request for someone else
  - Someone with permission "organisatie bewerken" can request
  - Always possible to request for yourself

---

Ticket: https://jira.uitdatabank.be/browse/III-6372
