### PR TITLE
III-6310 Use `TelephoneNumber` in legacy `BookingInfo`

### DIFF
--- a/src/BookingInfo.php
+++ b/src/BookingInfo.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingInfo as Udb3ModelBookingInfo;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use DateTimeImmutable;
 
@@ -14,7 +15,7 @@ use DateTimeImmutable;
  */
 final class BookingInfo implements JsonLdSerializableInterface
 {
-    private ?string $phone;
+    private ?TelephoneNumber $phone;
 
     private ?string $email;
 
@@ -29,7 +30,7 @@ final class BookingInfo implements JsonLdSerializableInterface
     public function __construct(
         ?string $url = null,
         ?MultilingualString $urlLabel = null,
-        ?string $phone = null,
+        ?TelephoneNumber $phone = null,
         ?string $email = null,
         ?DateTimeImmutable $availabilityStarts = null,
         ?DateTimeImmutable $availabilityEnds = null
@@ -40,7 +41,6 @@ final class BookingInfo implements JsonLdSerializableInterface
         // API clients are also allowed to send empty strings for BookingInfo properties via EntryAPI3, which should
         // also be treated as null.
         $url = $this->castEmptyStringToNull($url);
-        $phone = $this->castEmptyStringToNull($phone);
         $email = $this->castEmptyStringToNull($email);
 
         $this->url = $url;
@@ -51,7 +51,7 @@ final class BookingInfo implements JsonLdSerializableInterface
         $this->availabilityEnds = $availabilityEnds;
     }
 
-    public function getPhone(): ?string
+    public function getPhone(): ?TelephoneNumber
     {
         return $this->phone;
     }
@@ -85,7 +85,7 @@ final class BookingInfo implements JsonLdSerializableInterface
     {
         $serialized = array_filter(
             [
-              'phone' => $this->phone,
+              'phone' => $this->phone ? $this->phone->toString() : null,
               'email' => $this->email,
               'url' => $this->url,
             ]
@@ -137,7 +137,7 @@ final class BookingInfo implements JsonLdSerializableInterface
         return new self(
             $data['url'],
             $urlLabel,
-            $data['phone'],
+            !empty($data['phone']) ? new TelephoneNumber($data['phone']) : null,
             $data['email'],
             $availabilityStarts,
             $availabilityEnds
@@ -169,7 +169,7 @@ final class BookingInfo implements JsonLdSerializableInterface
         }
 
         if ($udb3ModelPhone = $udb3ModelBookingInfo->getTelephoneNumber()) {
-            $phone = $udb3ModelPhone->toString();
+            $phone = $udb3ModelPhone;
         }
 
         if ($udb3ModelEmail = $udb3ModelBookingInfo->getEmailAddress()) {

--- a/src/Http/Deserializer/BookingInfo/BookingInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/BookingInfo/BookingInfoJSONDeserializer.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\BookingInfo;
 use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\BookingInfo;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 
 /**
@@ -22,10 +23,7 @@ class BookingInfoJSONDeserializer extends JSONDeserializer
 
     public function deserialize(string $data): BookingInfo
     {
-        /* @var array $data */
-        $data = parent::deserialize($data);
-
-        $bookingInfo = $data['bookingInfo'];
+        $bookingInfo = parent::deserialize($data)['bookingInfo'];
 
         $availabilityStarts = null;
         if (isset($bookingInfo['availabilityStarts'])) {
@@ -40,7 +38,7 @@ class BookingInfoJSONDeserializer extends JSONDeserializer
         return new BookingInfo(
             isset($bookingInfo['url']) ? (string) $bookingInfo['url'] : null,
             isset($bookingInfo['urlLabel']) ? MultilingualString::deserialize($bookingInfo['urlLabel']) : null,
-            isset($bookingInfo['phone']) ? (string) $bookingInfo['phone'] : null,
+            !empty($bookingInfo['phone']) ? new TelephoneNumber($bookingInfo['phone']) : null,
             isset($bookingInfo['email']) ? (string) $bookingInfo['email'] : null,
             $availabilityStarts,
             $availabilityEnds

--- a/tests/BookingInfoTest.php
+++ b/tests/BookingInfoTest.php
@@ -28,7 +28,7 @@ class BookingInfoTest extends TestCase
                 new Language('nl'),
                 'publiq'
             ),
-            '02 123 45 67',
+            new TelephoneNumber('02 123 45 67'),
             'info@publiq.be'
         );
 
@@ -38,7 +38,7 @@ class BookingInfoTest extends TestCase
                 new Language('nl'),
                 'publiq'
             ),
-            '02 123 45 67',
+            new TelephoneNumber('02 123 45 67'),
             'info@publiq.be'
         );
 
@@ -48,7 +48,7 @@ class BookingInfoTest extends TestCase
                 new Language('nl'),
                 '2dotstwice'
             ),
-            '016 12 34 56',
+            new TelephoneNumber('016 12 34 56'),
             'info@2dotstwice.be'
         );
 
