### PR TITLE
III-6511 add symfony cache

### DIFF
--- a/app/Cache/CacheServiceProvider.php
+++ b/app/Cache/CacheServiceProvider.php
@@ -43,7 +43,7 @@ final class CacheServiceProvider extends AbstractServiceProvider
                 new Client(
                     $container->get('config')['cache']['redis']
                 ),
-                'permission' . '_',
+                'users' . '_',
                 86400,
             ),
         );

--- a/app/Cache/CacheServiceProvider.php
+++ b/app/Cache/CacheServiceProvider.php
@@ -8,6 +8,8 @@ use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use Doctrine\Common\Cache\PredisCache;
 use League\Container\Argument\Literal\CallableArgument;
 use Predis\Client;
+use RectorPrefix202209\Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 final class CacheServiceProvider extends AbstractServiceProvider
 {
@@ -15,6 +17,7 @@ final class CacheServiceProvider extends AbstractServiceProvider
     {
         return [
             'cache',
+            CacheInterface::class,
         ];
     }
 
@@ -32,6 +35,17 @@ final class CacheServiceProvider extends AbstractServiceProvider
                     )
                 )
             )
+        );
+
+        $container->addShared(
+            CacheInterface::class,
+            new RedisAdapter(
+                new Client(
+                    $container->get('config')['cache']['redis']
+                ),
+                'permission' . '_',
+                86400,
+            ),
         );
     }
 }

--- a/app/Cache/CacheServiceProvider.php
+++ b/app/Cache/CacheServiceProvider.php
@@ -8,8 +8,6 @@ use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use Doctrine\Common\Cache\PredisCache;
 use League\Container\Argument\Literal\CallableArgument;
 use Predis\Client;
-use Symfony\Component\Cache\Adapter\RedisAdapter;
-use Symfony\Contracts\Cache\CacheInterface;
 
 final class CacheServiceProvider extends AbstractServiceProvider
 {
@@ -17,7 +15,7 @@ final class CacheServiceProvider extends AbstractServiceProvider
     {
         return [
             'cache',
-            CacheInterface::class,
+            Client::class,
         ];
     }
 
@@ -38,14 +36,10 @@ final class CacheServiceProvider extends AbstractServiceProvider
         );
 
         $container->addShared(
-            CacheInterface::class,
-            new RedisAdapter(
-                new Client(
-                    $container->get('config')['cache']['redis']
-                ),
-                'users' . '_',
-                86400,
-            ),
+            Client::class,
+            new Client(
+                $container->get('config')['cache']['redis']
+            )
         );
     }
 }

--- a/app/Cache/CacheServiceProvider.php
+++ b/app/Cache/CacheServiceProvider.php
@@ -8,8 +8,8 @@ use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use Doctrine\Common\Cache\PredisCache;
 use League\Container\Argument\Literal\CallableArgument;
 use Predis\Client;
