### PR TITLE
III-6310 Refactor legacy `Tariff` to use `TranslatedTariffName`

### DIFF
--- a/src/Cdb/CdbXmlPriceInfoParser.php
+++ b/src/Cdb/CdbXmlPriceInfoParser.php
@@ -6,12 +6,13 @@ namespace CultuurNet\UDB3\Cdb;
 
 use CultureFeed_Cdb_Data_Detail;
 use CultureFeed_Cdb_Data_Price;
+use CultuurNet\UDB3\Model\ValueObject\Price\TariffName;
+use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\MoneyFactory;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\PriceInfo\Tariff;
-use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Money\Currency;
 
 final class CdbXmlPriceInfoParser
@@ -100,13 +101,13 @@ final class CdbXmlPriceInfoParser
             foreach ($translatedTariffs as $tariffName => $tariffPrice) {
                 if (!isset($tariffs[$tariffIndex])) {
                     $tariff = new Tariff(
-                        new MultilingualString(new Language($language), (string) $tariffName),
+                        new TranslatedTariffName(new Language($language), new TariffName((string) $tariffName)),
                         MoneyFactory::create($tariffPrice, new Currency('EUR'))
                     );
                 } else {
                     $tariff = $tariffs[$tariffIndex];
                     $name = $tariff->getName();
-                    $name = $name->withTranslation(new Language($language), (string) $tariffName);
+                    $name = $name->withTranslation(new Language($language), new TariffName($tariffName));
                     $tariff = new Tariff(
                         $name,
                         $tariff->getPrice()

--- a/src/Model/Serializer/ValueObject/Price/TranslatedTariffNameNormalizer.php
+++ b/src/Model/Serializer/ValueObject/Price/TranslatedTariffNameNormalizer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\Serializer\ValueObject\Price;
+
+use CultuurNet\UDB3\Model\Serializer\ValueObject\Translation\TranslatedValueObjectNormalizer;
+use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
+
+final class TranslatedTariffNameNormalizer extends TranslatedValueObjectNormalizer
+{
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data === TranslatedTariffName::class;
+    }
+}

--- a/src/Model/Serializer/ValueObject/Translation/TranslatedValueObjectNormalizer.php
+++ b/src/Model/Serializer/ValueObject/Translation/TranslatedValueObjectNormalizer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\Serializer\ValueObject\Translation;
+
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Translation\TranslatedValueObject;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+abstract class TranslatedValueObjectNormalizer implements NormalizerInterface
+{
+    /**
+     * @param TranslatedValueObject $object
+     */
+    public function normalize($object, $format = null, array $context = []): array
+    {
+        $data = [];
+
+        /** @var Language $language */
+        foreach ($object->getLanguages() as $language) {
+            $data[$language->toString()] = $object->getTranslation($language)->toString();
+        }
+
+        return $data;
+    }
+}

--- a/src/Offer/ReadModel/JSONLD/CdbXMLItemBaseImporter.php
+++ b/src/Offer/ReadModel/JSONLD/CdbXMLItemBaseImporter.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
 use CultureFeed_Cdb_Item_Base;
 use CultuurNet\UDB3\Cdb\CdbXmlPriceInfoParser;
 use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Model\Serializer\ValueObject\Price\TranslatedTariffNameNormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\ReadModel\MultilingualJsonLDProjectorTrait;
 
@@ -140,7 +141,7 @@ final class CdbXMLItemBaseImporter
         foreach ($priceInfo->getTariffs() as $tariff) {
             $jsonLD->priceInfo[] = [
                 'category' => 'tariff',
-                'name' => $tariff->getName()->serialize(),
+                'name' => (new TranslatedTariffNameNormalizer())->normalize($tariff->getName()),
                 'price' => $tariff->getPrice()->getAmount() / 100,
                 'priceCurrency' => $tariff->getCurrency()->getName(),
             ];

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Contact\ContactPointNormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
+use CultuurNet\UDB3\Model\Serializer\ValueObject\Price\TranslatedTariffNameNormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\Offer\AvailableTo;
@@ -668,10 +669,12 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
             'priceCurrency' => $basePrice->getCurrency()->getName(),
         ];
 
+        $translatedTariffNameNormalizer = new TranslatedTariffNameNormalizer();
+
         foreach ($priceInfoUpdated->getPriceInfo()->getTariffs() as $tariff) {
             $offerLd->priceInfo[] = [
                 'category' => 'tariff',
-                'name' => $tariff->getName()->serialize(),
+                'name' => $translatedTariffNameNormalizer->normalize($tariff->getName()),
                 'price' => $tariff->getPrice()->getAmount() / 100,
                 'priceCurrency' => $tariff->getCurrency()->getName(),
             ];
@@ -680,7 +683,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         foreach ($priceInfoUpdated->getPriceInfo()->getUiTPASTariffs() as $tariff) {
             $offerLd->priceInfo[] = [
                 'category' => 'uitpas',
-                'name' => $tariff->getName()->serialize(),
+                'name' => $translatedTariffNameNormalizer->normalize($tariff->getName()),
                 'price' => $tariff->getPrice()->getAmount() / 100,
                 'priceCurrency' => $tariff->getCurrency()->getName(),
             ];

--- a/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
+++ b/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
@@ -26,6 +26,8 @@ use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Price\TariffName;
+use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
@@ -627,18 +629,18 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
         $expectedPriceInfo = $expectedPriceInfo
             ->withExtraTariff(
                 new Tariff(
-                    new MultilingualString(
+                    new TranslatedTariffName(
                         new Language('nl'),
-                        'Senioren'
+                        new TariffName('Senioren')
                     ),
                     new Money(1000, new Currency('EUR'))
                 )
             )
             ->withExtraTariff(
                 new Tariff(
-                    new MultilingualString(
+                    new TranslatedTariffName(
                         new Language('nl'),
-                        'Studenten'
+                        new TariffName('Studenten')
                     ),
                     new Money(750, new Currency('EUR'))
                 )

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -61,6 +61,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
+use CultuurNet\UDB3\PriceInfo\Tariff as LegacyTariff;
 use CultuurNet\UDB3\SampleFiles;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
@@ -657,10 +658,10 @@ class EventTest extends AggregateRootScenarioTestCase
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(new BasePrice(new Money(100, new Currency('EUR')))))
                         ->withUiTPASTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Tariff 1'
+                                    new TariffName('Tariff 1')
                                 ),
                                 new Money(
                                     199,
@@ -687,10 +688,10 @@ class EventTest extends AggregateRootScenarioTestCase
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(new BasePrice(new Money(90, new Currency('EUR')))))
                         ->withUiTPASTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Tariff 1'
+                                    new TariffName('Tariff 1')
                                 ),
                                 new Money(
                                     199,
@@ -725,10 +726,10 @@ class EventTest extends AggregateRootScenarioTestCase
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(new BasePrice(new Money(100, new Currency('EUR')))))
                         ->withUiTPASTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Tariff 1'
+                                    new TariffName('Tariff 1')
                                 ),
                                 new Money(
                                     199,
@@ -748,10 +749,10 @@ class EventTest extends AggregateRootScenarioTestCase
                             )
                         )
                     ))->withUiTPASTariffs([
-                        new \CultuurNet\UDB3\PriceInfo\Tariff(
-                            new MultilingualString(
+                        new LegacyTariff(
+                            new TranslatedTariffName(
                                 new Language('nl'),
-                                'Tariff 1'
+                                new TariffName('Tariff 1')
                             ),
                             new Money(
                                 80,
@@ -766,10 +767,10 @@ class EventTest extends AggregateRootScenarioTestCase
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(new BasePrice(new Money(90, new Currency('EUR')))))
                         ->withUiTPASTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Tariff 1'
+                                    new TariffName('Tariff 1')
                                 ),
                                 new Money(
                                     199,
@@ -804,10 +805,10 @@ class EventTest extends AggregateRootScenarioTestCase
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(new BasePrice(new Money(100, new Currency('EUR')))))
                         ->withUiTPASTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Tariff 1'
+                                    new TariffName('Tariff 1')
                                 ),
                                 new Money(
                                     199,
@@ -855,10 +856,10 @@ class EventTest extends AggregateRootScenarioTestCase
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(new BasePrice(new Money(100, new Currency('EUR')))))
                         ->withUiTPASTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Tariff 1'
+                                    new TariffName('Tariff 1')
                                 ),
                                 new Money(
                                     199,
@@ -879,10 +880,10 @@ class EventTest extends AggregateRootScenarioTestCase
                         )
                     )
                     )->withUiTPASTariffs([
-                        new \CultuurNet\UDB3\PriceInfo\Tariff(
-                            new MultilingualString(
+                        new LegacyTariff(
+                            new TranslatedTariffName(
                                 new Language('nl'),
-                                'Tariff 1'
+                                new TariffName('Tariff 1')
                             ),
                             new Money(
                                 80,
@@ -947,10 +948,10 @@ class EventTest extends AggregateRootScenarioTestCase
                 fn (Event $event) => $event->updatePriceInfo(
                     (new PriceInfo((new BasePrice(new Money(1250, new Currency('EUR'))))))
                         ->withTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Met kinderen'
+                                    new TariffName('Met kinderen')
                                 ),
                                 new Money(2000, new Currency('EUR'))
                             ),
@@ -961,10 +962,10 @@ class EventTest extends AggregateRootScenarioTestCase
                 fn (Event $event) => $event->updatePriceInfo(
                     (new PriceInfo((new BasePrice(new Money(1250, new Currency('EUR'))))))
                         ->withTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Met kinderen'
+                                    new TariffName('Met kinderen')
                                 ),
                                 new Money(1499, new Currency('EUR'))
                             ),
@@ -976,10 +977,10 @@ class EventTest extends AggregateRootScenarioTestCase
                     $eventId,
                     (new PriceInfo(new BasePrice(new Money(1250, new Currency('EUR')))))
                         ->withTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Met kinderen'
+                                    new TariffName('Met kinderen')
                                 ),
                                 new Money(1499, new Currency('EUR'))
                             ),
@@ -1922,20 +1923,20 @@ class EventTest extends AggregateRootScenarioTestCase
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(new BasePrice(new Money(100, new Currency('EUR')))))
                         ->withUiTPASTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Tariff 1'
+                                    new TariffName('Tariff 1')
                                 ),
                                 new Money(
                                     199,
                                     new Currency('EUR')
                                 )
                             ),
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Tariff 2'
+                                    new TariffName('Tariff 2')
                                 ),
                                 new Money(
                                     299,
@@ -2023,20 +2024,20 @@ class EventTest extends AggregateRootScenarioTestCase
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(new BasePrice(new Money(100, new Currency('EUR')))))
                         ->withUiTPASTariffs([
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Tariff 1'
+                                    new TariffName('Tariff 1')
                                 ),
                                 new Money(
                                     199,
                                     new Currency('EUR')
                                 )
                             ),
