### PR TITLE
III-6399 Fix typo in postCode predicate URI in AddressEditor

### DIFF
--- a/features/data/organizers/rdf/organizer-with-address.ttl
+++ b/features/data/organizers/rdf/organizer-with-address.ttl
@@ -32,7 +32,7 @@
     locn:postName "Brussel"@nl, "Bruxelles"@fr ;
     locn:thoroughfare "Quai du Hainaut"@nl, "Quai du Hainaut"@fr ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "1080" ;
+    locn:postCode "1080" ;
     locn:locatorDesignator "41"
   ] ;
   locn:geometry [

--- a/features/data/places/rdf/place-with-invalid-address.ttl
+++ b/features/data/places/rdf/place-with-invalid-address.ttl
@@ -27,7 +27,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "bbbb" ;
+    locn:postCode "bbbb" ;
     locn:fullAddress "cccc, bbbb aaaa, BE"@nl ;
     locn:postName "aaaa"@nl
   ] ;

--- a/features/data/places/rdf/place-with-labels.ttl
+++ b/features/data/places/rdf/place-with-labels.ttl
@@ -28,7 +28,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3271" ;
+    locn:postCode "3271" ;
     locn:locatorDesignator "107" ;
     locn:fullAddress "Hoornblaas 107, 3271 Scherpenheuvel-Zichem, BE"@nl ;
     locn:postName "Scherpenheuvel-Zichem"@nl ;

--- a/features/data/places/rdf/place-with-required-fields.ttl
+++ b/features/data/places/rdf/place-with-required-fields.ttl
@@ -26,7 +26,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3271" ;
+    locn:postCode "3271" ;
     locn:locatorDesignator "107" ;
     locn:fullAddress "Hoornblaas 107, 3271 Scherpenheuvel-Zichem, BE"@nl ;
     locn:postName "Scherpenheuvel-Zichem"@nl ;

--- a/src/RDF/Editor/AddressEditor.php
+++ b/src/RDF/Editor/AddressEditor.php
@@ -19,7 +19,7 @@ final class AddressEditor
 
     private const PROPERTY_ADRES_STRAATNAAM = 'locn:thoroughfare';
     private const PROPERTY_ADRES_HUISNUMMER = 'locn:locatorDesignator';
