### PR TITLE
Revert "Bump rexml from 3.2.5 to 3.3.9"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
       stud
     rake (13.0.6)
     rchardet (1.8.0)
-    rexml (3.3.9)
+    rexml (3.2.5)
     stud (0.0.23)
 
 PLATFORMS


### PR DESCRIPTION
This reverts commit cba65dd458cc075b116539e2b78c0b6875a86a96.