### PR TITLE
III-6494 RDF convert blank nodes to named hashes

### DIFF
--- a/src/RDF/Editor/AddressEditor.php
+++ b/src/RDF/Editor/AddressEditor.php
@@ -6,10 +6,7 @@ namespace CultuurNet\UDB3\RDF\Editor;
 
 use CultuurNet\UDB3\Address\Formatter\FullAddressFormatter;
 use CultuurNet\UDB3\Address\Parser\AddressParser;
-use CultuurNet\UDB3\Model\Serializer\ValueObject\Geography\AddressNormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Geography\TranslatedAddress;
-use CultuurNet\UDB3\RDF\NodeUri\CRC32HashGenerator;
-use CultuurNet\UDB3\RDF\NodeUri\NodeUriGenerator;
 use EasyRdf\Literal;
 use EasyRdf\Resource;
 
@@ -17,36 +14,24 @@ final class AddressEditor
 {
     private AddressParser $addressParser;
 
+    private const TYPE_ADRES = 'locn:Address';
+
     private const PROPERTY_ADRES_STRAATNAAM = 'locn:thoroughfare';
     private const PROPERTY_ADRES_HUISNUMMER = 'locn:locatorDesignator';
     private const PROPERTY_ADRES_POSTCODE = 'locn:postCode';
     private const PROPERTY_ADRES_GEMEENTENAAM = 'locn:postName';
     private const PROPERTY_ADRES_LAND = 'locn:adminUnitL1';
     private const PROPERTY_ADRES_VOLLEDIG_ADRES = 'locn:fullAddress';
-    private AddressNormalizer $addressNormalizer;
 
-    public function __construct(AddressParser $addressParser, AddressNormalizer $addressNormalizer = null)
+    public function __construct(AddressParser $addressParser)
     {
         $this->addressParser = $addressParser;
-        $this->addressNormalizer = $addressNormalizer ?? new AddressNormalizer();
     }
 
     public function setAddress(Resource $resource, string $property, TranslatedAddress $translatedAddress): Resource
     {
-        //start
-        $nodeUriGenerator = new NodeUriGenerator(new CRC32HashGenerator());
-
-        $addressJson = [];
-        foreach ($translatedAddress->getLanguages() as $language) {
-            $addressJson[] = $this->addressNormalizer->normalize($translatedAddress->getTranslation($language));
-        }
-
-        $addressResource = $resource->getGraph()->resource($nodeUriGenerator->generate(
-            'address',
-            $addressJson
-        ));
+        $addressResource = $resource->getGraph()->newBNode([self::TYPE_ADRES]);
         $resource->add($property, $addressResource);
-        //end
 
         foreach ($translatedAddress->getLanguages() as $language) {
             $address = $translatedAddress->getTranslation($language);

--- a/src/RDF/NodeUri/CRC32HashGenerator.php
+++ b/src/RDF/NodeUri/CRC32HashGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\RDF\NodeUri;
+
+// We use CRC32 to generate hashes for the RDF namespaces.
+// We decided on CRC32 instead sha1/md5 because the hash is much shorter.
+// Because all hashes are always prefixed by the type of node, the risk of collisions is very low.
+use CultuurNet\UDB3\Json;
+
+final class CRC32HashGenerator implements HashGenerator
+{
+    public function generate(array $data): string
+    {
+        $this->recursiveSort($data);
+        return hash('crc32b', Json::encode($data));
+    }
+
+    private function recursiveSort(array &$array): void
+    {
+        ksort($array);
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $this->recursiveSort($value);
+            }
+        }
+    }
+}

--- a/src/RDF/NodeUri/HashGenerator.php
+++ b/src/RDF/NodeUri/HashGenerator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\RDF\NodeUri;
+
+interface HashGenerator
+{
+    public function generate(array $data): string;
+}

--- a/src/RDF/NodeUri/NodeUriGenerator.php
+++ b/src/RDF/NodeUri/NodeUriGenerator.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\RDF\NodeUri;
+
+final class NodeUriGenerator
+{
+    private HashGenerator $hashGenerator;
+
+    public function __construct(HashGenerator $hashGenerator)
+    {
+        $this->hashGenerator = $hashGenerator;
+    }
+
+    public function generate(string $nodeName, array $fields): string
+    {
+        return sprintf('#%s-%s', $nodeName, $this->hashGenerator->generate($fields));
+    }
+}

--- a/tests/RDF/NodeUri/CRC32HashGeneratorTest.php
+++ b/tests/RDF/NodeUri/CRC32HashGeneratorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\RDF\NodeUri;
+
+use CultuurNet\UDB3\Json;
+use PHPUnit\Framework\TestCase;
+
+final class CRC32HashGeneratorTest extends TestCase
+{
+    private CRC32HashGenerator $hashGenerator;
+
+    protected function setUp(): void
+    {
+        $this->hashGenerator = new CRC32HashGenerator();
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_produces_consistent_hash(): void
+    {
+        $data = [
+            'key1' => 'value1',
+            'key2' => [
+                'key2_1' => 'value2_1',
+                'key2_2' => 'value2_2',
+            ],
+        ];
+
+        $this->assertSame($this->hashGenerator->generate($data), $this->hashGenerator->generate($data));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_ignores_input_order(): void
+    {
+        $data1 = [
+            'key1' => 'value1',
+            'key2' => [
+                'key2_1' => 'value2_1',
+                'key2_2' => 'value2_2',
+            ],
+        ];
+
+        $data2 = [
+            'key2' => [
+                'key2_2' => 'value2_2',
+                'key2_1' => 'value2_1',
+            ],
+            'key1' => 'value1',
+        ];
+
+        $this->assertSame($this->hashGenerator->generate($data1), $this->hashGenerator->generate($data2));
+    }
+}

--- a/tests/RDF/NodeUri/CRC32HashGeneratorTest.php
+++ b/tests/RDF/NodeUri/CRC32HashGeneratorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\RDF\NodeUri;
 
-use CultuurNet\UDB3\Json;
 use PHPUnit\Framework\TestCase;
 
 final class CRC32HashGeneratorTest extends TestCase

--- a/tests/RDF/NodeUri/NodeUriGeneratorTest.php
+++ b/tests/RDF/NodeUri/NodeUriGeneratorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\RDF\NodeUri;
+
+use PHPUnit\Framework\TestCase;
+
+class NodeUriGeneratorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_generate_a_node_uri(): void
+    {
+        $generator = $this->createMock(HashGenerator::class);
+        $generator->expects($this->once())
+            ->method('generate')
+            ->with(['a', 'b', 'c'])
+            ->willReturn('abc');
+
+        $nodeUriGenerator = new NodeUriGenerator($generator);
+        $uri = $nodeUriGenerator->generate('address', ['a', 'b', 'c']);
+
+        $this->assertEquals('#address-abc', $uri);
+    }
+}


### PR DESCRIPTION
### Added
- Added 2 new classes and tests to convert blank nodes in the RDF projection to named nodes with a URI. This URI will contain a unique hash based on the content of the node. Currently this PR does not do anything, it is just for preperation for the work in https://jira.publiq.be/browse/III-6450

---

Ticket: https://jira.uitdatabank.be/browse/III-6494
