### PR TITLE
Improve setup documentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
     volumes:
-      - 'udb3-mysql:/var/lib/mysql'
+      - 'udb3-mysql:/bitnami/mysql/data'
       - ./docker/mysql:/docker-entrypoint-initdb.d
     ports:
       - '3306:3306'

--- a/docker.md
+++ b/docker.md
@@ -14,22 +14,6 @@ You will also need sudo privileges on the first run to add `127.0.0.1 io.uitdata
 $ make config
 ```
 
-### RabbitMQ
-
-Login to the management console on http://io.uitdatabank.local:15672/ with username `vagrant` and password `vagrant` 
-
-### Acceptance tests
-
-To run the acceptance tests for the very first time you need to initialize test data. This required test data contains several fixed labels and roles which are used by various acceptance tests.
-This can be done with:
-```
-$ make feature-init
-```
-You can run the actual acceptance tests with:
-```
-$ make feature
-```
-
 ## Start
 
 ### Docker
@@ -51,4 +35,20 @@ $ make init
 To execute all CI tasks, run the following command:
 ```
 $ make ci
+```
+
+### RabbitMQ
+
+Login to the management console on http://io.uitdatabank.local:15672/ with username `vagrant` and password `vagrant` 
+
+### Acceptance tests
+
+To run the acceptance tests for the very first time you need to initialize test data. This required test data contains several fixed labels and roles which are used by various acceptance tests.
+This can be done with:
+```
+$ make feature-init
+```
+You can run the actual acceptance tests with:
+```
+$ make feature
 ```

--- a/docker.md
+++ b/docker.md
@@ -8,7 +8,7 @@
 
 ### Configuration setup
 To get or update the configuration files, run the following command in the root of the project.
-You will also need sudo privileges on the first run to add `127.0.0.1 host.docker.internal` to your `/etc/hosts` file.
+You will also need sudo privileges on the first run to add `127.0.0.1 io.uitdatabank.local` to your `/etc/hosts` file.
 
 ```
 $ make config
@@ -16,7 +16,7 @@ $ make config
 
 ### RabbitMQ
 
-Login to the management console on http://host.docker.internal:15672/ with username `vagrant` and password `vagrant` 
+Login to the management console on http://io.uitdatabank.local:15672/ with username `vagrant` and password `vagrant` 
 
 ### Acceptance tests
 

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,9 @@
 
 This repository contains the PHP app that provides most of the backend of UiTdatabank v3, aka UDB3.
 
+## Setup
+You can find a full guide on how to setup the project [here](docker.md)
+
 ## Contributing
 
 Several CI checks have been provided to make sure any changes are compliant with our coding standards and to detect potential bugs.


### PR DESCRIPTION
### Changed
- Url in documentation is updated to `io.uitdatabank.local`.
- Change the ordering in `docker.md` so the project is set up as the first step.
- Link to installation instructions from `readme.md`

### Fixed
- The mount volumes were not pointing to the correct mysql directory. On `make down` and `make up` your db would be wiped.