### PR TITLE
III-6456 cli search trailer

### DIFF
--- a/app/Console/Command/AddMatchingTrailer.php
+++ b/app/Console/Command/AddMatchingTrailer.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Search\ResultsGenerator;
 use CultuurNet\UDB3\Search\ResultsGeneratorInterface;
 use CultuurNet\UDB3\Search\SearchServiceInterface;
 use CultuurNet\UDB3\Search\Sorting;
+use Google\Service\Exception as GoogleException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -74,7 +75,12 @@ final class AddMatchingTrailer extends Command
 
         $results = $this->searchResultsGenerator->search($query);
         foreach ($results as $eventId => $result) {
-            $this->dispatchAddVideoCommand($eventId, $output);
+            try {
+                $this->dispatchAddVideoCommand($eventId, $output);
+            } catch (GoogleException $exception) {
+                $output->writeln($exception->getMessage());
+                break;
+            }
         }
 
         return 0;

--- a/app/Console/Command/AddMatchingTrailer.php
+++ b/app/Console/Command/AddMatchingTrailer.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class FindMatchingTrailersOnYouTube extends Command
+final class AddMatchingTrailer extends Command
 {
     private CommandBus $commandBus;
 
@@ -48,7 +48,7 @@ final class FindMatchingTrailersOnYouTube extends Command
 
     public function configure(): void
     {
-        $this->setName('movies:find-trailers');
+        $this->setName('movies:add-trailers');
         $this->setDescription('Try to find a matching trailer for a movie');
     }
 

--- a/app/Console/Command/FindMatchingTrailersOnYouTube.php
+++ b/app/Console/Command/FindMatchingTrailersOnYouTube.php
@@ -46,6 +46,7 @@ final class FindMatchingTrailersOnYouTube extends Command
         $this->documentRepository = $documentRepository;
         $this->trailerRepository = $trailerRepository;
     }
+
     public function configure(): void
     {
         $this->setName('movies:find-trailers');

--- a/app/Console/Command/FindMatchingTrailersOnYouTube.php
+++ b/app/Console/Command/FindMatchingTrailersOnYouTube.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
 use CultuurNet\UDB3\Offer\Commands\Video\AddVideo;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
-use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Search\ResultsGenerator;
 use CultuurNet\UDB3\Search\ResultsGeneratorInterface;
 use CultuurNet\UDB3\Search\SearchServiceInterface;
@@ -74,15 +73,6 @@ final class FindMatchingTrailersOnYouTube extends Command
     private function getQueryForMoviesWithoutTrailer(): string
     {
         return 'terms.id:0.50.6.0.0 AND videosCount:0 AND creator:' . Uuid::NIL;
-    }
-
-    protected function getDocument(string $id): ?JsonDocument
-    {
-        try {
-            return $this->documentRepository->fetch($id);
-        } catch (DocumentDoesNotExist $e) {
-            return null;
-        }
     }
 
     private function dispatchAddVideoCommand(string $eventId, OutputInterface $output): void

--- a/app/Console/Command/FindMatchingTrailersOnYouTube.php
+++ b/app/Console/Command/FindMatchingTrailersOnYouTube.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Console\Command;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\Kinepolis\Trailer\TrailerRepository;
+use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
+use CultuurNet\UDB3\Offer\Commands\Video\AddVideo;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\Search\ResultsGenerator;
+use CultuurNet\UDB3\Search\ResultsGeneratorInterface;
+use CultuurNet\UDB3\Search\SearchServiceInterface;
+use CultuurNet\UDB3\Search\Sorting;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class FindMatchingTrailersOnYouTube extends Command
+{
+    private CommandBus $commandBus;
+
+    private ResultsGeneratorInterface $searchResultsGenerator;
+
+    private DocumentRepository $documentRepository;
+
+    private TrailerRepository $trailerRepository;
+
+    public function __construct(
+        CommandBus $commandBus,
+        SearchServiceInterface $searchService,
+        DocumentRepository $documentRepository,
+        TrailerRepository $trailerRepository
+    ) {
+        parent::__construct();
+        $this->commandBus = $commandBus;
+        $this->searchResultsGenerator = new ResultsGenerator(
+            $searchService,
+            new Sorting('created', 'desc'),
+            100
+        );
+        $this->documentRepository = $documentRepository;
+        $this->trailerRepository = $trailerRepository;
+    }
+    public function configure(): void
+    {
+        $this->setName('movies:find-trailers');
+        $this->setDescription('Try to find a matching trailer for a movie');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $query = $this->getQueryForMoviesWithoutTrailer();
+        $count = $this->searchResultsGenerator->count($query);
+
+        if ($count === 0) {
+            $output->writeln('Could not find any movies without trailer.');
+            return 0;
+        }
+
+        $results = $this->searchResultsGenerator->search($query);
+        foreach ($results as $eventId => $result) {
+            $this->dispatchAddVideoCommand($eventId, $output);
+        }
+
+        return 0;
+    }
+
+    private function getQueryForMoviesWithoutTrailer(): string
+    {
+        return 'terms.id:0.50.6.0.0 AND videosCount:0 AND creator:' . Uuid::NIL;
+    }
+
+    protected function getDocument(string $id): ?JsonDocument
+    {
+        try {
+            return $this->documentRepository->fetch($id);
+        } catch (DocumentDoesNotExist $e) {
+            return null;
+        }
+    }
+
+    private function dispatchAddVideoCommand(string $eventId, OutputInterface $output): void
+    {
+        try {
+            $document = $this->documentRepository->fetch($eventId);
+        } catch (DocumentDoesNotExist $e) {
+            $output->writeln("Skipping {$eventId}. (Could not find JSON-LD in local repository.)");
+            return;
+        }
+
+        $jsonLd = Json::decodeAssociatively($document->getRawBody());
+        $mainLanguage = $jsonLd->mainLanguage ?? 'nl';
+
+        if (!isset($jsonLd['name'][$mainLanguage])) {
+            $output->writeln("Skipping {$eventId}. (Could not find a name.)");
+            return;
+        }
+
+        $video = $this->trailerRepository->findMatchingTrailer($jsonLd['name'][$mainLanguage]);
+
+        if ($video === null) {
+            $output->writeln("Skipping {$eventId}. (Could not find a trailer.)");
+            return;
+        }
+
+        $this->commandBus->dispatch(
+            new AddVideo($eventId, $video)
+        );
+        $output->writeln("Added trailer for {$eventId}.");
+    }
+}

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -21,7 +21,7 @@ use CultuurNet\UDB3\Console\Command\ExcludeInvalidLabels;
 use CultuurNet\UDB3\Console\Command\ExcludeLabel;
 use CultuurNet\UDB3\Console\Command\ExecuteCommandFromCsv;
 use CultuurNet\UDB3\Console\Command\FetchMoviesFromKinepolisApi;
-use CultuurNet\UDB3\Console\Command\FindMatchingTrailersOnYouTube;
+use CultuurNet\UDB3\Console\Command\AddMatchingTrailer;
 use CultuurNet\UDB3\Console\Command\FindOutOfSyncProjections;
 use CultuurNet\UDB3\Console\Command\FireProjectedToJSONLDCommand;
 use CultuurNet\UDB3\Console\Command\FireProjectedToJSONLDForRelationsCommand;
@@ -120,7 +120,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         'console.organizer:convert-educational-description',
         'console.execute-command-from-csv',
         'console.movies:fetch',
-        'console.movies:find-trailers',
+        'console.movies:add-trailers',
     ];
 
     protected function getProvidedServiceNames(): array