-    private const PROPERTY_ADRES_POSTCODE = 'locn:postcode';
+    private const PROPERTY_ADRES_POSTCODE = 'locn:postCode';
     private const PROPERTY_ADRES_GEMEENTENAAM = 'locn:postName';
     private const PROPERTY_ADRES_LAND = 'locn:adminUnitL1';
     private const PROPERTY_ADRES_VOLLEDIG_ADRES = 'locn:fullAddress';

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-and-multiple-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-and-multiple-calendar.ttl
@@ -51,7 +51,7 @@ _:genid4
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Martelarenplein 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-and-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-and-single-calendar.ttl
@@ -35,7 +35,7 @@
       locn:address [
         a locn:Address ;
         locn:adminUnitL1 "BE" ;
-        locn:postcode "3000" ;
+        locn:postCode "3000" ;
         locn:locatorDesignator "1" ;
         locn:fullAddress "Martelarenplein 1, 3000 Leuven, BE"@nl ;
         locn:postName "Leuven"@nl ;

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name-and-multiple-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name-and-multiple-calendar.ttl
@@ -52,7 +52,7 @@ _:genid4
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Martelarenplein 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name-and-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name-and-single-calendar.ttl
@@ -36,7 +36,7 @@
       locn:address [
         a locn:Address ;
         locn:adminUnitL1 "BE" ;
-        locn:postcode "3000" ;
+        locn:postCode "3000" ;
         locn:locatorDesignator "1" ;
         locn:fullAddress "Martelarenplein 1, 3000 Leuven, BE"@nl ;
         locn:postName "Leuven"@nl ;

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name.ttl
@@ -34,7 +34,7 @@
     locn:address [
       a locn:Address ;
       locn:adminUnitL1 "BE" ;
-      locn:postcode "3000" ;
+      locn:postCode "3000" ;
       locn:locatorDesignator "1" ;
       locn:fullAddress "Martelarenplein 1, 3000 Leuven, BE"@nl ;
       locn:postName "Leuven"@nl ;

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location.ttl
@@ -33,7 +33,7 @@
     locn:address [
       a locn:Address ;
       locn:adminUnitL1 "BE" ;
-      locn:postcode "3000" ;
+      locn:postCode "3000" ;
       locn:locatorDesignator "1" ;
       locn:fullAddress "Martelarenplein 1, 3000 Leuven, BE"@nl ;
       locn:postName "Leuven"@nl ;

--- a/tests/Organizer/ReadModel/RDF/ttl/organizer-with-address.ttl
+++ b/tests/Organizer/ReadModel/RDF/ttl/organizer-with-address.ttl
@@ -29,7 +29,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3271" ;
+    locn:postCode "3271" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Kerkstraat 1, 3271 Zichem (Scherpenheuvel-Zichem), BE"@nl ;
     locn:postName "Zichem (Scherpenheuvel-Zichem)"@nl ;

--- a/tests/Place/ReadModel/RDF/ttl/place-with-coordinates.ttl
+++ b/tests/Place/ReadModel/RDF/ttl/place-with-coordinates.ttl
@@ -26,7 +26,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;

--- a/tests/Place/ReadModel/RDF/ttl/place-with-labels.ttl
+++ b/tests/Place/ReadModel/RDF/ttl/place-with-labels.ttl
@@ -27,7 +27,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;

--- a/tests/Place/ReadModel/RDF/ttl/place-with-publication-date.ttl
+++ b/tests/Place/ReadModel/RDF/ttl/place-with-publication-date.ttl
@@ -26,7 +26,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;

--- a/tests/Place/ReadModel/RDF/ttl/place-with-status-approved.ttl
+++ b/tests/Place/ReadModel/RDF/ttl/place-with-status-approved.ttl
@@ -25,7 +25,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;

--- a/tests/Place/ReadModel/RDF/ttl/place-with-status-deleted.ttl
+++ b/tests/Place/ReadModel/RDF/ttl/place-with-status-deleted.ttl
@@ -25,7 +25,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;

--- a/tests/Place/ReadModel/RDF/ttl/place-with-status-ready-for-validation.ttl
+++ b/tests/Place/ReadModel/RDF/ttl/place-with-status-ready-for-validation.ttl
@@ -25,7 +25,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;

--- a/tests/Place/ReadModel/RDF/ttl/place-with-status-rejected.ttl
+++ b/tests/Place/ReadModel/RDF/ttl/place-with-status-rejected.ttl
@@ -25,7 +25,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;

--- a/tests/Place/ReadModel/RDF/ttl/place-with-translations.ttl
+++ b/tests/Place/ReadModel/RDF/ttl/place-with-translations.ttl
@@ -28,6 +28,6 @@
     locn:postName "Leuven"@nl, "Louvain"@fr ;
     locn:thoroughfare "Martelarenlaan"@nl, "Martelarenlaan"@fr ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1"
   ] .

--- a/tests/Place/ReadModel/RDF/ttl/place.ttl
+++ b/tests/Place/ReadModel/RDF/ttl/place.ttl
@@ -25,7 +25,7 @@
   locn:address [
     a locn:Address ;
     locn:adminUnitL1 "BE" ;
-    locn:postcode "3000" ;
+    locn:postCode "3000" ;
     locn:locatorDesignator "1" ;
     locn:fullAddress "Martelarenlaan 1, 3000 Leuven, BE"@nl ;
     locn:postName "Leuven"@nl ;


### PR DESCRIPTION
### Changed
- The current predicate uri `locn:postcode` should be replaced with `locn:postCode`

---
Ticket: https://jira.publiq.be/browse/III-6399

