### PR TITLE
Only check unused dependencies on current PHP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ["7.4", "8.0", "8.1"]
+                php-versions: ["8.1"]
         name: Unused composer dependencies ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project


### PR DESCRIPTION
### Changed
- Only check unused dependencies on current PHP

---

Just to avoid the overkill of spinning three containers to do a simple check

From discussion around https://github.com/cultuurnet/udb3-search-service/pull/331
