### PR TITLE
Sort by availability by default during events PDF export

### DIFF
--- a/src/EventExport/Command/ExportEventsAsPDFJSONDeserializer.php
+++ b/src/EventExport/Command/ExportEventsAsPDFJSONDeserializer.php
@@ -88,6 +88,8 @@ class ExportEventsAsPDFJSONDeserializer extends JSONDeserializer
 
         if ($sorting !== null) {
             $command = $command->withSorting($sorting);
+        } else {
+            $command = $command->withSorting(new Sorting('availableTo', 'asc'));
         }
 
         if (isset($customizations->subtitle)) {

--- a/tests/Http/Export/ExportEventsAsPdfRequestHandlerTest.php
+++ b/tests/Http/Export/ExportEventsAsPdfRequestHandlerTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
 use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Search\Sorting;
 use PHPUnit\Framework\TestCase;
 
 final class ExportEventsAsPdfRequestHandlerTest extends TestCase
@@ -67,7 +68,7 @@ final class ExportEventsAsPdfRequestHandlerTest extends TestCase
                     'logo',
                     new Title('title'),
                     WebArchiveTemplate::map()
-                ))->withEmailNotificationTo(new EmailAddress('jane@anonymous.com')),
+                ))->withEmailNotificationTo(new EmailAddress('jane@anonymous.com'))->withSorting(new Sorting('availableTo', 'asc')),
             ],
             $this->commandBus->getRecordedCommands()
         );


### PR DESCRIPTION
### Changed
- Sort by availability by default during events PDF export

---

This is the deserializer used to parse the request parameters so this should be the central place to do that change but I wasn't 100% sure either if it should be added as default sorting to the command itself instead? https://github.com/cultuurnet/udb3-backend/blob/master/src/EventExport/Command/ExportEventsAsPDF.php#L65 I thought that might make the command less pure so I wasn't entirely sure, so not sure what you think

Ticket: https://jira.publiq.be/browse/III-5161
