### PR TITLE
III-6482 RDF Wrong class for virtual location

### DIFF
--- a/features/data/events/rdf/mixed-event-with-online-url-and-multiple-calendar.ttl
+++ b/features/data/events/rdf/mixed-event-with-online-url-and-multiple-calendar.ttl
@@ -20,7 +20,7 @@
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
-  platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-61d7772d> ;
+  platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d> ;
   cp:ruimtetijd <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-8b563a39>, <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-5da8175b> .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}>
@@ -33,8 +33,8 @@
   generiek:naamruimte "http://data.uitdatabank.local:80/events/" ;
   generiek:lokaleIdentificator "%{eventId}" .
 
-<http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-61d7772d>
-  a platform:virtueleLocatie ;
+<http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d>
+  a schema:virtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-8b563a39>

--- a/features/data/events/rdf/mixed-event-with-online-url-and-multiple-calendar.ttl
+++ b/features/data/events/rdf/mixed-event-with-online-url-and-multiple-calendar.ttl
@@ -34,7 +34,7 @@
   generiek:lokaleIdentificator "%{eventId}" .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d>
-  a schema:virtualLocation ;
+  a schema:VirtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-8b563a39>

--- a/features/data/events/rdf/mixed-event-with-online-url-and-permanent-calendar.ttl
+++ b/features/data/events/rdf/mixed-event-with-online-url-and-permanent-calendar.ttl
@@ -19,7 +19,7 @@
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
-  platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-61d7772d> ;
+  platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{uuid_place}> .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}>
@@ -32,6 +32,6 @@
   generiek:naamruimte "http://data.uitdatabank.local:80/events/" ;
   generiek:lokaleIdentificator "%{eventId}" .
 
-<http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-61d7772d>
-  a platform:virtueleLocatie ;
+<http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d>
+  a schema:virtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .

--- a/features/data/events/rdf/mixed-event-with-online-url-and-permanent-calendar.ttl
+++ b/features/data/events/rdf/mixed-event-with-online-url-and-permanent-calendar.ttl
@@ -33,5 +33,5 @@
   generiek:lokaleIdentificator "%{eventId}" .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d>
-  a schema:virtualLocation ;
+  a schema:VirtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .

--- a/features/data/events/rdf/online-event-with-multiple-calendar.ttl
+++ b/features/data/events/rdf/online-event-with-multiple-calendar.ttl
@@ -19,7 +19,7 @@
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
-  platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-b4e9ae58> ;
+  platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-b4e9ae58> ;
   cp:ruimtetijd <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-2aac7354>, <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-cbeaaec0> .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}>
@@ -32,7 +32,7 @@
   generiek:naamruimte "http://data.uitdatabank.local:80/events/" ;
   generiek:lokaleIdentificator "%{eventId}" .
 
-<http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-b4e9ae58> a platform:virtueleLocatie .
+<http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-b4e9ae58> a schema:virtualLocation .
 <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-2aac7354>
   a cidoc:E92_Spacetime_Volume ;
   cidoc:P160_has_temporal_projection <http://data.uitdatabank.local:80/events/%{eventId}#periodOfTime-31d8dd36> .

--- a/features/data/events/rdf/online-event-with-multiple-calendar.ttl
+++ b/features/data/events/rdf/online-event-with-multiple-calendar.ttl
@@ -8,6 +8,7 @@
 @prefix cp: <https://data.vlaanderen.be/ns/cultuurparticipatie#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix schema: <https://schema.org/> .
 @prefix m8g: <http://data.europa.eu/m8g/> .
 
 <http://data.uitdatabank.local:80/events/%{eventId}>
@@ -32,7 +33,7 @@
   generiek:naamruimte "http://data.uitdatabank.local:80/events/" ;
   generiek:lokaleIdentificator "%{eventId}" .
 
