### PR TITLE
Fixed updating non existing organizers throwing 404 and not 403

### DIFF
--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -463,7 +463,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
             fn () => new ConvertDescriptionToEducationalDescriptionForCultuurkuur(
                 $container->get('event_command_bus'),
                 $container->get(OrganizersSapi3SearchService::class),
-                new CacheDocumentRepository($container->get('organizer_jsonld_cache'))
+                $container->get('organizer_jsonld_cache')
             )
         );
 

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -48,7 +48,6 @@ use CultuurNet\UDB3\Console\Command\UpdateOfferStatusCommand;
 use CultuurNet\UDB3\Console\Command\UpdateUniqueLabels;
 use CultuurNet\UDB3\Console\Command\UpdateUniqueOrganizers;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
-use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
 use CultuurNet\UDB3\Event\Productions\ProductionRepository;

--- a/app/Http/MiddlewareServiceProvider.php
+++ b/app/Http/MiddlewareServiceProvider.php
@@ -12,7 +12,7 @@ final class MiddlewareServiceProvider extends AbstractServiceProvider
     {
         return [
             CheckTypeOfOfferMiddleware::class,
-            CheckOrganizerMiddleware::class
+            CheckOrganizerMiddleware::class,
         ];
     }
 

--- a/app/Http/MiddlewareServiceProvider.php
+++ b/app/Http/MiddlewareServiceProvider.php
@@ -12,6 +12,7 @@ final class MiddlewareServiceProvider extends AbstractServiceProvider
     {
         return [
             CheckTypeOfOfferMiddleware::class,
+            CheckOrganizerMiddleware::class
         ];
     }
 
@@ -24,6 +25,13 @@ final class MiddlewareServiceProvider extends AbstractServiceProvider
             fn () => new CheckTypeOfOfferMiddleware(
                 $container->get('place_jsonld_cache'),
                 $container->get('event_jsonld_cache')
+            )
+        );
+
+        $container->addShared(
+            CheckOrganizerMiddleware::class,
+            fn () => new CheckOrganizerMiddleware(
+                $container->get('organizer_jsonld_cache'),
             )
         );
     }

--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -247,6 +247,7 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
         $router->middleware($container->get(RequestAuthenticatorMiddleware::class));
 
         $router->middleware($container->get(CheckTypeOfOfferMiddleware::class));
+        $router->middleware($container->get(CheckOrganizerMiddleware::class));
     }
 
     private function bindNewsArticles(Router $router): void

--- a/app/Organizer/OrganizerJSONLDServiceProvider.php
+++ b/app/Organizer/OrganizerJSONLDServiceProvider.php
@@ -76,7 +76,7 @@ final class OrganizerJSONLDServiceProvider extends AbstractServiceProvider
         $container->addShared(
             'organizer_jsonld_repository',
             function () use ($container) {
-                $repository = new CacheDocumentRepository($container->get('organizer_jsonld_cache'));
+                $repository = $container->get('organizer_jsonld_cache');
                 $repository = new PropertyPolyfillRepository($repository, $container->get(LabelServiceProvider::JSON_READ_REPOSITORY));
 
                 $repository = new ContributorEnrichedRepository(
@@ -97,7 +97,7 @@ final class OrganizerJSONLDServiceProvider extends AbstractServiceProvider
         $container->addShared(
             'organizer_jsonld_cache',
             function () use ($container) {
-                return $container->get('cache')('organizer_jsonld');
+                return new CacheDocumentRepository($container->get('cache')('organizer_jsonld'));
             }
         );
     }

--- a/features/organizer/update.feature
+++ b/features/organizer/update.feature
@@ -226,3 +226,11 @@ Feature: Test updating organizers via complete overwrite
     }
     """
 
+  Scenario: Trying to update an organizer that does not exist
+    Given I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I set the JSON request payload to:
+    """
+        {"name": "madewithlove"}
+    """
+    And I send a PUT request to "/organizers/139357a0-5e28-4c02-8fe5-d14b9f5791b7/name/nl"
+    And the response status should be "404"

--- a/src/Http/CheckOrganizerMiddleware.php
+++ b/src/Http/CheckOrganizerMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CultuurNet\UDB3\Http;
 
 use CultuurNet\UDB3\Http\Request\RouteParameters;

--- a/src/Http/CheckOrganizerMiddleware.php
+++ b/src/Http/CheckOrganizerMiddleware.php
@@ -11,15 +11,21 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class CheckOrganizerMiddleware implements MiddlewareInterface
 {
-    private DocumentRepository $offerRepository;
+    private DocumentRepository $organizerRepository;
 
-    public function __construct(DocumentRepository $offerRepository)
+    public function __construct(DocumentRepository $organizerRepository)
     {
-        $this->offerRepository = $offerRepository;
+        $this->organizerRepository = $organizerRepository;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $routeParameters = new RouteParameters($request);
+        if ($routeParameters->hasOrganizerId()) {
+            $organizerId = $routeParameters->getOrganizerId();
+            $this->organizerRepository->fetch($organizerId);
+        }
+
+        return $handler->handle($request);
     }
 }

--- a/src/Http/CheckOrganizerMiddleware.php
+++ b/src/Http/CheckOrganizerMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace CultuurNet\UDB3\Http;
+
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class CheckOrganizerMiddleware implements MiddlewareInterface
+{
+    private DocumentRepository $offerRepository;
+
+    public function __construct(DocumentRepository $offerRepository)
+    {
+        $this->offerRepository = $offerRepository;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+    }
+}


### PR DESCRIPTION
### Fixed
- Fixed updating non existing organizers throwing 404 and not 403

---

Uses the same middleware approach as how it was fixed for offers and places

Ticket: https://jira.publiq.be/browse/III-5324
