### PR TITLE
III-6366 Mailer smtp class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
     "sweetrdf/easyrdf": "1.8.0",
     "swiftmailer/swiftmailer": "~5.3",
     "symfony/console": "^5.4",
+    "symfony/mailer": "^5.4",
     "symfony/process": "4.4.30",
     "symfony/serializer": "^v3.1.10",
     "twig/extensions": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04b6df844fae64fc6f7acdc0463ce42c",
+    "content-hash": "65ac4521529159f927ca7ff58678056b",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1275,6 +1275,84 @@
             "time": "2020-05-29T18:28:51+00:00"
         },
         {
+            "name": "doctrine/lexer",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6",
+                "reference": "861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12",
+                "phpstan/phpstan": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^4.11 || ^5.21"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-05T11:35:39+00:00"
+        },
+        {
             "name": "doctrine/migrations",
             "version": "2.3.5",
             "source": {
@@ -1369,6 +1447,73 @@
                 }
             ],
             "time": "2021-10-19T19:55:20+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "3.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7",
+                "reference": "e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^1.2|^2",
+                "php": ">=7.2",
+                "symfony/polyfill-intl-idn": "^1.15"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.8|^9.3.3",
+                "vimeo/psalm": "^4"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/egulias/EmailValidator/issues",
+                "source": "https://github.com/egulias/EmailValidator/tree/3.2.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/egulias",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-06-01T07:04:22+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -5403,6 +5548,56 @@
             "time": "2021-11-05T16:50:12+00:00"
         },
         {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
             "name": "psr/http-client",
             "version": "1.0.1",
             "source": {
@@ -6455,6 +6650,170 @@
             "time": "2023-01-24T14:02:46+00:00"
         },
         {
+            "name": "symfony/event-dispatcher",
+            "version": "v5.4.40",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "a54e2a8a114065f31020d6a89ede83e34c3b27a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a54e2a8a114065f31020d6a89ede83e34c3b27a4",
+                "reference": "a54e2a8a114065f31020d6a89ede83e34c3b27a4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/event-dispatcher-contracts": "^2|^3",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/expression-language": "^4.4|^5.0|^6.0",
+                "symfony/http-foundation": "^4.4|^5.0|^6.0",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/stopwatch": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.40"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T14:33:22+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v2.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "540f4c73e87fd0c71ca44a6aa305d024ac68cb73"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/540f4c73e87fd0c71ca44a6aa305d024ac68cb73",
+                "reference": "540f4c73e87fd0c71ca44a6aa305d024ac68cb73",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/event-dispatcher": "^1"
+            },
+            "suggest": {
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.5.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-23T13:51:25+00:00"
+        },
+        {
             "name": "symfony/filesystem",
             "version": "v4.4.42",
             "source": {
@@ -6516,6 +6875,165 @@
                 }
             ],
             "time": "2022-05-20T08:49:14+00:00"
+        },
+        {
+            "name": "symfony/mailer",
+            "version": "v5.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "f732e1fafdf0f4a2d865e91f1018aaca174aeed9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/f732e1fafdf0f4a2d865e91f1018aaca174aeed9",
+                "reference": "f732e1fafdf0f4a2d865e91f1018aaca174aeed9",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "php": ">=7.2.5",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/mime": "^5.2.6|^6.0",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2|^3"
+            },
+            "conflict": {
+                "symfony/http-kernel": "<4.4"
+            },
+            "require-dev": {
+                "symfony/http-client": "^4.4|^5.0|^6.0",
+                "symfony/messenger": "^4.4|^5.0|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v5.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v5.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "bb2ccf759e2b967dcd11bdee5bdf30dddd2290bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/bb2ccf759e2b967dcd11bdee5bdf30dddd2290bd",
+                "reference": "bb2ccf759e2b967dcd11bdee5bdf30dddd2290bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/mailer": "<4.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/property-access": "^4.4|^5.1|^6.0",
+                "symfony/property-info": "^4.4|^5.1|^6.0",
+                "symfony/serializer": "^5.2|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v5.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-09-01T18:18:29+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -6742,6 +7260,89 @@
                 }
             ],
             "time": "2024-05-31T15:07:36+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "c36586dcf89a12315939e00ec9b4474adcb1d773"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/c36586dcf89a12315939e00ec9b4474adcb1d773",