-use RectorPrefix202209\Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Contracts\Cache\CacheInterface;
 
 final class CacheServiceProvider extends AbstractServiceProvider
 {

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -67,7 +67,7 @@ use CultuurNet\UDB3\Search\EventsSapi3SearchService;
 use CultuurNet\UDB3\Search\OffersSapi3SearchService;
 use CultuurNet\UDB3\Search\OrganizersSapi3SearchService;
 use CultuurNet\UDB3\Search\PlacesSapi3SearchService;
-use CultuurNet\UDB3\User\Keycloak\KeycloakUserIdentityResolver;
+use CultuurNet\UDB3\User\Keycloak\CachedUserIdentityResolver;
 use Google_Client;
 use Google_Service_YouTube;
 use Http\Adapter\Guzzle7\Client;
@@ -409,7 +409,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         $container->addShared(
             'console.keycloak:find-user',
             fn () => new KeycloakCommand(
-                $container->get(KeycloakUserIdentityResolver::class)
+                $container->get(CachedUserIdentityResolver::class)
             )
         );
 

--- a/app/Keycloak/KeycloakServiceProvider.php
+++ b/app/Keycloak/KeycloakServiceProvider.php
@@ -16,7 +16,6 @@ final class KeycloakServiceProvider extends AbstractServiceProvider
     protected function getProvidedServiceNames(): array
     {
         return [
-            KeycloakUserIdentityResolver::class,
             CachedUserIdentityResolver::class,
         ];
     }
@@ -26,22 +25,15 @@ final class KeycloakServiceProvider extends AbstractServiceProvider
         $container = $this->getContainer();
 
         $container->add(
-            KeycloakUserIdentityResolver::class,
-            function () use ($container): KeycloakUserIdentityResolver {
-                return new KeycloakUserIdentityResolver(
-                    new Client(),
-                    $container->get('config')['keycloak']['domain'],
-                    $container->get('config')['keycloak']['realm'],
-                    $container->get(ManagementTokenProvider::class)->token()
-                );
-            }
-        );
-
-        $container->add(
             CachedUserIdentityResolver::class,
             function () use ($container): CachedUserIdentityResolver {
                 return new CachedUserIdentityResolver(
-                    $container->get(KeycloakUserIdentityResolver::class),
+                    new KeycloakUserIdentityResolver(
+                        new Client(),
+                        $container->get('config')['keycloak']['domain'],
+                        $container->get('config')['keycloak']['realm'],
+                        $container->get(ManagementTokenProvider::class)->token()
+                    ),
                     CacheFactory::create(
                         $container,
                         'user_identity',

--- a/app/Keycloak/KeycloakServiceProvider.php
+++ b/app/Keycloak/KeycloakServiceProvider.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\User\Keycloak\CachedUserIdentityResolver;
 use CultuurNet\UDB3\User\Keycloak\KeycloakUserIdentityResolver;
 use CultuurNet\UDB3\User\ManagementToken\ManagementTokenProvider;
 use GuzzleHttp\Client;
+use Predis\Client as RedisClient;
 
 final class KeycloakServiceProvider extends AbstractServiceProvider
 {
@@ -35,7 +36,7 @@ final class KeycloakServiceProvider extends AbstractServiceProvider
                         $container->get(ManagementTokenProvider::class)->token()
                     ),
                     CacheFactory::create(
-                        $container,
+                        $container->get(RedisClient::class),
                         'user_identity',
                         86400
                     )

--- a/app/User/UserServiceProvider.php
+++ b/app/User/UserServiceProvider.php
@@ -13,8 +13,8 @@ use CultuurNet\UDB3\Http\User\GetUserByEmailRequestHandler;
 use CultuurNet\UDB3\Security\InMemoryUserEmailAddressRepository;
 use CultuurNet\UDB3\Security\UserEmailAddressRepository;
 use CultuurNet\UDB3\UiTID\CdbXmlCreatedByToUserIdResolver;
+use CultuurNet\UDB3\User\Keycloak\CachedUserIdentityResolver;
 use CultuurNet\UDB3\User\Keycloak\KeycloakManagementTokenGenerator;
-use CultuurNet\UDB3\User\Keycloak\KeycloakUserIdentityResolver;
 use CultuurNet\UDB3\User\ManagementToken\CacheRepository;
 use CultuurNet\UDB3\User\ManagementToken\ManagementTokenProvider;
 use GuzzleHttp\Client;
@@ -97,6 +97,6 @@ final class UserServiceProvider extends AbstractServiceProvider
 
     private function getUserIdentityResolver(DefinitionContainerInterface $container): UserIdentityResolver
     {
-        return $container->get(KeycloakUserIdentityResolver::class);
+        return $container->get(CachedUserIdentityResolver::class);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
     "slim/psr7": "^1.4",
     "sweetrdf/easyrdf": "1.8.0",
     "swiftmailer/swiftmailer": "~5.3",
+    "symfony/cache": "^5.4",
     "symfony/console": "^5.4",
     "symfony/process": "4.4.30",
     "symfony/serializer": "^v3.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04b6df844fae64fc6f7acdc0463ce42c",
+    "content-hash": "2b1fa4f1ad3459b6710872688a4d60a3",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6289,6 +6289,182 @@
             "time": "2018-07-31T09:26:32+00:00"
         },
         {
+            "name": "symfony/cache",
+            "version": "v5.4.46",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "0fe08ee32cec2748fbfea10c52d3ee02049e0f6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/0fe08ee32cec2748fbfea10c52d3ee02049e0f6b",
+                "reference": "0fe08ee32cec2748fbfea10c52d3ee02049e0f6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/cache": "^1.0|^2.0",
+                "psr/log": "^1.1|^2|^3",
+                "symfony/cache-contracts": "^1.1.7|^2",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/var-exporter": "^4.4|^5.0|^6.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.13.1",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/http-kernel": "<4.4",
+                "symfony/var-dumper": "<4.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0|2.0",
+                "psr/simple-cache-implementation": "1.0|2.0",
+                "symfony/cache-implementation": "1.0|2.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/cache": "^1.6|^2.0",
+                "doctrine/dbal": "^2.13.1|^3|^4",
+                "predis/predis": "^1.1|^2.0",
+                "psr/simple-cache": "^1.0|^2.0",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/filesystem": "^4.4|^5.0|^6.0",
+                "symfony/http-kernel": "^4.4|^5.0|^6.0",
+                "symfony/messenger": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v5.4.46"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-04T11:43:55+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "517c3a3619dadfa6952c4651767fcadffb4df65e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/517c3a3619dadfa6952c4651767fcadffb4df65e",
+                "reference": "517c3a3619dadfa6952c4651767fcadffb4df65e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/cache": "^1.0|^2.0|^3.0"
+            },
+            "suggest": {
+                "symfony/cache-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v2.5.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v5.4.42",
             "source": {
@@ -7684,6 +7860,79 @@
                 }
             ],
             "time": "2024-01-23T13:51:25+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v5.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "862700068db0ddfd8c5b850671e029a90246ec75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/862700068db0ddfd8c5b850671e029a90246ec75",
+                "reference": "862700068db0ddfd8c5b850671e029a90246ec75",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "require-dev": {
+                "symfony/var-dumper": "^4.4.9|^5.0.9|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v5.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "twig/extensions",

--- a/src/Cache/CacheFactory.php
+++ b/src/Cache/CacheFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace CultuurNet\UDB3\Cache;
+
+use Predis\Client;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class CacheFactory
+{
+    public static function create(
+        ContainerInterface $container,
+        string $namespace,
+        int $defaultLifeTime
+    ): CacheInterface {
+        return new RedisAdapter($container->get(Client::class), $namespace, $defaultLifeTime);
+    }
+}

--- a/src/Cache/CacheFactory.php
+++ b/src/Cache/CacheFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CultuurNet\UDB3\Cache;
 
 use Predis\Client;

--- a/src/Cache/CacheFactory.php
+++ b/src/Cache/CacheFactory.php
@@ -5,17 +5,16 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Cache;
 
 use Predis\Client;
-use Psr\Container\ContainerInterface;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Contracts\Cache\CacheInterface;
 
 final class CacheFactory
 {
     public static function create(
-        ContainerInterface $container,
+        Client $client,
         string $namespace,
         int $defaultLifeTime
     ): CacheInterface {
-        return new RedisAdapter($container->get(Client::class), $namespace, $defaultLifeTime);
+        return new RedisAdapter($client, $namespace, $defaultLifeTime);
     }
 }

--- a/src/User/Keycloak/CachedUserIdentityResolver.php
+++ b/src/User/Keycloak/CachedUserIdentityResolver.php
@@ -20,7 +20,7 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
         CacheInterface $cache
     ) {
         $this->userIdentityResolver = $userIdentityResolver;
-        $this->cache =$cache;
+        $this->cache = $cache;
     }
 
     public function getUserById(string $userId): ?UserIdentityDetails
@@ -29,7 +29,7 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
             $this->cache->get(
                 $this->createCacheKey($userId, 'user_id'),
                 function () use ($userId) {
-                    return $this->userIdentityResolver->getUserById($userId)->jsonSerialize();
+                    return $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserById($userId));
                 }
             )
         );
@@ -41,7 +41,7 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
             $this->cache->get(
                 $this->createCacheKey($email->toString(), 'email'),
                 function () use ($email) {
-                    return $this->userIdentityResolver->getUserByEmail($email)->jsonSerialize();
+                    return $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserByEmail($email));
                 }
             )
         );
@@ -53,7 +53,7 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
             $this->cache->get(
                 $this->createCacheKey($nick, 'nick'),
                 function () use ($nick) {
-                    return $this->userIdentityResolver->getUserByNick($nick)->jsonSerialize();
+                    return $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserByNick($nick));
                 }
             )
         );