@@ -83,7 +83,7 @@ class BookingInfoTest extends TestCase
                 new Language('nl'),
                 'publiq'
             ),
-            '044/444444',
+            new TelephoneNumber('044/444444'),
             'info@publiq.be',
             DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00'),
             DateTimeFactory::fromAtom('2018-01-10T00:00:00+01:00')
@@ -117,7 +117,7 @@ class BookingInfoTest extends TestCase
         $bookingInfoWithEmptyString = new BookingInfo(
             '',
             null,
-            '',
+            null,
             '',
             null,
             null
@@ -161,7 +161,7 @@ class BookingInfoTest extends TestCase
      */
     public function it_can_serialize_and_deserialize_partial_booking_info(): void
     {
-        $phone = '044/444444';
+        $phone = new TelephoneNumber('044/444444');
         $email = 'info@publiq.be';
 
         $original = new BookingInfo(
@@ -174,7 +174,7 @@ class BookingInfoTest extends TestCase
         );
 
         $expectedSerialized = [
-            'phone' => $phone,
+            'phone' => $phone->toString(),
             'email' => $email,
         ];
 
@@ -209,7 +209,7 @@ class BookingInfoTest extends TestCase
                 new Language('nl'),
                 'publiq'
             ),
-            '044/444444',
+            new TelephoneNumber('044/444444'),
             'info@publiq.be',
             DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00'),
             DateTimeFactory::fromAtom('2018-01-14T23:59:59+01:00')

--- a/tests/Event/Commands/UpdateBookingInfoTest.php
+++ b/tests/Event/Commands/UpdateBookingInfoTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Event\Commands;
 
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
@@ -21,7 +22,7 @@ class UpdateBookingInfoTest extends TestCase
             new BookingInfo(
                 'http://foo.bar',
                 new MultilingualString(new Language('nl'), 'urlLabel'),
-                '0123456789',
+                new TelephoneNumber('0123456789'),
                 'foo@bar.com',
                 DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
                 DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
@@ -39,7 +40,7 @@ class UpdateBookingInfoTest extends TestCase
             new BookingInfo(
                 'http://foo.bar',
                 new MultilingualString(new Language('nl'), 'urlLabel'),
-                '0123456789',
+                new TelephoneNumber('0123456789'),
                 'foo@bar.com',
                 DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
                 DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -607,7 +607,7 @@ class EventTest extends AggregateRootScenarioTestCase
         $bookingInfo = new BookingInfo(
             'www.publiq.be',
             new MultilingualString(new Language('nl'), 'publiq'),
-            '02 123 45 67',
+            new TelephoneNumber('02 123 45 67'),
             'info@publiq.be'
         );
         $xmlData = $this->getSample('EventTest.cdbxml.xml');

--- a/tests/Event/Events/BookingInfoUpdatedTest.php
+++ b/tests/Event/Events/BookingInfoUpdatedTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Event\Events;
 
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
@@ -60,7 +61,7 @@ class BookingInfoUpdatedTest extends TestCase
                     new BookingInfo(
                         'http://foo.bar',
                         new MultilingualString(new Language('nl'), 'urlLabel'),
-                        '0123456789',
+                        new TelephoneNumber('0123456789'),
                         'foo@bar.com',
                         DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
                         DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -673,7 +673,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                         'https://www.publiq.be',
                         (new MultilingualString(new Language('nl'), 'Nederlandse label'))
                             ->withTranslation(new Language('en'), 'English label'),
-                        '016 12 34 56',
+                        new TelephoneNumber('016 12 34 56'),
                         'info@publiq.be',
                         new DateTimeImmutable('2021-05-17T22:00:00+00:00'),
                         new DateTimeImmutable('2021-05-21T22:00:00+00:00')

--- a/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateBookingInfoRequestHandlerTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Offer\Commands\AbstractUpdateBookingInfo;
 use CultuurNet\UDB3\Place\Commands\UpdateBookingInfo as PlaceUpdateBookingInfo;
@@ -97,7 +98,7 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
         $bookingInfoBasicUrl = new BookingInfo(
             $basicUrl,
             new MultilingualString(new Language('nl'), 'Publiq vzw'),
-            '02/1232323',
+            new TelephoneNumber('02/1232323'),
             'info@publiq.be',
             DateTimeFactory::fromAtom('2023-01-01T00:00:00+01:00'),
             DateTimeFactory::fromAtom('2028-01-31T23:59:59+01:00')
@@ -106,7 +107,7 @@ final class UpdateBookingInfoRequestHandlerTest extends TestCase
         $bookingInfoSpecialCharactersUrl = new BookingInfo(
             $specialCharactersUrl,
             new MultilingualString(new Language('nl'), 'Publiq vzw'),
-            '02/1232323',
+            new TelephoneNumber('02/1232323'),
             'info@publiq.be',
             DateTimeFactory::fromAtom('2023-01-01T00:00:00+01:00'),
             DateTimeFactory::fromAtom('2028-01-31T23:59:59+01:00')

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -866,7 +866,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
                             new Language('nl'),
                             'Bestel hier je tickets'
                         ),
-                        '016 10 20 30',
+                        new TelephoneNumber('016 10 20 30'),
                         'booking@dehel.be',
                         new DateTimeImmutable('2020-05-17T22:00:00+00:00'),
                         new DateTimeImmutable('2028-05-17T22:00:00+00:00'),

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -328,7 +328,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
                 new Language('nl'),
                 'Publiq'
             ),
-            '044/444444',
+            new TelephoneNumber('044/444444'),
             'info@publiq.be',
             new DateTimeImmutable('2018-01-01T10:00:00+01:00'),
             new DateTimeImmutable('2018-01-10T10:00:00+01:00')

--- a/tests/Offer/Commands/AbstractUpdateBookingInfoTest.php
+++ b/tests/Offer/Commands/AbstractUpdateBookingInfoTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -28,7 +29,7 @@ class AbstractUpdateBookingInfoTest extends TestCase
         $this->bookingInfo = new BookingInfo(
             'http://foo.bar',
             new MultilingualString(new Language('nl'), 'urlLabel'),
-            '0123456789',
+            new TelephoneNumber('0123456789'),
             'foo@bar.com',
             DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
             DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
@@ -49,7 +50,7 @@ class AbstractUpdateBookingInfoTest extends TestCase
         $expectedBookingInfo = new BookingInfo(
             'http://foo.bar',
             new MultilingualString(new Language('nl'), 'urlLabel'),
-            '0123456789',
+            new TelephoneNumber('0123456789'),
             'foo@bar.com',
             DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
             DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')

--- a/tests/Offer/Events/AbstractBookingInfoEventTest.php
+++ b/tests/Offer/Events/AbstractBookingInfoEventTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Offer\Events;
 
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +28,7 @@ class AbstractBookingInfoEventTest extends TestCase
         $this->bookingInfo = new BookingInfo(
             'http://foo.bar',
             new MultilingualString(new Language('nl'), 'urlLabel'),
-            '0123456789',
+            new TelephoneNumber('0123456789'),
             'foo@bar.com',
             DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
             DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
@@ -47,7 +48,7 @@ class AbstractBookingInfoEventTest extends TestCase
         $expectedBookingInfo = new BookingInfo(
             'http://foo.bar',
             new MultilingualString(new Language('nl'), 'urlLabel'),
-            '0123456789',
+            new TelephoneNumber('0123456789'),
             'foo@bar.com',
             DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
             DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
@@ -69,7 +70,7 @@ class AbstractBookingInfoEventTest extends TestCase
         $expectedBookingInfo = new BookingInfo(
             'http://foo.bar',
             new MultilingualString(new Language('nl'), 'urlLabel'),
-            '0123456789',
+            new TelephoneNumber('0123456789'),
             'foo@bar.com',
             DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
             DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')
@@ -130,7 +131,7 @@ class AbstractBookingInfoEventTest extends TestCase
                     new BookingInfo(
                         'http://foo.bar',
                         new MultilingualString(new Language('nl'), 'urlLabel'),
-                        '0123456789',
+                        new TelephoneNumber('0123456789'),
                         'foo@bar.com',
                         DateTimeFactory::fromAtom('2016-01-01T00:00:00+01:00'),
                         DateTimeFactory::fromAtom('2016-01-31T00:00:00+01:00')

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -2013,21 +2013,21 @@ class OfferTest extends AggregateRootScenarioTestCase
         $bookingInfo = new BookingInfo(
             'www.publiq.be',
             new MultilingualString(new Language('nl'), 'publiq'),
-            '02 123 45 67',
+            new TelephoneNumber('02 123 45 67'),
             'info@publiq.be'
         );
 
         $sameBookingInfo = new BookingInfo(
             'www.publiq.be',
             new MultilingualString(new Language('nl'), 'publiq'),
-            '02 123 45 67',
+            new TelephoneNumber('02 123 45 67'),
             'info@publiq.be'
         );
 
         $otherBookingInfo = new BookingInfo(
             'www.2dotstwice.be',
             new MultilingualString(new Language('nl'), '2dotstwice'),
-            '016 12 34 56',
+            new TelephoneNumber('016 12 34 56'),
             'info@2dotstwice.be'
         );
 

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -21,6 +21,7 @@ use CultuurNet\UDB3\Media\Properties\Description as MediaDescription;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
+use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Video;
@@ -2469,7 +2470,7 @@ class OfferLDProjectorTest extends TestCase
         $event = new BookingInfoUpdated($id, new BookingInfo(
             'http://www.google.be',
             new MultilingualString(new Language('nl'), 'Dit is een booking info event'),
-            '0471123456',
+            new TelephoneNumber('0471123456'),
             'test@test.be'
         ));
 

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -115,7 +115,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
         $id = 'foo';
         $url = 'http://www.google.be';
         $urlLabel = new MultilingualString(new Language('nl'), 'Google');
-        $phone = '045';
+        $phone = new TelephoneNumber('045');
         $email = 'test@test.com';
         $availabilityStarts = DateTimeFactory::fromAtom('2018-01-01T00:00:00+01:00');
         $availabilityEnds = DateTimeFactory::fromAtom('2018-01-31T00:00:00+01:00');
@@ -129,7 +129,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
 
         $expectedBody = (object)[
             'bookingInfo' => (object)[
-                'phone' => $phone,
+                'phone' => $phone->toString(),
                 'email' => $email,
                 'url' => $url,
                 'urlLabel' => (object) $urlLabel->serialize(),

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -403,7 +403,7 @@ class PlaceTest extends AggregateRootScenarioTestCase
         $bookingInfo = new BookingInfo(
             'www.publiq.be',
             new MultilingualString(new Language('nl'), 'Publiq'),
-            '02 123 45 67',
+            new TelephoneNumber('02 123 45 67'),
             'info@publiq.be'
         );
 


### PR DESCRIPTION
### Changed
- Used `TelephoneNumber` in legacy `BookingInfo`

### Note
- This approach will make it easier to switch from the legacy `BookingInfo` to the new `BookingInfo` because their interface will be the same.

---

Ticket: https://jira.uitdatabank.be/browse/III-6310