@@ -525,8 +525,8 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         );
 
         $container->addShared(
-            'console.movies:find-trailers',
-            fn () => new FindMatchingTrailersOnYouTube(
+            'console.movies:add-trailers',
+            fn () => new AddMatchingTrailer(
                 $container->get('event_command_bus'),
                 $container->get(EventsSapi3SearchService::class),
                 $container->get('event_jsonld_repository'),

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -21,6 +21,7 @@ use CultuurNet\UDB3\Console\Command\ExcludeInvalidLabels;
 use CultuurNet\UDB3\Console\Command\ExcludeLabel;
 use CultuurNet\UDB3\Console\Command\ExecuteCommandFromCsv;
 use CultuurNet\UDB3\Console\Command\FetchMoviesFromKinepolisApi;
+use CultuurNet\UDB3\Console\Command\FindMatchingTrailersOnYouTube;
 use CultuurNet\UDB3\Console\Command\FindOutOfSyncProjections;
 use CultuurNet\UDB3\Console\Command\FireProjectedToJSONLDCommand;
 use CultuurNet\UDB3\Console\Command\FireProjectedToJSONLDForRelationsCommand;
@@ -119,6 +120,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         'console.organizer:convert-educational-description',
         'console.execute-command-from-csv',
         'console.movies:fetch',
+        'console.movies:find-trailers',
     ];
 
     protected function getProvidedServiceNames(): array
@@ -519,6 +521,28 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
                         LoggerName::forService('fetching-movies', 'kinepolis')
                     )
                 ),
+            )
+        );
+
+        $container->addShared(
+            'console.movies:find-trailers',
+            fn () => new FindMatchingTrailersOnYouTube(
+                $container->get('event_command_bus'),
+                $container->get(EventsSapi3SearchService::class),
+                $container->get('event_jsonld_repository'),
+                new YoutubeTrailerRepository(
+                    new Google_Service_YouTube(
+                        new Google_Client(
+                            [
+                                'application_name' => 'UiTDatabankTrailerFinder',
+                                'developer_key' => $container->get('config')['kinepolis']['trailers']['developer_key'],
+                            ]
+                        )
+                    ),
+                    $container->get('config')['kinepolis']['trailers']['channel_id'],
+                    new Version4Generator(),
+                    $container->get('config')['kinepolis']['trailers']['enabled'] ??  true,
+                )
             )
         );
     }


### PR DESCRIPTION
### Added

- `FindMatchingTrailersOnYouTube`: CLI-script to add matching trailers from YouTube to Kinepolis movies.

### Changed

- `ConsoleServiceProvider`: Register `FindMatchingTrailersOnYouTube`

### Note

- In a follow-up PR the trailerSearch within the KinepolisService will be removed, to have a clear separation of responsibilities.

---

Ticket: https://jira.publiq.be/browse/III-6456
