### PR TITLE
III-6310 remove legacy status from timestamp

### DIFF
--- a/src/Calendar/Timestamp.php
+++ b/src/Calendar/Timestamp.php
@@ -6,7 +6,9 @@ namespace CultuurNet\UDB3\Calendar;
 
 use Broadway\Serializer\Serializable;
 use CultuurNet\UDB3\DateTimeFactory;
-use CultuurNet\UDB3\Event\ValueObjects\Status;
+use CultuurNet\UDB3\Model\Serializer\ValueObject\Calendar\StatusDenormalizer;
+use CultuurNet\UDB3\Model\Serializer\ValueObject\Calendar\StatusNormalizer;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
@@ -80,7 +82,7 @@ final class Timestamp implements Serializable
     {
         $status = null;
         if (isset($data['status'])) {
-            $status = Status::deserialize($data['status']);
+            $status =  (new StatusDenormalizer())->denormalize($data['status'], Status::class);
         }
 
         $bookingAvailability = null;
@@ -103,7 +105,7 @@ final class Timestamp implements Serializable
         return [
             'startDate' => $this->startDate->format(DateTimeInterface::ATOM),
             'endDate' => $this->endDate->format(DateTimeInterface::ATOM),
-            'status' => $this->status->serialize(),
+            'status' => (new StatusNormalizer())->normalize($this->status),
             'bookingAvailability' => $this->bookingAvailability->serialize(),
         ];
     }
@@ -121,7 +123,7 @@ final class Timestamp implements Serializable
         return new Timestamp(
             $subEvent->getDateRange()->getFrom(),
             $subEvent->getDateRange()->getTo(),
-            Status::fromUdb3ModelStatus($subEvent->getStatus()),
+            $subEvent->getStatus(),
             BookingAvailability::fromUdb3ModelBookingAvailability($subEvent->getBookingAvailability())
         );
     }

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -377,7 +377,7 @@ final class Event extends Offer
 
             $timestamp = $timestamps[$index];
 
-            $subEventStatus = $subEventUpdate->getStatus() ? Status::fromUdb3ModelStatus($subEventUpdate->getStatus()) : null;
+            $subEventStatus = $subEventUpdate->getStatus() ?: null;
             $subEventBookingAvailability = $subEventUpdate->getBookingAvailability() ? BookingAvailability::fromUdb3ModelBookingAvailability($subEventUpdate->getBookingAvailability()) : null;
 
             $updatedTimestamp = new Timestamp(

--- a/src/Http/Deserializer/Calendar/CalendarJSONParser.php
+++ b/src/Http/Deserializer/Calendar/CalendarJSONParser.php
@@ -7,7 +7,8 @@ namespace CultuurNet\UDB3\Http\Deserializer\Calendar;
 use CultuurNet\UDB3\Calendar\DayOfWeekCollection;
 use CultuurNet\UDB3\Calendar\OpeningHour;
 use CultuurNet\UDB3\Calendar\OpeningTime;
-use CultuurNet\UDB3\Event\ValueObjects\Status;
+use CultuurNet\UDB3\Event\ValueObjects\Status as LegacyStatus;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Calendar\Timestamp;
 
@@ -31,13 +32,13 @@ class CalendarJSONParser
         return new \DateTime($data['endDate']);
     }
 
-    public function getStatus(array $data): ?Status
+    public function getStatus(array $data): ?LegacyStatus
     {
         if (!isset($data['status'])) {
             return null;
         }
 
-        return Status::deserialize($data['status']);
+        return LegacyStatus::deserialize($data['status']);
     }
 
     public function getBookingAvailability(array $data): ?BookingAvailability
@@ -66,9 +67,9 @@ class CalendarJSONParser
 
             $timestamp = new Timestamp(new \DateTime($timeSpan['start']), new \DateTime($timeSpan['end']));
 
-            $status = isset($timeSpan['status']) ? Status::deserialize($timeSpan['status']) : $this->getStatus($data);
+            $status = isset($timeSpan['status']) ? LegacyStatus::deserialize($timeSpan['status']) : $this->getStatus($data);
             if ($status) {
-                $timestamp = $timestamp->withStatus($status);
+                $timestamp = $timestamp->withStatus(new Status($status->getType(), $status->getReason()));
             }
 
             $bookingAvailability = isset($timeSpan['bookingAvailability']) ?