@@ -62,6 +62,14 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
     private function createCacheKey(string $value, string $property): string
     {
         return preg_replace('/[{}()\/\\\\@:]/', '_', $value . '_' . $property);
+    }
+
+    private function getUserIdentityDetailsAsArray(?UserIdentityDetails $userIdentityDetails): ?array
+    {
+        if ($userIdentityDetails !== null) {
+            return $userIdentityDetails->jsonSerialize();
+        }
+        return null;
     }
 
     private function deserializeUserIdentityDetails(?array $cachedUserIdentityDetails): ?UserIdentityDetails

--- a/src/User/Keycloak/CachedUserIdentityResolver.php
+++ b/src/User/Keycloak/CachedUserIdentityResolver.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\User\Keycloak;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\User\UserIdentityDetails;
+use CultuurNet\UDB3\User\UserIdentityResolver;
+use Symfony\Contracts\Cache\CacheInterface;
+use function Clue\StreamFilter\fun;
+
+final class CachedUserIdentityResolver implements UserIdentityResolver
+{
+    private UserIdentityResolver $userIdentityResolver;
+
+    private CacheInterface $cache;
+
+    public function __construct(
+        UserIdentityResolver $userIdentityResolver,
+        CacheInterface $cache
+    ) {
+        $this->userIdentityResolver = $userIdentityResolver;
+        $this->cache =$cache;
+    }
+    public function getUserById(string $userId): ?UserIdentityDetails
+    {
+        return $this->cache->get(
+            $this->createCacheKey($userId, 'user_id'),
+            function () use ($userId) {
+                return $this->userIdentityResolver->getUserById($userId);
+            }
+        );
+    }
+
+    public function getUserByEmail(EmailAddress $email): ?UserIdentityDetails
+    {
+        return $this->cache->get(
+            $this->createCacheKey($email->toString(), 'email'),
+            function () use ($email) {
+                return $this->userIdentityResolver->getUserByEmail($email);
+            }
+        );
+    }
+
+    public function getUserByNick(string $nick): ?UserIdentityDetails
+    {
+        return $this->cache->get(
+            $this->createCacheKey($nick, 'nick'),
+            function () use ($nick) {
+                return $this->userIdentityResolver->getUserByNick($nick);
+            }
+        );
+    }
+
+    private function createCacheKey(string $value, string $property): string
+    {
+        return 'user_identity_' .  $value . '_' . $property;
+    }
+}

