### PR TITLE
Fixe broken acceptance testen for Ownsership Search

### DIFF
--- a/features/ownership/search.feature
+++ b/features/ownership/search.feature
@@ -51,7 +51,6 @@ Feature: Test searching ownerships
     And I create a minimal organizer and save the "id" as "anotherOrganizerId"
     And I request ownership for "%{ownerId}" on the organizer with organizerId "%{anotherOrganizerId}" and save the "id" as "ownershipId2"
     When I send a GET request to '/ownerships/?ownerId=%{ownerId}'
-    And show me the unparsed response
     Then the response status should be 200
     And the JSON response at "itemsPerPage" should be 2
     And the JSON response at "totalItems" should be 2

--- a/features/ownership/search.feature
+++ b/features/ownership/search.feature
@@ -45,19 +45,26 @@ Feature: Test searching ownerships
 
   Scenario: Searching ownership of an organizer by ownerId
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
+    And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I create a random name of 10 characters and keep it as "ownerId"
-    And I request ownership for "%{ownerId}" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
+    And I request ownership for "%{ownerId}" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I create a minimal organizer and save the "id" as "anotherOrganizerId"
-    And I request ownership for "%{ownerId}" on the organizer with organizerId "%{anotherOrganizerId}" and save the "id" as "ownershipId3"
+    And I request ownership for "%{ownerId}" on the organizer with organizerId "%{anotherOrganizerId}" and save the "id" as "ownershipId2"
     When I send a GET request to '/ownerships/?ownerId=%{ownerId}'
+    And show me the unparsed response
     Then the response status should be 200
     And the JSON response at "itemsPerPage" should be 2
     And the JSON response at "totalItems" should be 2
-    And the JSON response at "member/0/id" should be "%{ownershipId2}"
+    And the JSON response should include:
+    """
+    "%{ownershipId1}"
+    """
+    And the JSON response should include:
+    """
+    "%{ownershipId2}"
+    """
     And the JSON response at "member/0/ownerId" should be "%{ownerId}"
     And the JSON response at "member/0/state" should be "requested"
-    And the JSON response at "member/1/id" should be "%{ownershipId3}"
     And the JSON response at "member/1/ownerId" should be "%{ownerId}"
     And the JSON response at "member/1/state" should be "requested"
 


### PR DESCRIPTION
### Changed

- `ownership/search.feature`: Just check if `ownershipId1` & `ownershipId2`, regardless of order.

### Fixed

- `Scenario: Searching ownership of an organizer by ownerId`: should now always be `green` instead of random `green|red`
---