### PR TITLE
III-6310 Remove legacy `Language` from `MultilingualString`

### DIFF
--- a/src/Cdb/CdbXmlPriceInfoParser.php
+++ b/src/Cdb/CdbXmlPriceInfoParser.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Cdb;
 
 use CultureFeed_Cdb_Data_Detail;
 use CultureFeed_Cdb_Data_Price;
-use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\MoneyFactory;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
@@ -101,13 +100,13 @@ final class CdbXmlPriceInfoParser
             foreach ($translatedTariffs as $tariffName => $tariffPrice) {
                 if (!isset($tariffs[$tariffIndex])) {
                     $tariff = new Tariff(
-                        new MultilingualString(new LegacyLanguage($language), (string) $tariffName),
+                        new MultilingualString(new Language($language), (string) $tariffName),
                         MoneyFactory::create($tariffPrice, new Currency('EUR'))
                     );
                 } else {
                     $tariff = $tariffs[$tariffIndex];
                     $name = $tariff->getName();
-                    $name = $name->withTranslation(new LegacyLanguage($language), (string) $tariffName);
+                    $name = $name->withTranslation(new Language($language), (string) $tariffName);
                     $tariff = new Tariff(
                         $name,
                         $tariff->getPrice()

--- a/src/ValueObject/MultilingualString.php
+++ b/src/ValueObject/MultilingualString.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\ValueObject;
 
-use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Translation\TranslatedValueObject;
 
 /**
@@ -136,7 +136,7 @@ class MultilingualString
         }
 
         $string = new MultilingualString(
-            Language::fromUdb3ModelLanguage($originalLanguage),
+            $originalLanguage,
             $originalValue->toString()
         );
 

--- a/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
+++ b/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3;
 
 use Broadway\Serializer\Serializer;
 use CultuurNet\UDB3\Event\Events\ContactPointUpdated;
-use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Event\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Event\Events\DescriptionTranslated;
 use CultuurNet\UDB3\Event\Events\EventCreated;
@@ -455,7 +454,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
         $bookingInfoUpdated = $this->serializer->deserialize($decoded);
 
         $this->assertEquals(
-            new MultilingualString(new LegacyLanguage('nl'), 'Reserveer plaatsen'),
+            new MultilingualString(new Language('nl'), 'Reserveer plaatsen'),
             $bookingInfoUpdated->getBookingInfo()->getUrlLabel()
         );
     }
@@ -625,7 +624,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
             ->withExtraTariff(
                 new Tariff(
                     new MultilingualString(
-                        new LegacyLanguage('nl'),
+                        new Language('nl'),
                         'Senioren'
                     ),
                     new Money(1000, new Currency('EUR'))
@@ -634,7 +633,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
             ->withExtraTariff(
                 new Tariff(
                     new MultilingualString(
-                        new LegacyLanguage('nl'),
+                        new Language('nl'),
                         'Studenten'
                     ),
                     new Money(750, new Currency('EUR'))

--- a/tests/BookingInfoTest.php
+++ b/tests/BookingInfoTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
-use CultuurNet\UDB3\Model\ValueObject\Translation\Language as Udb3ModelLanguage;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Model\ValueObject\Web\TranslatedWebsiteLabel;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
@@ -25,7 +25,7 @@ class BookingInfoTest extends TestCase
         $bookingInfo = new BookingInfo(
             'www.publiq.be',
             new MultilingualString(
-                new Udb3ModelLanguage('nl'),
+                new Language('nl'),
                 'publiq'
             ),
             '02 123 45 67',
@@ -35,7 +35,7 @@ class BookingInfoTest extends TestCase
         $sameBookingInfo = new BookingInfo(
             'www.publiq.be',
             new MultilingualString(
-                new Udb3ModelLanguage('nl'),
+                new Language('nl'),
                 'publiq'
             ),
             '02 123 45 67',
@@ -45,7 +45,7 @@ class BookingInfoTest extends TestCase
         $otherBookingInfo = new BookingInfo(
             'www.2dotstwice.be',
             new MultilingualString(
-                new Udb3ModelLanguage('nl'),
+                new Language('nl'),
                 '2dotstwice'
             ),
             '016 12 34 56',
@@ -65,7 +65,7 @@ class BookingInfoTest extends TestCase
             new WebsiteLink(
                 new Url('https://publiq.be'),
                 new TranslatedWebsiteLabel(
-                    new Udb3ModelLanguage('nl'),
+                    new Language('nl'),
                     new WebsiteLabel('publiq')
                 )
             ),
@@ -80,7 +80,7 @@ class BookingInfoTest extends TestCase
         $expected = new BookingInfo(
             'https://publiq.be',
             new MultilingualString(
-                new Udb3ModelLanguage('nl'),
+                new Language('nl'),
                 'publiq'
             ),
             '044/444444',
@@ -206,7 +206,7 @@ class BookingInfoTest extends TestCase
         $expected = new BookingInfo(
             'https://www.publiq.be',
             new MultilingualString(
-                new Udb3ModelLanguage('nl'),
+                new Language('nl'),
                 'publiq'
             ),
             '044/444444',

--- a/tests/BookingInfoTest.php
+++ b/tests/BookingInfoTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language as Udb3ModelLanguage;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Model\ValueObject\Web\TranslatedWebsiteLabel;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
@@ -24,7 +25,7 @@ class BookingInfoTest extends TestCase
         $bookingInfo = new BookingInfo(
             'www.publiq.be',
             new MultilingualString(
-                new Language('nl'),
+                new Udb3ModelLanguage('nl'),
                 'publiq'
             ),
             '02 123 45 67',
@@ -34,7 +35,7 @@ class BookingInfoTest extends TestCase
         $sameBookingInfo = new BookingInfo(
             'www.publiq.be',
             new MultilingualString(
-                new Language('nl'),
+                new Udb3ModelLanguage('nl'),
                 'publiq'
             ),
             '02 123 45 67',
@@ -44,7 +45,7 @@ class BookingInfoTest extends TestCase
         $otherBookingInfo = new BookingInfo(
             'www.2dotstwice.be',
             new MultilingualString(
-                new Language('nl'),
+                new Udb3ModelLanguage('nl'),
                 '2dotstwice'
             ),
             '016 12 34 56',
@@ -64,7 +65,7 @@ class BookingInfoTest extends TestCase
             new WebsiteLink(
                 new Url('https://publiq.be'),
                 new TranslatedWebsiteLabel(
-                    new \CultuurNet\UDB3\Model\ValueObject\Translation\Language('nl'),
+                    new Udb3ModelLanguage('nl'),
                     new WebsiteLabel('publiq')
                 )
             ),
@@ -79,7 +80,7 @@ class BookingInfoTest extends TestCase
         $expected = new BookingInfo(
             'https://publiq.be',
             new MultilingualString(
-                new Language('nl'),
+                new Udb3ModelLanguage('nl'),
                 'publiq'
             ),
             '044/444444',
@@ -205,7 +206,7 @@ class BookingInfoTest extends TestCase
         $expected = new BookingInfo(
             'https://www.publiq.be',
             new MultilingualString(
-                new Language('nl'),
+                new Udb3ModelLanguage('nl'),
                 'publiq'
             ),
             '044/444444',

--- a/tests/Event/Commands/UpdateBookingInfoTest.php
+++ b/tests/Event/Commands/UpdateBookingInfoTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Event\Commands;
 
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\DateTimeFactory;
-use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -609,7 +609,7 @@ class EventTest extends AggregateRootScenarioTestCase
 
         $bookingInfo = new BookingInfo(
             'www.publiq.be',
-            new MultilingualString(new LegacyLanguage('nl'), 'publiq'),
+            new MultilingualString(new Language('nl'), 'publiq'),
             '02 123 45 67',
             'info@publiq.be'
         );
@@ -661,7 +661,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withUiTPASTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Tariff 1'
                                 ),
                                 new Money(
@@ -691,7 +691,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withUiTPASTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Tariff 1'
                                 ),
                                 new Money(
@@ -729,7 +729,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withUiTPASTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Tariff 1'
                                 ),
                                 new Money(
@@ -752,7 +752,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     ))->withUiTPASTariffs([
                         new \CultuurNet\UDB3\PriceInfo\Tariff(
                             new MultilingualString(
-                                new LegacyLanguage('nl'),
+                                new Language('nl'),
                                 'Tariff 1'
                             ),
                             new Money(
@@ -770,7 +770,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withUiTPASTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Tariff 1'
                                 ),
                                 new Money(
@@ -808,7 +808,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withUiTPASTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Tariff 1'
                                 ),
                                 new Money(
@@ -859,7 +859,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withUiTPASTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Tariff 1'
                                 ),
                                 new Money(
@@ -883,7 +883,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     )->withUiTPASTariffs([
                         new \CultuurNet\UDB3\PriceInfo\Tariff(
                             new MultilingualString(
-                                new LegacyLanguage('nl'),
+                                new Language('nl'),
                                 'Tariff 1'
                             ),
                             new Money(
@@ -951,7 +951,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Met kinderen'
                                 ),
                                 new Money(2000, new Currency('EUR'))
@@ -965,7 +965,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Met kinderen'
                                 ),
                                 new Money(1499, new Currency('EUR'))
@@ -980,7 +980,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Met kinderen'
                                 ),
                                 new Money(1499, new Currency('EUR'))
@@ -1926,7 +1926,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withUiTPASTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Tariff 1'
                                 ),
                                 new Money(
@@ -1936,7 +1936,7 @@ class EventTest extends AggregateRootScenarioTestCase
                             ),
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Tariff 2'
                                 ),
                                 new Money(
@@ -2027,7 +2027,7 @@ class EventTest extends AggregateRootScenarioTestCase
                         ->withUiTPASTariffs([
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Tariff 1'
                                 ),
                                 new Money(
@@ -2037,7 +2037,7 @@ class EventTest extends AggregateRootScenarioTestCase
                             ),
                             new \CultuurNet\UDB3\PriceInfo\Tariff(
                                 new MultilingualString(
-                                    new LegacyLanguage('nl'),
+                                    new Language('nl'),
                                     'Tariff 2'
                                 ),
                                 new Money(

--- a/tests/Event/Events/BookingInfoUpdatedTest.php
+++ b/tests/Event/Events/BookingInfoUpdatedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Event\Events;
 
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\DateTimeFactory;
-use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -33,7 +33,6 @@ use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
-use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Properties\Description as MediaDescription;
@@ -672,8 +671,8 @@ final class ImportEventRequestHandlerTest extends TestCase
                     $eventId,
                     new BookingInfo(
                         'https://www.publiq.be',
-                        (new MultilingualString(new LegacyLanguage('nl'), 'Nederlandse label'))
-                            ->withTranslation(new LegacyLanguage('en'), 'English label'),
+                        (new MultilingualString(new Language('nl'), 'Nederlandse label'))
+                            ->withTranslation(new Language('en'), 'English label'),
                         '016 12 34 56',
                         'info@publiq.be',
                         new DateTimeImmutable('2021-05-17T22:00:00+00:00'),

--- a/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
-use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Offer\Commands\AbstractUpdateBookingInfo;
 use CultuurNet\UDB3\Place\Commands\UpdateBookingInfo as PlaceUpdateBookingInfo;
 use CultuurNet\UDB3\ValueObject\MultilingualString;

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -25,7 +25,6 @@ use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
-use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Properties\Description;
@@ -864,7 +863,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
                     new BookingInfo(
                         'https://www.dehel.be/booking',
                         new MultilingualString(
-                            new LegacyLanguage('nl'),
+                            new Language('nl'),
                             'Bestel hier je tickets'
                         ),
                         '016 10 20 30',

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -300,7 +300,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
         );
         $expected = $expected->withExtraTariff(
             new \CultuurNet\UDB3\PriceInfo\Tariff(
-                new MultilingualString(new \CultuurNet\UDB3\Language('nl'), 'Senioren'),
+                new MultilingualString(new Language('nl'), 'Senioren'),
                 new Money(1050, new Currency('EUR'))
             )
         );
@@ -326,7 +326,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
         $expected = new \CultuurNet\UDB3\BookingInfo(
             'https://www.publiq.be',
             new MultilingualString(
-                new \CultuurNet\UDB3\Language('nl'),
+                new Language('nl'),
                 'Publiq'
             ),
             '044/444444',

--- a/tests/Offer/Commands/AbstractUpdateBookingInfoTest.php
+++ b/tests/Offer/Commands/AbstractUpdateBookingInfoTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\DateTimeFactory;
-use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Offer/Events/AbstractBookingInfoEventTest.php
+++ b/tests/Offer/Events/AbstractBookingInfoEventTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Offer\Events;
 
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\DateTimeFactory;
-use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -2013,21 +2013,21 @@ class OfferTest extends AggregateRootScenarioTestCase
 
         $bookingInfo = new BookingInfo(
             'www.publiq.be',
-            new MultilingualString(new LegacyLanguage('nl'), 'publiq'),
+            new MultilingualString(new Language('nl'), 'publiq'),
             '02 123 45 67',
             'info@publiq.be'
         );
 
         $sameBookingInfo = new BookingInfo(
             'www.publiq.be',
-            new MultilingualString(new LegacyLanguage('nl'), 'publiq'),
+            new MultilingualString(new Language('nl'), 'publiq'),
             '02 123 45 67',
             'info@publiq.be'
         );
 
         $otherBookingInfo = new BookingInfo(
             'www.2dotstwice.be',
-            new MultilingualString(new LegacyLanguage('nl'), '2dotstwice'),
+            new MultilingualString(new Language('nl'), '2dotstwice'),
             '016 12 34 56',
             'info@2dotstwice.be'
         );

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -15,7 +15,6 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
-use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Properties\Description as MediaDescription;
@@ -763,7 +762,7 @@ class OfferLDProjectorTest extends TestCase
         $priceInfo = $priceInfo->withExtraTariff(
             new Tariff(
                 new MultilingualString(
-                    new LegacyLanguage('nl'),
+                    new Language('nl'),
                     'Tarief inwoners'
                 ),
                 new Money(950, new Currency('EUR'))
@@ -773,7 +772,7 @@ class OfferLDProjectorTest extends TestCase
         $priceInfo = $priceInfo->withExtraUiTPASTariff(
             new Tariff(
                 new MultilingualString(
-                    new LegacyLanguage('nl'),
+                    new Language('nl'),
                     'UiTPAS tarief'
                 ),
                 new Money(650, new Currency('EUR'))
@@ -2468,7 +2467,7 @@ class OfferLDProjectorTest extends TestCase
 
         $event = new BookingInfoUpdated($id, new BookingInfo(
             'http://www.google.be',
-            new MultilingualString(new LegacyLanguage('nl'), 'Dit is een booking info event'),
+            new MultilingualString(new Language('nl'), 'Dit is een booking info event'),
             '0471123456',
             'test@test.be'
         ));

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3;
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
-use CultuurNet\UDB3\Language as LegacyLanguage;
 use Broadway\EventHandling\EventListener;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\Properties\Description as MediaDescription;
@@ -115,7 +114,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
     {
         $id = 'foo';
         $url = 'http://www.google.be';
-        $urlLabel = new MultilingualString(new LegacyLanguage('nl'), 'Google');
+        $urlLabel = new MultilingualString(new Language('nl'), 'Google');
         $phone = '045';
         $email = 'test@test.com';
         $availabilityStarts = DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00');

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -403,7 +403,7 @@ class PlaceTest extends AggregateRootScenarioTestCase
 
         $bookingInfo = new BookingInfo(
             'www.publiq.be',
-            new MultilingualString(new LegacyLanguage('nl'), 'Publiq'),
+            new MultilingualString(new Language('nl'), 'Publiq'),
             '02 123 45 67',
             'info@publiq.be'
         );

--- a/tests/PriceInfo/PriceInfoTest.php
+++ b/tests/PriceInfo/PriceInfoTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\PriceInfo;
 
-use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Price\TariffName;
 use CultuurNet\UDB3\Model\ValueObject\Price\Tariffs;
 use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Money\Currency;
 use Money\Money;

--- a/tests/ValueObject/MultilingualStringTest.php
+++ b/tests/ValueObject/MultilingualStringTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\ValueObject;
 
-use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Address;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Locality;
@@ -13,6 +12,7 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\Street;
 use CultuurNet\UDB3\Model\ValueObject\Geography\TranslatedAddress;
 use CultuurNet\UDB3\Model\ValueObject\Price\TariffName;
 use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use PHPUnit\Framework\TestCase;
 
 class MultilingualStringTest extends TestCase


### PR DESCRIPTION
### Removed
- Removed legacy `Language` from `MultilingualString`

---

Ticket: https://jira.uitdatabank.be/browse/III-6310