--- a/src/Model/Serializer/ValueObject/Calendar/StatusNormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/StatusNormalizer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\Serializer\ValueObject\Calendar;
+
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class StatusNormalizer implements NormalizerInterface
+{
+    /**
+     * @param Status $status
+     */
+    public function normalize($status, $format = null, array $context = []): array
+    {
+        $serialized = [
+            'type' => $status->getType()->toString(),
+        ];
+
+        if ($status->getReason() === null) {
+            return $serialized;
+        }
+
+        $statusReasons = [];
+        foreach ($status->getReason()->getLanguages() as $language) {
+            $statusReasons[$language->getCode()] = $status->getReason()->getTranslation($language)->toString();
+        }
+        $serialized['reason'] = $statusReasons;
+
+        return $serialized;
+    }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data === Status::class;
+    }
+}

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -9,7 +9,7 @@ use CultureFeed_Cdb_Item_Base;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Event\EventType;
-use CultuurNet\UDB3\Event\ValueObjects\Status;
+use CultuurNet\UDB3\Event\ValueObjects\Status as LegacyStatus;
 use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\LabelAwareAggregateRoot;
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Properties\Description as ImageDescription;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -183,12 +184,12 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
         }
     }
 
-    public function updateAllStatuses(Status $status): void
+    public function updateAllStatuses(LegacyStatus $status): void
     {
         $this->updateCalendar(
             $this->calendar
                 ->withStatus($status)
-                ->withStatusOnTimestamps($status)
+                ->withStatusOnTimestamps(new Status($status->getType(), $status->getReason()))
         );
     }
 

--- a/tests/Calendar/CalendarTest.php
+++ b/tests/Calendar/CalendarTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Calendar;
 
 use CultuurNet\UDB3\DateTimeFactory;
-use CultuurNet\UDB3\Event\ValueObjects\Status;
+use CultuurNet\UDB3\Event\ValueObjects\Status as LegacyStatus;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability as Udb3ModelBookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType as Udb3ModelBookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
@@ -20,7 +20,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Time;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PeriodicCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\Status as Udb3ModelStatus;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusReason;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType as Udb3ModelStatusType;
@@ -501,7 +501,7 @@ class CalendarTest extends TestCase
      */
     public function it_can_deserialize_with_explicit_status(): void
     {
-        $status = new Status(
+        $status = new LegacyStatus(
             StatusType::TemporarilyUnavailable(),
             (new TranslatedStatusReason(
                 new Language('nl'),
@@ -1059,7 +1059,7 @@ class CalendarTest extends TestCase
                         ),
                     ]
                 ))->withStatus(
-                    new Status(
+                    new LegacyStatus(
                         StatusType::Available(),
                         (new TranslatedStatusReason(new Language('nl'), new StatusReason('Alles goed')))
                             ->withTranslation(new Language('fr'), new StatusReason('All good'))
@@ -1205,7 +1205,7 @@ class CalendarTest extends TestCase
                 'calendar' => (new Calendar(
                     CalendarType::PERMANENT()
                 ))->withStatus(
-                    new Status(
+                    new LegacyStatus(
                         StatusType::TemporarilyUnavailable(),
                         new TranslatedStatusReason(new Language('nl'), new StatusReason('We zijn in volle verbouwing'))
                     )
@@ -1444,12 +1444,12 @@ class CalendarTest extends TestCase
                 DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
                 DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00')
             ),
-            new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
+            new Status(Udb3ModelStatusType::Unavailable()),
             new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable())
         );
 
         $udb3ModelCalendar = (new SingleSubEventCalendar($subEvent))
-            ->withStatus(new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()))
+            ->withStatus(new Status(Udb3ModelStatusType::Unavailable()))
             ->withBookingAvailability(new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable()));
 
         $expected = (new Calendar(
@@ -1465,7 +1465,7 @@ class CalendarTest extends TestCase
                 ),
             ],
             []
-        ))->withStatus(new Status(StatusType::Unavailable(), null))
+        ))->withStatus(new LegacyStatus(StatusType::Unavailable(), null))
             ->withBookingAvailability(BookingAvailability::unavailable());
 
         $actual = Calendar::fromUdb3ModelCalendar($udb3ModelCalendar);