--- a/src/User/Keycloak/CachedUserIdentityResolver.php
+++ b/src/User/Keycloak/CachedUserIdentityResolver.php
@@ -22,38 +22,54 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
         $this->userIdentityResolver = $userIdentityResolver;
         $this->cache =$cache;
     }
+
     public function getUserById(string $userId): ?UserIdentityDetails
     {
-        return $this->cache->get(
-            $this->createCacheKey($userId, 'user_id'),
-            function () use ($userId) {
-                return $this->userIdentityResolver->getUserById($userId);
-            }
+        return $this->deserializeUserIdentityDetails(
+            $this->cache->get(
+                $this->createCacheKey($userId, 'user_id'),
+                function () use ($userId) {
+                    return $this->userIdentityResolver->getUserById($userId)->jsonSerialize();
+                }
+            )
         );
     }
 
     public function getUserByEmail(EmailAddress $email): ?UserIdentityDetails
     {
-        return $this->cache->get(
-            $this->createCacheKey($email->toString(), 'email'),
-            function () use ($email) {
-                return $this->userIdentityResolver->getUserByEmail($email);
-            }
+        return $this->deserializeUserIdentityDetails(
+            $this->cache->get(
+                $this->createCacheKey($email->toString(), 'email'),
+                function () use ($email) {
+                    return $this->userIdentityResolver->getUserByEmail($email)->jsonSerialize();
+                }
+            )
         );
     }
 
     public function getUserByNick(string $nick): ?UserIdentityDetails
     {
-        return $this->cache->get(
-            $this->createCacheKey($nick, 'nick'),
-            function () use ($nick) {
-                return $this->userIdentityResolver->getUserByNick($nick);
-            }
+        return $this->deserializeUserIdentityDetails(
+            $this->cache->get(
+                $this->createCacheKey($nick, 'nick'),
+                function () use ($nick) {
+                    return $this->userIdentityResolver->getUserByNick($nick)->jsonSerialize();
+                }
+            )
         );
     }
 
     private function createCacheKey(string $value, string $property): string
     {
         return preg_replace('/[{}()\/\\\\@:]/', '_', 'user_identity_' . $value . '_' . $property);
+    }
+
+    private function deserializeUserIdentityDetails(?array $cachedUserIdentityDetails): ?UserIdentityDetails
+    {
+        return $cachedUserIdentityDetails !== null ? new UserIdentityDetails(
+            $cachedUserIdentityDetails['uuid'],
+            $cachedUserIdentityDetails['username'],
+            $cachedUserIdentityDetails['email']
+        ) : null;
     }
 }

--- a/src/User/Keycloak/CachedUserIdentityResolver.php
+++ b/src/User/Keycloak/CachedUserIdentityResolver.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\User\UserIdentityDetails;
 use CultuurNet\UDB3\User\UserIdentityResolver;
 use Symfony\Contracts\Cache\CacheInterface;
-use function Clue\StreamFilter\fun;
 
 final class CachedUserIdentityResolver implements UserIdentityResolver
 {
@@ -55,6 +54,6 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
 
     private function createCacheKey(string $value, string $property): string
     {
-        return 'user_identity_' .  $value . '_' . $property;
+        return preg_replace('/[{}()\/\\\\@:]/', '_', 'user_identity_' . $value . '_' . $property);
     }
 }

--- a/src/User/Keycloak/CachedUserIdentityResolver.php
+++ b/src/User/Keycloak/CachedUserIdentityResolver.php
@@ -61,7 +61,7 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
 
     private function createCacheKey(string $value, string $property): string
     {
-        return preg_replace('/[{}()\/\\\\@:]/', '_', 'user_identity_' . $value . '_' . $property);
+        return preg_replace('/[{}()\/\\\\@:]/', '_', $value . '_' . $property);
     }
 
     private function deserializeUserIdentityDetails(?array $cachedUserIdentityDetails): ?UserIdentityDetails

--- a/tests/User/Keycloak/CachedUserIdentityResolverTest.php
+++ b/tests/User/Keycloak/CachedUserIdentityResolverTest.php
@@ -47,21 +47,21 @@ final class CachedUserIdentityResolverTest extends TestCase
         );
 
         $cache->get(
-            'user_identity_d515f818-fe13-497d-abfa-c99be9a8ffae_user_id',
+            'd515f818-fe13-497d-abfa-c99be9a8ffae_user_id',
             function () {
                 return $this->cachedUserIdentityDetails->jsonSerialize();
             }
         );
 
         $cache->get(
-            'user_identity_jane_anonymous.com_email',
+            'jane_anonymous.com_email',
             function () {
                 return $this->cachedUserIdentityDetails->jsonSerialize();
             }
         );
 
         $cache->get(
-            'user_identity_Jane Doe_nick',
+            'Jane Doe_nick',
             function () {
                 return $this->cachedUserIdentityDetails->jsonSerialize();
             }

--- a/tests/User/Keycloak/CachedUserIdentityResolverTest.php
+++ b/tests/User/Keycloak/CachedUserIdentityResolverTest.php
@@ -49,21 +49,21 @@ final class CachedUserIdentityResolverTest extends TestCase
         $cache->get(
             'user_identity_d515f818-fe13-497d-abfa-c99be9a8ffae_user_id',
             function () {
-                return $this->cachedUserIdentityDetails;
+                return $this->cachedUserIdentityDetails->jsonSerialize();
             }
         );
 
         $cache->get(
             'user_identity_jane_anonymous.com_email',
             function () {
-                return $this->cachedUserIdentityDetails;
+                return $this->cachedUserIdentityDetails->jsonSerialize();
             }
         );
 
         $cache->get(
             'user_identity_Jane Doe_nick',
             function () {
-                return $this->cachedUserIdentityDetails;
+                return $this->cachedUserIdentityDetails->jsonSerialize();
             }
         );
     }

--- a/tests/User/Keycloak/CachedUserIdentityResolverTest.php
+++ b/tests/User/Keycloak/CachedUserIdentityResolverTest.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\User\UserIdentityResolver;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Contracts\Cache\CacheInterface;
 
 final class CachedUserIdentityResolverTest extends TestCase
 {

--- a/tests/User/Keycloak/CachedUserIdentityResolverTest.php
+++ b/tests/User/Keycloak/CachedUserIdentityResolverTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Contracts\Cache\CacheInterface;
-use function Clue\StreamFilter\fun;
 
 final class CachedUserIdentityResolverTest extends TestCase
 {
@@ -19,8 +18,6 @@ final class CachedUserIdentityResolverTest extends TestCase
      * @var UserIdentityResolver&MockObject
      */
     private $fallbackUserIdentityResolver;
-
-    private CacheInterface $cache;
 
     private CachedUserIdentityResolver $cachedUserIdentityResolver;
 
@@ -31,11 +28,11 @@ final class CachedUserIdentityResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->fallbackUserIdentityResolver = $this->createMock(UserIdentityResolver::class);
-        $this->cache =  new ArrayAdapter();
+        $cache =  new ArrayAdapter();
 
         $this->cachedUserIdentityResolver = new CachedUserIdentityResolver(
             $this->fallbackUserIdentityResolver,
-            $this->cache
+            $cache
         );
 
         $this->uncachedUserIdentityDetails = new UserIdentityDetails(
@@ -50,21 +47,21 @@ final class CachedUserIdentityResolverTest extends TestCase
             'jane@anonymous.com'
         );
 
-        $this->cache->get(
+        $cache->get(
             'user_identity_d515f818-fe13-497d-abfa-c99be9a8ffae_user_id',
             function () {
                 return $this->cachedUserIdentityDetails;
             }
         );
 
-        $this->cache->get(
+        $cache->get(
             'user_identity_jane_anonymous.com_email',
             function () {
                 return $this->cachedUserIdentityDetails;
             }
         );
 
-        $this->cache->get(
+        $cache->get(
             'user_identity_Jane Doe_nick',
             function () {
                 return $this->cachedUserIdentityDetails;


### PR DESCRIPTION
### Added

- `CacheFactory`: Factory for Caches
- `CachedUserIdentityResolver`: Added `UserIdentityResolver` with caching
- `CachedUserIdentityResolverTest`: Unit tests

### Changed

- `composer.json`: Added `symfony/cache`
- `CacheServiceProvider`: Added new CacheInterface next legacy `Predis\Cache`
- `UserServiceProvider` & `ConsoleServiceProvider`: Use `CachedUserIdentityResolver` instead of `KeycloakUserIdentityResolver`
- `KeycloakServiceProvider`: Add `CachedServiceProvider`

---

Ticket: https://jira.publiq.be/browse/III-6511
