### PR TITLE
III-5221 Feature test for Search fail with ' or - character

### DIFF
--- a/features/Steps/UtilitySteps.php
+++ b/features/Steps/UtilitySteps.php
@@ -17,6 +17,15 @@ trait UtilitySteps
     }
 
     /**
+     * @Given /^I create a name that includes a dash and keep it as "([^"]*)"$/
+     */
+    public function iCreateANameThatIncludesADashAndKeepItAs(string $variableName): void
+    {
+        $value = uniqid('', true) . '-\'' . uniqid('', true);
+        $this->variableState->setVariable($variableName, $value);
+    }
+
+    /**
      * @Given I create a random name of :nrOfCharacters characters
      */
     public function iCreateARandomNameOfCharacters(int $nrOfCharacters): void

--- a/features/search/search-with-special-characters.feature
+++ b/features/search/search-with-special-characters.feature
@@ -1,0 +1,25 @@
+@sapi3
+Feature: Test the UDB3 search proxy
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+
+
+  Scenario: Search places via proxy endpoint
+    Given I set the value of name to "test-test"
+    Given I create a name that includes a dash and keep it as "name"
+    Given I create a place from "places/place-with-required-fields-and-variable-name.json" and save the "url" as "placeUrl"
+    And I wait for the place with url "%{placeUrl}" to be indexed
+    And I am not authorized
+
+    When I send a GET request to "/offers" with parameters:
+      | limit                 | 1 |
+      | embed                 | true |
+      | disableDefaultFilters | true |
+      | text      | *%{name}* |
+    Then the response status should be "200"
+    And the JSON response at "itemsPerPage" should be 1
+    And the JSON response at "totalItems" should not be 0
+    And the JSON response at "member/0/@id" should be "%{placeUrl}"


### PR DESCRIPTION
### Fixed
 
- Currently a search with a ' or - will not work. (in the text field).
- This is the feature test, the actual fix is in the SAPI3 code: https://github.com/cultuurnet/udb3-search-service/pull/339
 
---

Ticket: https://jira.uitdatabank.be/browse/III-5221 
Related: https://github.com/cultuurnet/udb3-search-service/pull/339