@@ -1484,7 +1484,7 @@ class CalendarTest extends TestCase
                     DateTimeFactory::fromAtom('2016-03-06T10:00:00+01:00'),
                     DateTimeFactory::fromAtom('2016-03-07T10:00:00+01:00')
                 ),
-                new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
+                new Status(Udb3ModelStatusType::Unavailable()),
                 new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable())
             ),
             new SubEvent(
@@ -1492,13 +1492,13 @@ class CalendarTest extends TestCase
                     DateTimeFactory::fromAtom('2016-03-09T10:00:00+01:00'),
                     DateTimeFactory::fromAtom('2016-03-10T10:00:00+01:00')
                 ),
-                new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
+                new Status(Udb3ModelStatusType::Unavailable()),
                 new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable())
             )
         );
 
         $udb3ModelCalendar = (new MultipleSubEventsCalendar($subEvents))
-            ->withStatus(new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()))
+            ->withStatus(new Status(Udb3ModelStatusType::Unavailable()))
             ->withBookingAvailability(new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable()));
 
         $expected = (new Calendar(
@@ -1520,7 +1520,7 @@ class CalendarTest extends TestCase
                 ),
             ],
             []
-        ))->withStatus(new Status(StatusType::Unavailable(), null))
+        ))->withStatus(new LegacyStatus(StatusType::Unavailable(), null))
             ->withBookingAvailability(BookingAvailability::unavailable());
 
         $actual = Calendar::fromUdb3ModelCalendar($udb3ModelCalendar);
@@ -1826,11 +1826,11 @@ class CalendarTest extends TestCase
         );
 
         $this->assertEquals(
-            new Status(StatusType::Available(), null),
+            new LegacyStatus(StatusType::Available(), null),
             $calendar->getStatus()
         );
 
-        $newStatus = new Status(
+        $newStatus = new LegacyStatus(
             StatusType::Unavailable(),
             new TranslatedStatusReason(new Language('nl'), new StatusReason('Het mag niet van de afgevaardigde van de eerste minister'))
         );
@@ -1871,7 +1871,7 @@ class CalendarTest extends TestCase
         );
 
         $this->assertEquals(
-            new Status(StatusType::Available(), null),
+            new LegacyStatus(StatusType::Available(), null),
             $calendar->getStatus()
         );
 
@@ -1881,10 +1881,10 @@ class CalendarTest extends TestCase
         );
 
         $updatedCalendar = $calendar
-            ->withStatus($newStatus)
+            ->withStatus(LegacyStatus::fromUdb3ModelStatus($newStatus))
             ->withStatusOnTimestamps($newStatus);
 