-<http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-b4e9ae58> a schema:virtualLocation .
+<http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-b4e9ae58> a schema:VirtualLocation .
 <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-2aac7354>
   a cidoc:E92_Spacetime_Volume ;
   cidoc:P160_has_temporal_projection <http://data.uitdatabank.local:80/events/%{eventId}#periodOfTime-31d8dd36> .

--- a/features/data/events/rdf/online-event-with-online-url-and-multiple-calendar.ttl
+++ b/features/data/events/rdf/online-event-with-online-url-and-multiple-calendar.ttl
@@ -34,7 +34,7 @@
   generiek:lokaleIdentificator "%{eventId}" .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d>
-  a schema:virtualLocation ;
+  a schema:VirtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-2aac7354>

--- a/features/data/events/rdf/online-event-with-online-url-and-multiple-calendar.ttl
+++ b/features/data/events/rdf/online-event-with-online-url-and-multiple-calendar.ttl
@@ -20,7 +20,7 @@
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
-  platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-61d7772d> ;
+  platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d> ;
   cp:ruimtetijd <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-2aac7354>, <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-cbeaaec0> .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}>
@@ -33,8 +33,8 @@
   generiek:naamruimte "http://data.uitdatabank.local:80/events/" ;
   generiek:lokaleIdentificator "%{eventId}" .
 
-<http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-61d7772d>
-  a platform:virtueleLocatie ;
+<http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d>
+  a schema:virtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-2aac7354>

--- a/features/data/events/rdf/online-event-with-online-url-and-permanent-calendar.ttl
+++ b/features/data/events/rdf/online-event-with-online-url-and-permanent-calendar.ttl
@@ -18,7 +18,7 @@
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
-  platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-61d7772d> .
+  platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d> .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}>
   a adms:Identifier ;
@@ -30,6 +30,6 @@
   generiek:naamruimte "http://data.uitdatabank.local:80/events/" ;
   generiek:lokaleIdentificator "%{eventId}" .
 
-<http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-61d7772d>
-  a platform:virtueleLocatie ;
+<http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d>
+  a schema:virtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .

--- a/features/data/events/rdf/online-event-with-online-url-and-permanent-calendar.ttl
+++ b/features/data/events/rdf/online-event-with-online-url-and-permanent-calendar.ttl
@@ -31,5 +31,5 @@
   generiek:lokaleIdentificator "%{eventId}" .
 
 <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d>
-  a schema:virtualLocation ;
+  a schema:VirtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .

--- a/src/Event/ReadModel/RDF/EventJsonToTurtleConverter.php
+++ b/src/Event/ReadModel/RDF/EventJsonToTurtleConverter.php
@@ -77,7 +77,7 @@ final class EventJsonToTurtleConverter implements JsonToTurtleConverter
     private const TYPE_PERIOD = 'm8g:PeriodOfTime';
     private const TYPE_DATE_TIME = 'xsd:dateTime';
     private const TYPE_LOCATIE = 'dcterms:Location';
-    private const TYPE_VIRTUAL_LOCATION = 'schema:virtualLocation';
+    private const TYPE_VIRTUAL_LOCATION = 'schema:VirtualLocation';
     private const TYPE_VIRTUAL_LOCATION_URL = 'schema:URL';
     private const TYPE_BOEKINGSINFO = 'cpa:Boekingsinfo';
     private const TYPE_ORGANISATOR = 'cp:Organisator';

--- a/src/Event/ReadModel/RDF/EventJsonToTurtleConverter.php
+++ b/src/Event/ReadModel/RDF/EventJsonToTurtleConverter.php
@@ -77,6 +77,7 @@ final class EventJsonToTurtleConverter implements JsonToTurtleConverter
     private const TYPE_PERIOD = 'm8g:PeriodOfTime';
     private const TYPE_DATE_TIME = 'xsd:dateTime';
     private const TYPE_LOCATIE = 'dcterms:Location';
