### PR TITLE
III-6447 Avoid crash on legacy booking info when start date is after end date

### DIFF
--- a/src/Model/Serializer/ValueObject/Contact/BookingInfoDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Contact/BookingInfoDenormalizer.php
@@ -83,6 +83,10 @@ class BookingInfoDenormalizer implements DenormalizerInterface
         }
 
         if ($starts || $ends) {
+            // Avoid crashes when the start date is after the end date for legacy data inside the event store.
+            if ($starts && $ends && $starts > $ends) {
+                $starts = $ends;
+            }
             $availability = new BookingAvailability($starts, $ends);
         }
 


### PR DESCRIPTION
### Changed
- Avoid crash on legacy booking info when start date is after end date

---
Ticket: https://jira.uitdatabank.be/browse/III-6447
