### PR TITLE
III-6312 Allow encoded space

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-III-6312-allow-encoded-space",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-III-6312-allow-encoded-space",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1851bb69f66f19085cae039c262ef346",
+    "content-hash": "79fda9d664460977a01493450dc5e7ab",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -6041,7 +6041,7 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-III-6312-allow-encoded-space",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
@@ -6053,6 +6053,7 @@
                 "reference": "15e2a28a2c63d46823613cb7a4dc8e86dfe7dffe",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79fda9d664460977a01493450dc5e7ab",
+    "content-hash": "1851bb69f66f19085cae039c262ef346",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -6041,19 +6041,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-III-6312-allow-encoded-space",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "e5a840e87769c39d22fef7c51e4b003eff9edc6a"
+                "reference": "15e2a28a2c63d46823613cb7a4dc8e86dfe7dffe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/e5a840e87769c39d22fef7c51e4b003eff9edc6a",
-                "reference": "e5a840e87769c39d22fef7c51e4b003eff9edc6a",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/15e2a28a2c63d46823613cb7a4dc8e86dfe7dffe",
+                "reference": "15e2a28a2c63d46823613cb7a4dc8e86dfe7dffe",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6068,9 +6067,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/III-6312-allow-encoded-space"
             },
-            "time": "2024-10-31T08:48:40+00:00"
+            "time": "2024-11-06T13:09:26+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/features/curator/create.feature
+++ b/features/curator/create.feature
@@ -323,7 +323,7 @@ Feature: Test the curator API
     {
       "schemaErrors": [
         {
-          "error": "The string should match pattern: ^http(s?):([/|.|\\w|\\s|-])*\\.(?:jpeg|jpg|gif|png)$",
+          "error": "The string should match pattern: ^http(s?):([/|.|\\w|%20|-])*\\.(?:jpeg|jpg|gif|png)$",
           "jsonPointer": "/image/url"
         }
       ],

--- a/features/curator/create.feature
+++ b/features/curator/create.feature
@@ -120,6 +120,47 @@ Feature: Test the curator API
     }
     """
 
+  Scenario: Create a news article with an image with a space in it's url
+    Given I set the JSON request payload to:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}",
+      "image": {
+        "url": "https://www.uitinvlaanderen.be/img%20small.png",
+        "copyrightHolder": "publiq vzw"
+      }
+    }
+    """
+    When I send a POST request to "/news-articles"
+    Then the response status should be "201"
+    And the response body should be valid JSON
+    And I keep the value of the JSON response at "id" as "articleId"
+    When I send a GET request to "/news-articles/%{articleId}"
+    Then the response status should be "200"
+    And the JSON response should be:
+    """
+    {
+      "headline": "publiq wint API award",
+      "inLanguage": "nl",
+      "text": "Op 10 januari 2020 wint publiq de API award",
+      "about": "17284745-7bcf-461a-aad0-d3ad54880e75",
+      "publisher": "BILL",
+      "publisherLogo": "https://www.bill.be/img/favicon.png",
+      "url": "https://www.publiq.be/blog/%{name}",
+      "image": {
+        "url": "https://www.uitinvlaanderen.be/img%20small.png",
+        "copyrightHolder": "publiq vzw"
+      },
+      "id": "%{articleId}"
+    }
+    """
+
   Scenario: Create a news article with url that should have been encoded
     Given I set the JSON request payload to:
     """

--- a/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
@@ -534,7 +534,7 @@ final class CreateNewsArticleRequestHandlerTest extends TestCase
                 ApiProblem::bodyInvalidData(
                     new SchemaError(
                         '/image/url',
-                        'The string should match pattern: ^http(s?):([/|.|\w|\s|-])*\.(?:jpeg|jpg|gif|png)$'
+                        'The string should match pattern: ^http(s?):([/|.|\w|%20|-])*\.(?:jpeg|jpg|gif|png)$'
                     )
                 ),
             ],

--- a/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
@@ -386,7 +386,7 @@ final class UpdateNewsArticleRequestHandlerTest extends TestCase
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidData(
-                new SchemaError('/image/url', 'The string should match pattern: ^http(s?):([/|.|\w|\s|-])*\.(?:jpeg|jpg|gif|png)$')
+                new SchemaError('/image/url', 'The string should match pattern: ^http(s?):([/|.|\w|%20|-])*\.(?:jpeg|jpg|gif|png)$')
             ),
             fn () => $this->updateNewsArticleRequestHandler->handle($updateNewsArticleRequest)
         );


### PR DESCRIPTION
### Changed
- Allowed encoded space for the image URL of a news article. Only an encoded space is allowed to not interfere with the `Url` value object validation in `udb3-backed`

### Noted
- Related pull request https://github.com/cultuurnet/apidocs/pull/412

---

Ticket: https://jira.uitdatabank.be/browse/III-6312