+    private const TYPE_VIRTUAL_LOCATION = 'schema:virtualLocation';
     private const TYPE_VIRTUAL_LOCATION_URL = 'schema:URL';
     private const TYPE_BOEKINGSINFO = 'cpa:Boekingsinfo';
     private const TYPE_ORGANISATOR = 'cp:Organisator';
@@ -96,7 +97,6 @@ final class EventJsonToTurtleConverter implements JsonToTurtleConverter
     private const PROPERTY_RUIMTE_TIJD_CALENDAR_TYPE = 'cidoc:P160_has_temporal_projection';
     private const PROPERTY_LOCATIE_ADRES = 'locn:address';
     private const PROPERTY_LOCATIE_NAAM = 'locn:locatorName';
-
     private const PROPERTY_VIRTUAL_LOCATION = 'platform:virtueleLocatie';
     private const PROPERTY_VIRTUAL_LOCATION_URL = 'schema:url';
     private const PROPERTY_LOCATIE_TYPE = 'cpa:locatieType';
@@ -445,7 +445,7 @@ final class EventJsonToTurtleConverter implements JsonToTurtleConverter
 
     private function setVirtualLocation(Resource $resource, ?Url $onlineUrl): void
     {
-        $virtualLocationResource = $this->rdfResourceFactory->create($resource, self::PROPERTY_VIRTUAL_LOCATION, [
+        $virtualLocationResource = $this->rdfResourceFactory->create($resource, self::TYPE_VIRTUAL_LOCATION, [
             $onlineUrl ? $onlineUrl->toString() : '',
         ]);
 

--- a/src/RDF/NodeUri/NodeUriGenerator.php
+++ b/src/RDF/NodeUri/NodeUriGenerator.php
@@ -21,7 +21,7 @@ final class NodeUriGenerator
         }
 
         // Convert AddressDetail to addressDetail
-        $nodeName = mb_strtolower(substr($nodeName, 0, 1)) . substr($nodeName, 1);
+        $nodeName = lcfirst($nodeName);
 
         return sprintf('#%s-%s', $nodeName, $this->hashGenerator->generate($fields));
     }

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-multiple-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-multiple-calendar.ttl
@@ -35,7 +35,7 @@
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
-  a schema:virtualLocation ;
+  a schema:VirtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-multiple-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-multiple-calendar.ttl
@@ -21,7 +21,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
-  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d> ;
+  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-a889f286> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>
@@ -34,8 +34,8 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d>
-  a platform:virtueleLocatie ;
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
+  a schema:virtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-permanent-calendar.ttl
@@ -35,5 +35,5 @@
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
-  a schema:virtualLocation ;
+  a schema:VirtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-permanent-calendar.ttl
@@ -21,7 +21,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
-  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d> ;
+  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>
@@ -34,6 +34,6 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d>
-  a platform:virtueleLocatie ;
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
+  a schema:virtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-single-calendar.ttl
@@ -35,7 +35,7 @@
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
-  a schema:virtualLocation ;
+  a schema:VirtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-single-calendar.ttl
@@ -21,7 +21,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
-  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d> ;
+  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>
@@ -34,8 +34,8 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d>
-  a platform:virtueleLocatie ;
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
+  a schema:virtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-permanent-calendar.ttl
@@ -34,4 +34,4 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:virtualLocation .
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:VirtualLocation .

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-permanent-calendar.ttl
@@ -9,6 +9,7 @@
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix schema: <https://schema.org/> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a cidoc:E7_Activity ;
@@ -20,7 +21,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
-  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-b4e9ae58> ;
+  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>
@@ -33,4 +34,4 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-b4e9ae58> a platform:virtueleLocatie .
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:virtualLocation .

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-single-calendar.ttl
@@ -8,6 +8,7 @@
 @prefix platform: <https://data.uitwisselingsplatform.be/ns/platform#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix schema: <https://schema.org/> .
 @prefix m8g: <http://data.europa.eu/m8g/> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -20,7 +21,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
-  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-b4e9ae58> ;
+  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>
@@ -33,7 +34,7 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-b4e9ae58> a platform:virtueleLocatie .
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:virtualLocation .
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>
   a cidoc:E92_Spacetime_Volume ;
   cidoc:P161_has_spatial_projection <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-single-calendar.ttl
@@ -34,7 +34,7 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:virtualLocation .
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:VirtualLocation .
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>
   a cidoc:E92_Spacetime_Volume ;
   cidoc:P161_has_spatial_projection <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-multiple-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-multiple-calendar.ttl
@@ -35,7 +35,7 @@
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
-  a schema:virtualLocation ;
+  a schema:VirtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-multiple-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-multiple-calendar.ttl
@@ -21,7 +21,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
-  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d> ;
+  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-a889f286> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>
@@ -34,8 +34,8 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d>
-  a platform:virtueleLocatie ;
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
+  a schema:virtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-permanent-calendar.ttl
@@ -33,5 +33,5 @@
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
-  a schema:virtualLocation ;
+  a schema:VirtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-permanent-calendar.ttl
@@ -20,7 +20,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
-  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d> .
+  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>
   a adms:Identifier ;
@@ -32,6 +32,6 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d>
-  a platform:virtueleLocatie ;
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
+  a schema:virtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-single-calendar.ttl
@@ -35,7 +35,7 @@
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
-  a schema:virtualLocation ;
+  a schema:VirtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-single-calendar.ttl
@@ -21,7 +21,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
-  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d> ;
+  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>
@@ -34,8 +34,8 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-61d7772d>
-  a platform:virtueleLocatie ;
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d>
+  a schema:virtualLocation ;
   schema:url "https://www.publiq.be/livestream"^^schema:URL .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-permanent-calendar.ttl
@@ -8,6 +8,7 @@
 @prefix platform: <https://data.uitwisselingsplatform.be/ns/platform#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix schema: <https://schema.org/> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a cidoc:E7_Activity ;
@@ -19,7 +20,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
-  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-b4e9ae58> .
+  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>
   a adms:Identifier ;
@@ -31,4 +32,4 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-b4e9ae58> a platform:virtueleLocatie .
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:virtualLocation .

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-permanent-calendar.ttl
@@ -32,4 +32,4 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:virtualLocation .
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:VirtualLocation .

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-single-calendar.ttl
@@ -8,6 +8,7 @@
 @prefix platform: <https://data.uitwisselingsplatform.be/ns/platform#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix schema: <https://schema.org/> .
 @prefix m8g: <http://data.europa.eu/m8g/> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
@@ -20,7 +21,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
-  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-b4e9ae58> ;
+  platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>
@@ -33,7 +34,7 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtueleLocatie-b4e9ae58> a platform:virtueleLocatie .
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:virtualLocation .
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>
   a cidoc:E92_Spacetime_Volume ;
   cidoc:P160_has_temporal_projection <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#periodOfTime-8de5b7f4> .

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-single-calendar.ttl
@@ -34,7 +34,7 @@
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
 
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:virtualLocation .
+<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> a schema:VirtualLocation .
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>
   a cidoc:E92_Spacetime_Volume ;
   cidoc:P160_has_temporal_projection <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#periodOfTime-8de5b7f4> .


### PR DESCRIPTION
Details you find in the comment of https://jira.publiq.be/browse/III-6496, feedback from Stan.

### Changed
- Change class of Virtual location.

Before:

<http://data.uitdatabank.local:80/events/%{eventId}#virtueleLocatie-61d7772d>
  a platform:virtueleLocatie ;
  schema:url "https://www.publiq.be/livestream"^^schema:URL .

Now:

 <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d>
  a schema:VirtualLocation ;
  schema:url "https://www.publiq.be/livestream"^^schema:URL .

---

Ticket: https://jira.uitdatabank.be/browse/III-6482
Related: https://jira.publiq.be/browse/III-6496
