### PR TITLE
III-6420 clientName in metadata

### DIFF
--- a/src/Http/Auth/Jwt/JsonWebToken.php
+++ b/src/Http/Auth/Jwt/JsonWebToken.php
@@ -151,8 +151,8 @@ final class JsonWebToken
     {
         // Check first if the token has the claim, to prevent an OutOfBoundsException (thrown if the default is set to
         // null and the claim is missing).
-        if ($this->token->claims()->has('https://publiq.be/client-name')) {
-            return (string) $this->token->claims()->get('https://publiq.be/client-name');
+        if ($this->token->claims()->has('https://publiq.be/client_name')) {
+            return (string) $this->token->claims()->get('https://publiq.be/client_name');
         }
         return null;
     }

--- a/tests/Http/Auth/Jwt/JsonWebTokenTest.php
+++ b/tests/Http/Auth/Jwt/JsonWebTokenTest.php
@@ -96,7 +96,7 @@ class JsonWebTokenTest extends TestCase
     {
         $jwt = JsonWebTokenFactory::createWithClaims(
             [
-                'https://publiq.be/client-name' => 'Example',
+                'https://publiq.be/client_name' => 'Example',
             ]
         );
 


### PR DESCRIPTION
### Changed

- `JsonWebToken`: check for `https://publiq.be/client_name`-claim(used in `Keycloak`) instead of `https://publiq.be/client-name`-claim(used in `auth0`)
- `JsonWebTokenTest`: update unit test

### Fixed

- `auth_api_client_name` is again stored in `metadata`

### Note

- I'll wait till Erwin answers in Slack, before we decide to merge this.

---

Ticket: https://jira.publiq.be/browse/III-6420
