### PR TITLE
III-6366 Set up ownership mailings

### DIFF
--- a/app/Migrations/Version20250212071939.php
+++ b/app/Migrations/Version20250212071939.php
@@ -15,7 +15,7 @@ class Version20250212071939 extends AbstractMigration
         $table = $schema->createTable('mails_sent');
 
         $table->addColumn('identifier', Types::GUID)->setLength(36)->setNotnull(true);
-        $table->addColumn('email', Types::STRING)->setLength(100)->setNotnull(true);
+        $table->addColumn('email', Types::STRING)->setLength(320)->setNotnull(true);
         $table->addColumn('type', Types::STRING)->setLength(100)->setNotnull(true);
         $table->addColumn('dateTime', Types::DATETIME_IMMUTABLE)->setNotnull(true);
 

--- a/app/Migrations/Version20250212071939.php
+++ b/app/Migrations/Version20250212071939.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20250212071939 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable('mails_sent');
+
+        $table->addColumn('identifier', Types::GUID)->setLength(36)->setNotnull(true);
+        $table->addColumn('email', Types::STRING)->setLength(100)->setNotnull(true);
+        $table->addColumn('type', Types::STRING)->setLength(100)->setNotnull(true);
+        $table->addColumn('dateTime', Types::DATETIME_IMMUTABLE)->setNotnull(true);
+
+        $table->setPrimaryKey(['identifier', 'type']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('mails_sent');
+    }
+}

--- a/src/Mailer/DBALMailsSentRepository.php
+++ b/src/Mailer/DBALMailsSentRepository.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use DateTimeInterface;
 use Doctrine\DBAL\Connection;
 
-class DBALMailsSentRepository implements MailsSentRepository
+final class DBALMailsSentRepository implements MailsSentRepository
 {
     private Connection $connection;
 

--- a/src/Mailer/DBALMailsSentRepository.php
+++ b/src/Mailer/DBALMailsSentRepository.php
@@ -33,18 +33,11 @@ final class DBALMailsSentRepository implements MailsSentRepository
 
     public function addMailSent(Uuid $identifier, EmailAddress $email, string $type, DateTimeInterface $dateTime): void
     {
-        $this->connection->createQueryBuilder()
-            ->insert('mails_sent')
-            ->setValue('identifier', ':identifier')
-            ->setValue('email', ':email')
-            ->setValue('type', ':type')
-            ->setValue('dateTime', ':dateTime')
-            ->setParameters([
-                ':identifier' => $identifier->toString(),
-                ':email' => $email->toString(),
-                ':type' => $type,
-                ':dateTime' => $dateTime->format(DateTimeInterface::ATOM),
-            ])
-            ->execute();
+        $this->connection->insert('mails_sent', [
+            'identifier' => $identifier->toString(),
+            'type' => $type,
+            'email' => $email->toString(),
+            'dateTime' => $dateTime->format(DateTimeInterface::ATOM),
+        ]);
     }
 }

--- a/src/Mailer/MailsSentRepository.php
+++ b/src/Mailer/MailsSentRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailer;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+
+interface MailsSentRepository
+{
+    public function isMailSent(Uuid $identifier, string $type): bool;
+
+    public function addMailSent(Uuid $identifier, EmailAddress $email, string $type, \DateTimeInterface $dateTime): void;
+}

--- a/tests/Mailer/DBALMailsSentRepositoryTest.php
+++ b/tests/Mailer/DBALMailsSentRepositoryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailer;
+
+use CultuurNet\UDB3\DBALTestConnectionTrait;
+use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Ownership\Events\OwnershipApproved;
+use CultuurNet\UDB3\Ownership\Events\OwnershipRejected;
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+
+class DBALMailsSentRepositoryTest extends TestCase
+{
+    use DBALTestConnectionTrait;
+
+    private const DATE_TIME_VALUE = '2025-01-01T12:30:00+00:00';
+
+    private DBALMailsSentRepository $repository;
+
+    public function setUp(): void
+    {
+        $this->setUpDatabase();
+        $this->repository = new DBALMailsSentRepository($this->connection);
+    }
+
+    /** @test */
+    public function handles_add_mail_sent(): void
+    {
+        $identifier = Uuid::uuid4();
+        $email = new EmailAddress('koen@publiq.be');
+        $type = OwnershipApproved::class;
+        $date = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, self::DATE_TIME_VALUE);
+
+        $this->repository->addMailSent($identifier, $email, $type, $date);
+
+        $result = $this->connection->fetchAssociative(
+            'SELECT * FROM mails_sent'
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals($identifier->toString(), $result['identifier']);
+        $this->assertEquals($email->toString(), $result['email']);
+        $this->assertEquals($type, $result['type']);
+        $this->assertEquals($date->format('Y-m-d H:i:s'), $result['dateTime']);
+    }
+
+    /**
+     * @dataProvider mailSentDataProvider
+     * @test
+     */
+    public function handles_is_mail_sent(Uuid $identifier, string $type, Uuid $identifierMatched, string $typeMatched, bool $isSent): void
+    {
+        $email = new EmailAddress('koen@publiq.be');
+        $date = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, self::DATE_TIME_VALUE);
+
+        $this->connection->insert('mails_sent', [
+            'identifier' => $identifier->toString(),
+            'email' => $email->toString(),
+            'type' => $type,
+            'dateTime' => $date->format(DateTimeInterface::ATOM),
+        ]);
+
+        $this->assertEquals($isSent, $this->repository->isMailSent($identifierMatched, $typeMatched));
+    }
+
+    public function mailSentDataProvider(): array
+    {
+        $uuid = Uuid::uuid4();
+        $uuid2 = Uuid::uuid4();
+
+        return [
+            [$uuid, OwnershipApproved::class, $uuid, OwnershipApproved::class, true],
+            [$uuid2, OwnershipApproved::class, $uuid2, OwnershipRejected::class, false],
+            [Uuid::uuid4(), OwnershipApproved::class, Uuid::uuid4(), OwnershipApproved::class, false],
+        ];
+    }
+}

--- a/tests/Mailer/DBALMailsSentRepositoryTest.php
+++ b/tests/Mailer/DBALMailsSentRepositoryTest.php
@@ -73,9 +73,9 @@ class DBALMailsSentRepositoryTest extends TestCase
         $uuid2 = Uuid::uuid4();
 
         return [
-            [$uuid, OwnershipApproved::class, $uuid, OwnershipApproved::class, true],
-            [$uuid2, OwnershipApproved::class, $uuid2, OwnershipRejected::class, false],
-            [Uuid::uuid4(), OwnershipApproved::class, Uuid::uuid4(), OwnershipApproved::class, false],
+            'Mail is already sent' => [$uuid, OwnershipApproved::class, $uuid, OwnershipApproved::class, true],
+            'Mail is not sent yet, different type of email was sent' => [$uuid2, OwnershipApproved::class, $uuid2, OwnershipRejected::class, false],
+            'Mail is not sent yet, different identifier was used' => [Uuid::uuid4(), OwnershipApproved::class, Uuid::uuid4(), OwnershipApproved::class, false],
         ];
     }
 }


### PR DESCRIPTION
To prepare to sending ownership mails, we want to remember if a mail has been sent already or not.
For this I added an extra database table.

## Notes:
- I tried to make it generic named (hence identifier instead of organiserId) for reuse for other mails later
- I also note down the email / date of the mail, while not technically required this will make it very practical if we ever need to lookup if a specific mail was sent.

### Added
- Mail sent migration + repo + test

---

Ticket: https://jira.uitdatabank.be/browse/III-6366 
