### PR TITLE
Bugfix: add missing testblocks

### DIFF
--- a/tests/Media/Properties/MIMETypeTest.php
+++ b/tests/Media/Properties/MIMETypeTest.php
@@ -8,24 +8,36 @@ use PHPUnit\Framework\TestCase;
 
 final class MIMETypeTest extends TestCase
 {
+    /**
+     * @test
+     */
     public function it_can_be_created_from_a_string(): void
     {
         $mimeType = new MIMEType('image/jpeg');
         $this->assertEquals('image/jpeg', $mimeType->toString());
     }
 
+    /**
+     * @test
+     */
     public function it_can_be_created_from_a_subtype(): void
     {
         $mimeType = MIMEType::fromSubtype('jpeg');
         $this->assertEquals('image/jpeg', $mimeType->toString());
     }
 
+    /**
+     * @test
+     */
     public function it_returns_a_filename_extension(): void
     {
         $mimeType = new MIMEType('image/jpeg');
         $this->assertEquals('jpeg', $mimeType->getFilenameExtension());
     }
 
+    /**
+     * @test
+     */
     public function it_validates_the_subtype(): void
     {
         $this->expectException(UnsupportedMIMETypeException::class);


### PR DESCRIPTION
### Changed

-  `MIMETypeTest`: Add missing `test`-blocks

### Fixed

- No more warning about risky tests

---