+                "reference": "c36586dcf89a12315939e00ec9b4474adcb1d773",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
@@ -8686,84 +9287,6 @@
             "time": "2022-03-03T08:28:38+00:00"
         },
         {
-            "name": "doctrine/lexer",
-            "version": "2.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/lexer.git",
-                "reference": "861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6",
-                "reference": "861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12",
-                "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
-                "psalm/plugin-phpunit": "^0.18.3",
-                "vimeo/psalm": "^4.11 || ^5.21"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Lexer\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
-            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "lexer",
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/2.1.1"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-02-05T11:35:39+00:00"
-        },
-        {
             "name": "friendsofphp/php-cs-fixer",
             "version": "v3.4.0",
             "source": {
@@ -9832,56 +10355,6 @@
                 }
             ],
             "time": "2023-08-19T07:10:56+00:00"
-        },
-        {
-            "name": "psr/event-dispatcher",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/event-dispatcher.git",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\EventDispatcher\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Standard interfaces for event handling.",
-            "keywords": [
-                "events",
-                "psr",
-                "psr-14"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/event-dispatcher/issues",
-                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
-            },
-            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "publiq/php-cs-fixer-config",
@@ -11113,170 +11586,6 @@
                 }
             ],
             "time": "2023-05-05T14:42:55+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v5.4.40",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "a54e2a8a114065f31020d6a89ede83e34c3b27a4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a54e2a8a114065f31020d6a89ede83e34c3b27a4",
