### PR TITLE
III-6382 Cleanup duplicate places table

### DIFF
--- a/app/Migrations/Version20241031084923.php
+++ b/app/Migrations/Version20241031084923.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241031084923 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $schema->dropTable('duplicate_places_removed_from_cluster_import');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->createTable('duplicate_places_removed_from_cluster_import');
+        $table->addColumn('place_uuid', Types::GUID)->setLength(36)->setNotnull(true);
+    }
+}

--- a/app/Migrations/Version20241031085217.php
+++ b/app/Migrations/Version20241031085217.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241031085217 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $schema->getTable('duplicate_places_removed_from_cluster')
+            ->dropColumn('cluster_id');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->getTable('duplicate_places_removed_from_cluster')
+            ->addColumn('cluster_id', Types::STRING)->setNotnull(true)->setLength(40);
+    }
+}

--- a/app/Migrations/Version20241031085647.php
+++ b/app/Migrations/Version20241031085647.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241031085647 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $schema->getTable('duplicate_places_import')
+            ->dropColumn('canonical');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->getTable('duplicate_places_import')
+            ->addColumn('canonical', Types::GUID)->setLength(36)->setNotnull(false)->setDefault(null);
+    }
+}


### PR DESCRIPTION
### Removed
- Remove table `duplicate_places_removed_from_cluster_import`
- Remove column `cluster_id` from `duplicate_places_removed_from_cluster`
- Remove column `canonical` from `duplicate_places_import`

---

Ticket: https://jira.uitdatabank.be/browse/III-6382