-        $this->assertEquals($newStatus, $updatedCalendar->getStatus());
+        $this->assertEquals(LegacyStatus::fromUdb3ModelStatus($newStatus), $updatedCalendar->getStatus());
 
         foreach ($updatedCalendar->getTimestamps() as $timestamp) {
             $this->assertEquals($newStatus, $timestamp->getStatus());

--- a/tests/Calendar/TimestampTest.php
+++ b/tests/Calendar/TimestampTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Calendar;
 
 use CultuurNet\UDB3\DateTimeFactory;
-use CultuurNet\UDB3\Event\ValueObjects\Status;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusReason;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\TranslatedStatusReason;

--- a/tests/Event/CommandHandlers/UpdateSubEventsHandlerTest.php
+++ b/tests/Event/CommandHandlers/UpdateSubEventsHandlerTest.php
@@ -16,7 +16,6 @@ use CultuurNet\UDB3\Event\Events\CalendarUpdated;
 use CultuurNet\UDB3\Event\Events\EventCreated;
 use CultuurNet\UDB3\Event\EventType as LegacyEventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId as LegacyLocationId;
-use CultuurNet\UDB3\Event\ValueObjects\Status as LegacyStatus;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
@@ -380,7 +379,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                                new DateTime('2020-01-03 10:00:00'),
                                new DateTime('2020-01-03 12:00:00')
                            ))->withStatus(
-                               new LegacyStatus(
+                               new Status(
                                    StatusType::Unavailable(),
                                    new TranslatedStatusReason(
                                        new Language('nl'),
@@ -447,7 +446,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                                 new DateTime('2020-01-01 10:00:00'),
                                 new DateTime('2020-01-01 12:00:00')
                             ))->withStatus(
-                                new LegacyStatus(
+                                new Status(
                                     StatusType::Unavailable(),
                                     new TranslatedStatusReason(
                                         new Language('nl'),
@@ -459,7 +458,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                                 new DateTime('2020-01-03 10:00:00'),
                                 new DateTime('2020-01-03 12:00:00')
                             ))->withStatus(
-                                new LegacyStatus(
+                                new Status(
                                     StatusType::TemporarilyUnavailable(),
                                     new TranslatedStatusReason(
                                         new Language('nl'),
@@ -632,7 +631,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                                 new DateTime('2020-01-03 10:00:00'),
                                 new DateTime('2020-01-03 12:00:00')
                             ))->withStatus(
-                                new LegacyStatus(
+                                new Status(
                                     StatusType::Unavailable(),
                                     new TranslatedStatusReason(
                                         new Language('nl'),
@@ -711,7 +710,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                                 new DateTime('2020-01-01 10:00:00'),
                                 new DateTime('2020-01-01 12:00:00')
                             ))->withStatus(
-                                new LegacyStatus(
+                                new Status(
                                     StatusType::Unavailable(),
                                     new TranslatedStatusReason(
                                         new Language('nl'),
@@ -723,7 +722,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                                 new DateTime('2020-01-03 10:00:00'),
                                 new DateTime('2020-01-03 12:00:00')
                             ))->withStatus(
-                                new LegacyStatus(
+                                new Status(
                                     StatusType::TemporarilyUnavailable(),
                                     new TranslatedStatusReason(
                                         new Language('nl'),

--- a/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
@@ -11,10 +11,11 @@ use CultuurNet\UDB3\Calendar\OpeningHour;
 use CultuurNet\UDB3\Calendar\OpeningTime;
 use CultuurNet\UDB3\Calendar\CalendarType;
 use CultuurNet\UDB3\DateTimeFactory;
-use CultuurNet\UDB3\Event\ValueObjects\Status;
+use CultuurNet\UDB3\Event\ValueObjects\Status as LegacyStatus;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusReason;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\TranslatedStatusReason;
@@ -114,7 +115,7 @@ class CalendarJSONDeserializerTest extends TestCase
         );
 
         $expectedCalendar = $expectedCalendar->withStatus(
-            new Status(
+            new LegacyStatus(
                 StatusType::Unavailable(),
                 (new TranslatedStatusReason(
                     new Language('nl'),
@@ -221,7 +222,7 @@ class CalendarJSONDeserializerTest extends TestCase
         );
 
         $expectedCalendar = $expectedCalendar->withStatus(
-            new Status(
+            new LegacyStatus(
                 StatusType::TemporarilyUnavailable(),
                 (new TranslatedStatusReason(
                     new Language('nl'),

--- a/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
@@ -9,10 +9,11 @@ use CultuurNet\UDB3\Calendar\DayOfWeekCollection;
 use CultuurNet\UDB3\Calendar\OpeningHour;
 use CultuurNet\UDB3\Calendar\OpeningTime;
 use CultuurNet\UDB3\DateTimeFactory;
-use CultuurNet\UDB3\Event\ValueObjects\Status;
+use CultuurNet\UDB3\Event\ValueObjects\Status as LegacyStatus;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusReason;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\TranslatedStatusReason;
@@ -101,7 +102,7 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_can_get_the_status(): void
     {
-        $status = new Status(
+        $status = new LegacyStatus(
             StatusType::TemporarilyUnavailable(),
             (new TranslatedStatusReason(
                 new Language('nl'),

--- a/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
@@ -11,13 +11,14 @@ use CultuurNet\UDB3\Calendar\DayOfWeekCollection;
 use CultuurNet\UDB3\Calendar\OpeningHour;
 use CultuurNet\UDB3\Calendar\OpeningTime;
 use CultuurNet\UDB3\DateTimeFactory;
-use CultuurNet\UDB3\Event\ValueObjects\Status;
+use CultuurNet\UDB3\Event\ValueObjects\Status as LegacyStatus;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusReason;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\TranslatedStatusReason;
@@ -219,7 +220,7 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                                     )
                                 )
                                 ->withBookingAvailability(new BookingAvailability(BookingAvailabilityType::unavailable())),
-                            new Status(
+                            new LegacyStatus(
                                 StatusType::TemporarilyUnavailable(),
                                 new TranslatedStatusReason(
                                     new Language('nl'),
@@ -358,7 +359,7 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                         DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
                         DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         [],
-                        new Status(
+                        new LegacyStatus(
                             StatusType::TemporarilyUnavailable(),
                             new TranslatedStatusReason(
                                 new Language('nl'),
@@ -440,7 +441,7 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     self::EVENT_ID,
                     Calendar::permanent(
                         [],
-                        new Status(
+                        new LegacyStatus(
                             StatusType::TemporarilyUnavailable(),
                             new TranslatedStatusReason(
                                 new Language('nl'),
@@ -825,7 +826,7 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                         DateTimeFactory::fromAtom('2021-01-01T14:00:30+01:00'),
                         DateTimeFactory::fromAtom('2021-01-01T17:00:30+01:00'),
                         [],
-                        new Status(
+                        new LegacyStatus(
                             StatusType::TemporarilyUnavailable(),
                             new TranslatedStatusReason(
                                 new Language('nl'),
@@ -907,7 +908,7 @@ class UpdateCalendarRequestHandlerTest extends TestCase
                     self::PLACE_ID,
                     Calendar::permanent(
                         [],
-                        new Status(
+                        new LegacyStatus(
                             StatusType::TemporarilyUnavailable(),
                             new TranslatedStatusReason(
                                 new Language('nl'),

--- a/tests/Offer/CommandHandlers/UpdateStatusHandlerTest.php
+++ b/tests/Offer/CommandHandlers/UpdateStatusHandlerTest.php
@@ -11,6 +11,7 @@ use Broadway\EventStore\EventStore;
 use CultuurNet\UDB3\Calendar\Calendar;
 use CultuurNet\UDB3\Calendar\CalendarType;
 use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Offer\Commands\Status\UpdateStatus;
@@ -19,7 +20,7 @@ use CultuurNet\UDB3\Event\Events\CalendarUpdated;
 use CultuurNet\UDB3\Event\Events\EventCreated;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
-use CultuurNet\UDB3\Event\ValueObjects\Status;
+use CultuurNet\UDB3\Event\ValueObjects\Status as LegacyStatus;
 use CultuurNet\UDB3\Offer\OfferRepository;
 use CultuurNet\UDB3\Place\PlaceRepository;
 use CultuurNet\UDB3\Calendar\Timestamp;
@@ -46,7 +47,7 @@ class UpdateStatusHandlerTest extends CommandHandlerScenarioTestCase
         $id = '1';
         $initialCalendar = new Calendar(CalendarType::PERMANENT());
 
-        $newStatus = new Status(StatusType::TemporarilyUnavailable(), null);
+        $newStatus = new LegacyStatus(StatusType::TemporarilyUnavailable(), null);
         $expectedCalendar = (new Calendar(CalendarType::PERMANENT()))->withStatus($newStatus);
 
         $command = new UpdateStatus($id, $newStatus);
@@ -75,7 +76,7 @@ class UpdateStatusHandlerTest extends CommandHandlerScenarioTestCase
         $initialTimestamps = [new Timestamp($startDate, $endDate)];
         $initialCalendar = new Calendar(CalendarType::SINGLE(), $startDate, $startDate, $initialTimestamps);
 
-        $newStatus = new Status(StatusType::Unavailable(), null);
+        $newStatus = new LegacyStatus(StatusType::Unavailable(), null);
 
         $expectedTimestamps = [new Timestamp($startDate, $endDate, new Status(StatusType::Unavailable(), null))];
         $expectedCalendar = (new Calendar(CalendarType::SINGLE(), $startDate, $startDate, $expectedTimestamps, []))->withStatus($newStatus);


### PR DESCRIPTION
### Changed
- Refactored legacy `Timestamp` to use the new `Status` model

---

Ticket: https://jira.uitdatabank.be/browse/III-6310