-                            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                                new MultilingualString(
+                            new LegacyTariff(
+                                new TranslatedTariffName(
                                     new Language('nl'),
-                                    'Tariff 2'
+                                    new TariffName('Tariff 2')
                                 ),
                                 new Money(
                                     299,

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -45,6 +45,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Model\ValueObject\Web\WebsiteLabel;
 use CultuurNet\UDB3\Model\ValueObject\Web\WebsiteLink;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
+use CultuurNet\UDB3\PriceInfo\Tariff as LegacyTariff;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use DateTimeImmutable;
@@ -299,8 +300,8 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
             )
         );
         $expected = $expected->withExtraTariff(
-            new \CultuurNet\UDB3\PriceInfo\Tariff(
-                new MultilingualString(new Language('nl'), 'Senioren'),
+            new LegacyTariff(
+                new TranslatedTariffName(new Language('nl'), new TariffName('Senioren')),
                 new Money(1050, new Currency('EUR'))
             )
         );

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -24,6 +24,8 @@ use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Video;
+use CultuurNet\UDB3\Model\ValueObject\Price\TariffName;
+use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
 use CultuurNet\UDB3\Model\ValueObject\Text\Description;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
@@ -761,9 +763,9 @@ class OfferLDProjectorTest extends TestCase
 
         $priceInfo = $priceInfo->withExtraTariff(
             new Tariff(
-                new MultilingualString(
+                new TranslatedTariffName(
                     new Language('nl'),
-                    'Tarief inwoners'
+                    new TariffName('Tarief inwoners')
                 ),
                 new Money(950, new Currency('EUR'))
             )
@@ -771,9 +773,9 @@ class OfferLDProjectorTest extends TestCase
 
         $priceInfo = $priceInfo->withExtraUiTPASTariff(
             new Tariff(
-                new MultilingualString(
+                new TranslatedTariffName(
                     new Language('nl'),
-                    'UiTPAS tarief'
+                    new TariffName('UiTPAS tarief')
                 ),
                 new Money(650, new Currency('EUR'))
             )

--- a/tests/PriceInfo/PriceInfoTest.php
+++ b/tests/PriceInfo/PriceInfoTest.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Model\ValueObject\Price\TariffName;
 use CultuurNet\UDB3\Model\ValueObject\Price\Tariffs;
 use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
-use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
@@ -37,9 +36,9 @@ class PriceInfoTest extends TestCase
 
         $this->tariffs = [
             new Tariff(
-                new MultilingualString(
+                new TranslatedTariffName(
                     new Language('nl'),
-                    'Tarief inwoners'
+                    new TariffName('Inwoners')
                 ),
                 new Money(950, new Currency('EUR'))
             ),
@@ -47,9 +46,9 @@ class PriceInfoTest extends TestCase
 
         $this->uitpasTariffs = [
             new Tariff(
-                new MultilingualString(
+                new TranslatedTariffName(
                     new Language('nl'),
-                    'UiTPAS tarief'
+                    new TariffName('UiTPAS tarief')
                 ),
                 new Money(650, new Currency('EUR'))
             ),
@@ -103,7 +102,7 @@ class PriceInfoTest extends TestCase
         $udb3ModelPriceInfo = new \CultuurNet\UDB3\Model\ValueObject\Price\PriceInfo(
             new \CultuurNet\UDB3\Model\ValueObject\Price\Tariff(
                 new TranslatedTariffName(
-                    new \CultuurNet\UDB3\Model\ValueObject\Translation\Language('nl'),
+                    new Language('nl'),
                     new TariffName('Basistarief')
                 ),
                 new Money(1000, new Currency('EUR'))
@@ -154,9 +153,9 @@ class PriceInfoTest extends TestCase
         $expected = $expected
             ->withExtraTariff(
                 new Tariff(
-                    new MultilingualString(
+                    new TranslatedTariffName(
                         new Language('nl'),
-                        'Senioren'
+                        new TariffName('Senioren')
                     ),
                     new Money(500, new Currency('EUR'))
                 )


### PR DESCRIPTION
### Changed
- Refactor `Tariff` to use `TranslatedTariffName` instead of `MultilingualString`

---

Ticket: https://jira.uitdatabank.be/browse/III-6310
