### PR TITLE
Changed ownership pagination parameter to be start instead of offset

### DIFF
--- a/features/ownership/search.feature
+++ b/features/ownership/search.feature
@@ -67,14 +67,14 @@ Feature: Test searching ownerships
     And the JSON response at "member/1/ownerId" should be "%{ownerId}"
     And the JSON response at "member/1/state" should be "requested"
 
-  Scenario: Searching ownership of an organizer by state and with offset and limit
+  Scenario: Searching ownership of an organizer by state and with start and limit
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
     And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
     And I request ownership for "auth0|631748dba64ea78e3983b204" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId4"
     And I request ownership for "auth0|631748dba64ea78e3983b205" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId5"
-    When I send a GET request to '/ownerships/?itemId=%{organizerId}&limit=2&offset=2'
+    When I send a GET request to '/ownerships/?itemId=%{organizerId}&limit=2&start=2'
     Then the response status should be 200
     And the JSON response at "itemsPerPage" should be 2
     And the JSON response at "totalItems" should be 5

--- a/src/Http/Ownership/Search/SearchQuery.php
+++ b/src/Http/Ownership/Search/SearchQuery.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Ownership\Search;
 
 final class SearchQuery
 {
-    private int $offset;
+    private int $start;
     private int $limit;
     /** @var SearchParameter[] */
     private array $parameters;
@@ -14,17 +14,17 @@ final class SearchQuery
     /**
      * @param SearchParameter[] $parameters
      */
-    public function __construct(array $parameters, ?int $offset = null, ?int $limit = null)
+    public function __construct(array $parameters, ?int $start = null, ?int $limit = null)
     {
         $this->parameters = $parameters;
 
-        $this->offset = $offset !== null ? $offset : 0;
+        $this->start = $start !== null ? $start : 0;
         $this->limit = $limit !== null ? $limit : 50;
     }
 
-    public function getOffset(): int
+    public function getStart(): int
     {
-        return $this->offset;
+        return $this->start;
     }
 
     public function getLimit(): int

--- a/src/Http/Ownership/SearchOwnershipRequestHandler.php
+++ b/src/Http/Ownership/SearchOwnershipRequestHandler.php
@@ -43,7 +43,7 @@ final class SearchOwnershipRequestHandler implements RequestHandlerInterface
 
         $searchQuery = new SearchQuery(
             $searchParameters,
-            !empty($request->getQueryParams()['offset']) ? (int) $request->getQueryParams()['offset'] : null,
+            !empty($request->getQueryParams()['start']) ? (int) $request->getQueryParams()['start'] : null,
             !empty($request->getQueryParams()['limit']) ? (int) $request->getQueryParams()['limit'] : null
         );
 

--- a/src/Ownership/Repositories/Search/DBALOwnershipSearchRepository.php
+++ b/src/Ownership/Repositories/Search/DBALOwnershipSearchRepository.php
@@ -80,8 +80,8 @@ final class DBALOwnershipSearchRepository implements OwnershipSearchRepository
         $queryBuilder = $this->createSearchQueryBuilder($searchQuery)
             ->select('*');
 
-        if ($searchQuery->getOffset()) {
-            $queryBuilder->setFirstResult($searchQuery->getOffset());
+        if ($searchQuery->getStart()) {
+            $queryBuilder->setFirstResult($searchQuery->getStart());
         }
 
         if ($searchQuery->getLimit()) {

--- a/tests/Http/Ownership/Search/SearchQueryTest.php
+++ b/tests/Http/Ownership/Search/SearchQueryTest.php
@@ -11,11 +11,11 @@ class SearchQueryTest extends TestCase
     /**
      * @test
      */
-    public function it_stores_the_parameters_offset_and_limit(): void
+    public function it_stores_the_parameters_start_and_limit(): void
     {
         $searchQuery = new SearchQuery([], 2, 20);
 
-        $this->assertEquals(2, $searchQuery->getOffset());
+        $this->assertEquals(2, $searchQuery->getStart());
         $this->assertEquals(20, $searchQuery->getLimit());
     }
 
@@ -37,11 +37,11 @@ class SearchQueryTest extends TestCase
     /**
      * @test
      */
-    public function it_stores_the_parameters_offset_and_limit_with_default_values(): void
+    public function it_stores_the_parameters_start_and_limit_with_default_values(): void
     {
         $searchQuery = new SearchQuery([]);
 
-        $this->assertEquals(0, $searchQuery->getOffset());
+        $this->assertEquals(0, $searchQuery->getStart());
         $this->assertEquals(50, $searchQuery->getLimit());
     }
 }

--- a/tests/Http/Ownership/SearchOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/SearchOwnershipRequestHandlerTest.php
@@ -278,10 +278,10 @@ class SearchOwnershipRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_searching_ownerships_with_offset_and_limit(): void
+    public function it_handles_searching_ownerships_with_start_and_limit(): void
     {
         $getOwnershipRequest = (new Psr7RequestBuilder())
-            ->withUriFromString('?state=approved&offset=1&limit=1')
+            ->withUriFromString('?state=approved&start=1&limit=1')
             ->build('GET');
 
         $approvedOwnership1 = new OwnershipItem(

--- a/tests/Ownership/Repositories/Search/DBALOwnershipSearchRepositoryTest.php
+++ b/tests/Ownership/Repositories/Search/DBALOwnershipSearchRepositoryTest.php
@@ -222,7 +222,7 @@ class DBALOwnershipSearchRepositoryTest extends TestCase
     /**
      * @test
      */
-    public function it_takes_into_account_offset_when_searching(): void
+    public function it_takes_into_account_start_when_searching(): void
     {
         $ownershipItem = new OwnershipItem(
             'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
@@ -295,7 +295,7 @@ class DBALOwnershipSearchRepositoryTest extends TestCase
     /**
      * @test
      */
-    public function it_takes_into_account_limit_and_offset_when_searching(): void
+    public function it_takes_into_account_limit_and_start_when_searching(): void
     {
         $ownershipItem = new OwnershipItem(
             'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',


### PR DESCRIPTION
### Changed
- Changed ownership pagination parameter to be start instead of offset

---

Since the issue of which term to use is complicated since both have merits, I've elected to only change the ownership parameter to match the API Guidelines document, as it wasn't clear whether unifying the term in the code itself too would be clearer (since we sometimes refer to MySQL offsets explicitely).

Ticket: https://jira.publiq.be/browse/III-6077
