### PR TITLE
III-6458 Handle dummy locations with EventPlaceHistoryProjector

### DIFF
--- a/src/Event/ReadModel/History/EventPlaceHistoryProjector.php
+++ b/src/Event/ReadModel/History/EventPlaceHistoryProjector.php
@@ -15,6 +15,7 @@ use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;
 use CultuurNet\UDB3\Event\Events\EventUpdatedFromUDB2;
 use CultuurNet\UDB3\Event\Events\LocationUpdated;
 use CultuurNet\UDB3\Event\Events\MajorInfoUpdated;
+use CultuurNet\UDB3\Event\ReadModel\History\Exception\CannotDeterminePlaceIdForDummyPlace;
 use CultuurNet\UDB3\Event\ReadModel\Relations\EventPlaceHistoryRepository;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Model\Place\PlaceIDParser;
@@ -53,6 +54,13 @@ class EventPlaceHistoryProjector implements EventListener
         } catch (DocumentDoesNotExist $e) {
             $this->logger->error(sprintf('Failed to store location updated: %s', $e->getMessage()));
             return;
+        } catch (CannotDeterminePlaceIdForDummyPlace $e) {
+            $this->repository->storeEventPlaceStartingPoint(
+                new Uuid($locationUpdated->getItemId()),
+                new Uuid($locationUpdated->getLocationId()->toString()),
+                $domainMessage->getRecordedOn()->toNative()
+            );
+            return;
         }
 
         $this->repository->storeEventPlaceMove(
@@ -76,7 +84,7 @@ class EventPlaceHistoryProjector implements EventListener
     {
         try {
             $placeId = $this->getOldPlaceUuid($eventCopied->getOriginalEventId());
-        } catch (DocumentDoesNotExist $e) {
+        } catch (DocumentDoesNotExist|CannotDeterminePlaceIdForDummyPlace $e) {
             $this->logger->error(sprintf('Failed to store event copied: %s', $e->getMessage()));
             return;
         }
@@ -127,7 +135,7 @@ class EventPlaceHistoryProjector implements EventListener
 
         try {
             $oldPlaceId = $this->getOldPlaceUuid($eventUpdatedFromUDB2->getEventId());
-        } catch (DocumentDoesNotExist $e) {
+        } catch (DocumentDoesNotExist|CannotDeterminePlaceIdForDummyPlace $e) {
             $this->logger->error(sprintf('Failed to store event updated from UDB2: %s', $e->getMessage()));
             return;
         }
@@ -148,17 +156,22 @@ class EventPlaceHistoryProjector implements EventListener
 
     protected function applyMajorInfoUpdated(MajorInfoUpdated $majorInfoUpdated, DomainMessage $domainMessage): void
     {
+        $newPlaceId = new Uuid($majorInfoUpdated->getLocation()->toString());
+
         try {
             $oldPlaceId = $this->getOldPlaceUuid($majorInfoUpdated->getItemId());
-        } catch (DocumentDoesNotExist $e) {
+        } catch (DocumentDoesNotExist|InvalidArgumentException $e) {
             $this->logger->error(sprintf('Failed to store location updated: %s', $e->getMessage()));
             return;
-        } catch (InvalidArgumentException $e) {
-            $this->logger->error(sprintf('Failed to store location updated: %s', $e->getMessage()));
+        } catch (CannotDeterminePlaceIdForDummyPlace $e) {
+            $this->repository->storeEventPlaceStartingPoint(
+                new Uuid($majorInfoUpdated->getItemId()),
+                $newPlaceId,
+                $domainMessage->getRecordedOn()->toNative()
+            );
+
             return;
         }
-
-        $newPlaceId = new Uuid($majorInfoUpdated->getLocation()->toString());
 
         if ($newPlaceId->sameAs($oldPlaceId)) {
             return;
@@ -175,12 +188,17 @@ class EventPlaceHistoryProjector implements EventListener
     /**
      * @throws DocumentDoesNotExist
      * @throws InvalidArgumentException
+     * @throws CannotDeterminePlaceIdForDummyPlace
      */
     private function getOldPlaceUuid(string $eventId): Uuid
     {
         $myEvent = $this->eventRepository->fetch($eventId);
 
         $body = $myEvent->getAssocBody();
+
+        if (!isset($body['location']['@id'])) {
+            throw new CannotDeterminePlaceIdForDummyPlace();
+        }
 
         $id = (new PlaceIDParser())->fromUrl(new Url($body['location']['@id']));
         return new Uuid($id->toString());

--- a/src/Event/ReadModel/History/EventPlaceHistoryProjector.php
+++ b/src/Event/ReadModel/History/EventPlaceHistoryProjector.php
@@ -196,7 +196,7 @@ class EventPlaceHistoryProjector implements EventListener
 
         $body = $myEvent->getAssocBody();
 
-        if (!isset($body['location']['@id'])) {
+        if (empty($body['location']['@id'])) {
             throw new CannotDeterminePlaceIdForDummyPlace();
         }
 

--- a/src/Event/ReadModel/History/Exception/CannotDeterminePlaceIdForDummyPlace.php
+++ b/src/Event/ReadModel/History/Exception/CannotDeterminePlaceIdForDummyPlace.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\ReadModel\History\Exception;
+
+class CannotDeterminePlaceIdForDummyPlace extends \DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('Could not determine the old place uuid because it was a dummy place.');
+    }
+}


### PR DESCRIPTION
### Fixed
When updating / cloning an old location with a dummy location (= no location id), the new history projector would crash.
This handles the crashes for copy locations, update locations and major info events.
Comes with unit tests to prove the solution works.

---

Ticket: https://jira.uitdatabank.be/browse/III-6458 