-                "reference": "a54e2a8a114065f31020d6a89ede83e34c3b27a4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/event-dispatcher-contracts": "^2|^3",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<4.4"
-            },
-            "provide": {
-                "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "2.0"
-            },
-            "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/http-foundation": "^4.4|^5.0|^6.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/stopwatch": "^4.4|^5.0|^6.0"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.40"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-05-31T14:33:22+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.5.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "540f4c73e87fd0c71ca44a6aa305d024ac68cb73"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/540f4c73e87fd0c71ca44a6aa305d024ac68cb73",
-                "reference": "540f4c73e87fd0c71ca44a6aa305d024ac68cb73",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "psr/event-dispatcher": "^1"
-            },
-            "suggest": {
-                "symfony/event-dispatcher-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\EventDispatcher\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to dispatching event",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.5.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-01-23T13:51:25+00:00"
         },
         {
             "name": "symfony/finder",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b1fa4f1ad3459b6710872688a4d60a3",
+    "content-hash": "81db03c4e7157cb73aeb1b9cb959c7c4",
     "packages": [
         {
             "name": "aws/aws-crt-php",

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -8,5 +8,5 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 
 interface Mailer
 {
-    public function send(EmailAddress $to, string $subject, string $htmlTemplate, string $textTemplate, array $variables = []): bool;
+    public function send(EmailAddress $to, string $subject, string $html, string $text): bool;
 }

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailer;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+
+interface Mailer
+{
+    public function send(EmailAddress $to, string $subject, string $htmlTemplate, string $textTemplate, array $variables = []): bool;
+}

--- a/src/Mailer/SmtpMailer.php
+++ b/src/Mailer/SmtpMailer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailer;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Twig\Environment as TwigEnvironment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+
+final class SmtpMailer implements Mailer
+{
+    private TwigEnvironment $twig;
+    private MailerInterface $mailer;
+    private LoggerInterface $logger;
+    private Address $from;
+
+    public function __construct(TwigEnvironment $twig, MailerInterface $mailer, LoggerInterface $logger, Address $from)
+    {
+        $this->twig = $twig;
+        $this->mailer = $mailer;
+        $this->logger = $logger;
+        $this->from = $from;
+    }
+
+    public function send(EmailAddress $to, string $subject, string $htmlTemplate, string $textTemplate, array $variables = []): bool
+    {
+        try {
+            $html = $this->twig->render($htmlTemplate, $variables);
+            $text = $this->twig->render($textTemplate, $variables);
+        } catch (LoaderError|SyntaxError|RuntimeError $e) {
+            $this->logger->error('[TwigTemplate] ' . $e->getMessage());
+            return false;
+        }
+
+        $email = (new Email())
+            ->from($this->from)
+            ->to($to->toString())
+            ->subject($subject)
+            ->text($text)
+            ->html($html);
+
+        try {
+            $this->mailer->send($email);
+            return true;
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->critical('[TransportException] ' . $e->getMessage());
+            return false;
+        }
+    }
+}

--- a/src/Mailer/SmtpMailer.php
+++ b/src/Mailer/SmtpMailer.php
@@ -10,39 +10,22 @@ use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
-use Twig\Environment as TwigEnvironment;
-use Twig\Error\LoaderError;
-use Twig\Error\RuntimeError;
-use Twig\Error\SyntaxError;
 
 final class SmtpMailer implements Mailer
 {
-    private TwigEnvironment $twig;
     private MailerInterface $mailer;
     private LoggerInterface $logger;
     private Address $from;
-    /** @var string[] */
-    private array $whiteListedDomains;
 
-    public function __construct(TwigEnvironment $twig, MailerInterface $mailer, LoggerInterface $logger, Address $from, array $whiteListedDomains)
+    public function __construct(MailerInterface $mailer, LoggerInterface $logger, Address $from)
     {
-        $this->twig = $twig;
         $this->mailer = $mailer;
         $this->logger = $logger;
         $this->from = $from;
-        $this->whiteListedDomains = $whiteListedDomains;
     }
 
-    public function send(EmailAddress $to, string $subject, string $htmlTemplate, string $textTemplate, array $variables = []): bool
+    public function send(EmailAddress $to, string $subject, string $html, string $text): bool
     {
-        try {
-            $html = $this->twig->render($htmlTemplate, $variables);
-            $text = $this->twig->render($textTemplate, $variables);
-        } catch (LoaderError|SyntaxError|RuntimeError $e) {
-            $this->logger->error('[TwigTemplate] ' . $e->getMessage());
-            return false;
-        }
-
         $email = (new Email())
             ->from($this->from)
             ->to($to->toString())
@@ -51,33 +34,11 @@ final class SmtpMailer implements Mailer
             ->html($html);
 
         try {
-            if ($this->isAllowedToSentEmail($to)) {
-                $this->mailer->send($email);
-            }
+            $this->mailer->send($email);
             return true;
         } catch (TransportExceptionInterface $e) {
             $this->logger->critical('[TransportException] ' . $e->getMessage());
             return false;
         }
-    }
-
-    /*
-     * Checks if whitelisted domains are configured, in which case only mails to those domains can be sent.
-     * This is used on acc / test.
-     * If empty, on production, it will send mails to everybody.
-     * */
-    private function isAllowedToSentEmail(EmailAddress $email): bool
-    {
-        if ($this->whiteListedDomains === []) {
-            return true;
-        }
-
-        foreach ($this->whiteListedDomains as $domain) {
-            if (str_ends_with($email->toString(), $domain)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/Mailer/templates/approved.html.twig
+++ b/src/Mailer/templates/approved.html.twig
@@ -1,0 +1,10 @@
+<h2>Je bent nu beheerder van organisatie {{ organisationName }}!</h2>
+
+<p>Beste {{ firstName }},</p>
+
+<p>Je bent vanaf nu beheerder van de organisatie {{ organisationName }} in de UiTdatabank. Dit wil zeggen dat je zowel de organisatie informatie kan bewerken, als de informatie van de gelinkte evenementen aan deze organisatie.</p>
+
+<p><a href="{{ organisationUrl }}">Ga naar de beheerpagina voor meer informatie.</a></p>
+
+<p>Vriendelijke groet,<br />
+    Het UiTdatabank team.</p>

--- a/src/Mailer/templates/approved.txt.twig
+++ b/src/Mailer/templates/approved.txt.twig
@@ -1,0 +1,10 @@
+Je bent nu beheerder van organisatie {{ organisationName }}!
+
+Beste {{ firstName }},
+
+Je bent vanaf nu beheerder van de organisatie {{ organisationName }} in de UiTdatabank. Dit wil zeggen dat je zowel de organisatie informatie kan bewerken, als de informatie van de gelinkte evenementen aan deze organisatie.
+
+Ga naar de beheerpagina voor meer informatie. ({{ organisationUrl }})
+
+Vriendelijke groet,
+Het UiTdatabank team.

--- a/src/Mailer/templates/ownershipRequested.html.twig
+++ b/src/Mailer/templates/ownershipRequested.html.twig
@@ -1,0 +1,8 @@
+<h2>Beheers aanvraag voor organisatie {{ organisationName }}</h2>
+
+<p>Beste {{ firstName }},</p>
+
+<p>Er is een beheer aanvraag voor je organisatie {{ organisationName }} in de UiTdatabank. Ga naar de beheerderspagina om de aanvraag goed- of af te keuren. Beheerders kunnen zowel de organisatie informatie, als de informatie van de gelinkte evenementen aan deze organisatie bewerken.</p>
+
+<p>Vriendelijke groet,<br />
+    Het UiTdatabank team.</p>

--- a/src/Mailer/templates/ownershipRequested.txt.twig
+++ b/src/Mailer/templates/ownershipRequested.txt.twig
@@ -1,0 +1,8 @@
+Beheers aanvraag voor organisatie {{ organisationName }}
+
+Beste {{ firstName }},
+
+Er is een beheer aanvraag voor je organisatie {{ organisationName }} in de UiTdatabank. Ga naar de beheerderspagina om de aanvraag goed- of af te keuren. Beheerders kunnen zowel de organisatie informatie, als de informatie van de gelinkte evenementen aan deze organisatie bewerken.
+
+Vriendelijke groet,
+Het UiTdatabank team.

--- a/src/Mailer/templates/rejected.txt.twig
+++ b/src/Mailer/templates/rejected.txt.twig
@@ -1,0 +1,10 @@
+Je beheersaanvraag is geweigerd
+
+Beste {{ firstName }},
+
+Je aanvraag tot beheer voor de organisatie op de UiTdatabank is geweigerd door de huidige beheerder van de organisatie of door een admin.
+
+Voor meer informatie kan je contact opnemen met vragen@uitdatabank.be.
+
+Vriendelijke groet,
+Het UiTdatabank team.

--- a/tests/Mailer/SmtpMailerTest.php
+++ b/tests/Mailer/SmtpMailerTest.php
@@ -12,29 +12,23 @@ use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Twig\Environment as TwigEnvironment;
-use Twig\Error\LoaderError;
 
 class SmtpMailerTest extends TestCase
 {
     private SmtpMailer $smtpMailer;
     /** @var TwigEnvironment|MockObject */
-    private $twig;
-    /** @var MailerInterface|MockObject */
     private $mailer;
     /** @var LoggerInterface|MockObject */
     private $logger;
 
     protected function setUp(): void
     {
-        $this->twig = $this->createMock(TwigEnvironment::class);
         $this->mailer = $this->createMock(MailerInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->smtpMailer = new SmtpMailer(
-            $this->twig,
             $this->mailer,
             $this->logger,
             new Address('koen@publiq.be', 'Publiq'),
-            ['publiq.be']
         );
     }
 
@@ -43,41 +37,15 @@ class SmtpMailerTest extends TestCase
     {
         $to = new EmailAddress('user@publiq.be');
         $subject = 'Test Subject';
-        $htmlTemplate = 'email.html.twig';
-        $textTemplate = 'email.txt.twig';
-        $variables = ['name' => 'User'];
-
-        $this->twig->expects($this->exactly(2))
-            ->method('render')
-            ->willReturn('Rendered Content');
+        $html = 'My email';
+        $text = 'My email';
 
         $this->mailer->expects($this->once())
             ->method('send');
 
-        $result = $this->smtpMailer->send($to, $subject, $htmlTemplate, $textTemplate, $variables);
+        $result = $this->smtpMailer->send($to, $subject, $html, $text);
 
         $this->assertTrue($result);
-    }
-
-    /** @test */
-    public function it_handles_twig_rendering_failure(): void
-    {
-        $to = new EmailAddress('user@publiq.be');
-        $subject = 'Test Subject';
-        $htmlTemplate = 'email.html.twig';
-        $textTemplate = 'email.txt.twig';
-
-        $this->twig->expects($this->once())
-            ->method('render')
-            ->willThrowException(new LoaderError('Twig error'));
-
-        $this->logger->expects($this->once())
-            ->method('error')
-            ->with($this->stringContains('[TwigTemplate]'));
-
-        $result = $this->smtpMailer->send($to, $subject, $htmlTemplate, $textTemplate);
-
-        $this->assertFalse($result);
     }
 
     /** @test */
@@ -85,13 +53,8 @@ class SmtpMailerTest extends TestCase
     {
         $to = new EmailAddress('user@publiq.be');
         $subject = 'Test Subject';
-        $htmlTemplate = 'email.html.twig';
-        $textTemplate = 'email.txt.twig';
-        $variables = ['name' => 'User'];
-
-        $this->twig->expects($this->exactly(2))
-            ->method('render')
-            ->willReturn('Rendered Content');
+        $html = 'My email';
+        $text = 'My email';
 
         $this->mailer->expects($this->once())
             ->method('send')
@@ -101,30 +64,8 @@ class SmtpMailerTest extends TestCase
             ->method('critical')
             ->with($this->stringContains('[TransportException]'));
 
-        $result = $this->smtpMailer->send($to, $subject, $htmlTemplate, $textTemplate, $variables);
+        $result = $this->smtpMailer->send($to, $subject, $html, $text);
 
         $this->assertFalse($result);
-    }
-
-    /** @test */
-    public function it_does_not_sent_mail_to_illegal_domains(): void
-    {
-        $to = new EmailAddress('sauron@evil.com');
-        $subject = 'Test Subject';
-        $htmlTemplate = 'email.html.twig';
-        $textTemplate = 'email.txt.twig';
-        $variables = ['name' => 'User'];
-
-        $this->twig->expects($this->exactly(2))
-            ->method('render')
-            ->willReturn('Rendered Content');
-
-        // Do not send the email!
-        $this->mailer->expects($this->never())
-            ->method('send');
-
-        $result = $this->smtpMailer->send($to, $subject, $htmlTemplate, $textTemplate, $variables);
-
-        $this->assertTrue($result);
     }
 }

--- a/tests/Mailer/SmtpMailerTest.php
+++ b/tests/Mailer/SmtpMailerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Mailer;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Twig\Environment as TwigEnvironment;
+use Twig\Error\LoaderError;
+
+class SmtpMailerTest extends TestCase
+{
+    private SmtpMailer $smtpMailer;
+    /** @var TwigEnvironment|MockObject */
+    private $twig;
+    /** @var MailerInterface|MockObject */
+    private $mailer;
+    /** @var LoggerInterface|MockObject */
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->twig = $this->createMock(TwigEnvironment::class);
+        $this->mailer = $this->createMock(MailerInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->smtpMailer = new SmtpMailer(
+            $this->twig,
+            $this->mailer,
+            $this->logger,
+            new Address('koen@publiq.be', 'Publiq')
+        );
+    }
+
+    /** @test */
+    public function it_handles_successful_email_sending(): void
+    {
+        $to = new EmailAddress('user@example.com');
+        $subject = 'Test Subject';
+        $htmlTemplate = 'email.html.twig';
+        $textTemplate = 'email.txt.twig';
+        $variables = ['name' => 'User'];
+
+        $this->twig->expects($this->exactly(2))
+            ->method('render')
+            ->willReturn('Rendered Content');
+
+        $this->mailer->expects($this->once())
+            ->method('send');
+
+        $result = $this->smtpMailer->send($to, $subject, $htmlTemplate, $textTemplate, $variables);
+
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function it_handles_twig_rendering_failure(): void
+    {
+        $to = new EmailAddress('user@example.com');
+        $subject = 'Test Subject';
+        $htmlTemplate = 'email.html.twig';
+        $textTemplate = 'email.txt.twig';
+
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->willThrowException(new LoaderError('Twig error'));
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with($this->stringContains('[TwigTemplate]'));
+
+        $result = $this->smtpMailer->send($to, $subject, $htmlTemplate, $textTemplate);
+
+        $this->assertFalse($result);
+    }
+
+    /** @test */
+    public function it_handles_email_sending_failure(): void
+    {
+        $to = new EmailAddress('user@example.com');
+        $subject = 'Test Subject';
+        $htmlTemplate = 'email.html.twig';
+        $textTemplate = 'email.txt.twig';
+        $variables = ['name' => 'User'];
+
+        $this->twig->expects($this->exactly(2))
+            ->method('render')
+            ->willReturn('Rendered Content');
+
+        $this->mailer->expects($this->once())
+            ->method('send')
+            ->willThrowException($this->createMock(TransportExceptionInterface::class));
+
+        $this->logger->expects($this->once())
+            ->method('critical')
+            ->with($this->stringContains('[TransportException]'));
+
+        $result = $this->smtpMailer->send($to, $subject, $htmlTemplate, $textTemplate, $variables);
+
+        $this->assertFalse($result);
+    }
+}

--- a/tests/Mailer/SmtpMailerTest.php
+++ b/tests/Mailer/SmtpMailerTest.php
@@ -33,14 +33,15 @@ class SmtpMailerTest extends TestCase
             $this->twig,
             $this->mailer,
             $this->logger,
-            new Address('koen@publiq.be', 'Publiq')
+            new Address('koen@publiq.be', 'Publiq'),
+            ['publiq.be']
         );
     }
 
     /** @test */
     public function it_handles_successful_email_sending(): void
     {
-        $to = new EmailAddress('user@example.com');
+        $to = new EmailAddress('user@publiq.be');
         $subject = 'Test Subject';
         $htmlTemplate = 'email.html.twig';
         $textTemplate = 'email.txt.twig';
@@ -61,7 +62,7 @@ class SmtpMailerTest extends TestCase
     /** @test */
     public function it_handles_twig_rendering_failure(): void
     {
-        $to = new EmailAddress('user@example.com');
+        $to = new EmailAddress('user@publiq.be');
         $subject = 'Test Subject';
         $htmlTemplate = 'email.html.twig';
         $textTemplate = 'email.txt.twig';
@@ -82,7 +83,7 @@ class SmtpMailerTest extends TestCase
     /** @test */
     public function it_handles_email_sending_failure(): void
     {
-        $to = new EmailAddress('user@example.com');
+        $to = new EmailAddress('user@publiq.be');
         $subject = 'Test Subject';
         $htmlTemplate = 'email.html.twig';
         $textTemplate = 'email.txt.twig';
@@ -103,5 +104,27 @@ class SmtpMailerTest extends TestCase
         $result = $this->smtpMailer->send($to, $subject, $htmlTemplate, $textTemplate, $variables);
 
         $this->assertFalse($result);
+    }
+
+    /** @test */
+    public function it_does_not_sent_mail_to_illegal_domains(): void
+    {
+        $to = new EmailAddress('sauron@evil.com');
+        $subject = 'Test Subject';
+        $htmlTemplate = 'email.html.twig';
+        $textTemplate = 'email.txt.twig';
+        $variables = ['name' => 'User'];
+
+        $this->twig->expects($this->exactly(2))
+            ->method('render')
+            ->willReturn('Rendered Content');
+
+        // Do not send the email!
+        $this->mailer->expects($this->never())
+            ->method('send');
+
+        $result = $this->smtpMailer->send($to, $subject, $htmlTemplate, $textTemplate, $variables);
+
+        $this->assertTrue($result);
     }
 }


### PR DESCRIPTION
### Added
- Installed Symfony mailer package
- Provide a mailer class to sent mails by SMTP
- Add the twig templates that will be used in the feature for the mails
- Providing an option to only sent mails to certain domains for testing purposes

---

Ticket: https://jira.uitdatabank.be/browse/III-6366
Related to: https://github.com/cultuurnet/appconfig/pull/956