### PR TITLE
III-6511 authenticate api key

### DIFF
--- a/app/Authentication/AuthServiceProvider.php
+++ b/app/Authentication/AuthServiceProvider.php
@@ -11,6 +11,8 @@ use CultuurNet\UDB3\ApiGuard\Consumer\CultureFeedConsumerReadRepository;
 use CultuurNet\UDB3\ApiGuard\Consumer\InMemoryConsumerRepository;
 use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerIsInPermissionGroup;
 use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedApiKeyAuthenticator;
+use CultuurNet\UDB3\Cache\CachedApiKeyAuthenticator;
+use CultuurNet\UDB3\Cache\CacheFactory;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
 use CultuurNet\UDB3\Http\Auth\Jwt\UitIdV1JwtValidator;
@@ -21,6 +23,7 @@ use CultuurNet\UDB3\Role\UserPermissionsServiceProvider;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\User\CurrentUser;
 use League\Container\DefinitionContainerInterface;
+use Predis\Client as RedisClient;
 
 final class AuthServiceProvider extends AbstractServiceProvider
 {
@@ -52,7 +55,14 @@ final class AuthServiceProvider extends AbstractServiceProvider
                         $container->get('config')['jwt']['v1']['valid_issuers']
                     ),
                     $this->createUitIdV2JwtValidator($container),
-                    new CultureFeedApiKeyAuthenticator($container->get(ConsumerReadRepository::class)),
+                    new CachedApiKeyAuthenticator(
+                        new CultureFeedApiKeyAuthenticator($container->get(ConsumerReadRepository::class)),
+                        CacheFactory::create(
+                            $container->get(RedisClient::class),
+                            'api_key',
+                            86400
+                        )
+                    ),
                     $container->get(ConsumerReadRepository::class),
                     new ConsumerIsInPermissionGroup((string) $container->get('config')['api_key']['group_id']),
                     $container->get(UserPermissionsServiceProvider::USER_PERMISSIONS_READ_REPOSITORY),

--- a/src/Cache/CachedApiKeyAuthenticator.php
+++ b/src/Cache/CachedApiKeyAuthenticator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Cache;
+
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKeyAuthenticationException;
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKeyAuthenticator;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class CachedApiKeyAuthenticator implements ApiKeyAuthenticator
+{
+    private ApiKeyAuthenticator $baseApiKeyAuthenticator;
+
+    private CacheInterface $cache;
+
+    public function __construct(ApiKeyAuthenticator $baseApiKeyAuthenticator, CacheInterface $cache)
+    {
+        $this->baseApiKeyAuthenticator = $baseApiKeyAuthenticator;
+        $this->cache = $cache;
+    }
+    public function authenticate(ApiKey $apiKey): void
+    {
+        $isAuthenticated = $this->cache->get(
+            $apiKey->toString(),
+            function () use ($apiKey) {
+                try {
+                    $this->baseApiKeyAuthenticator->authenticate($apiKey);
+                    return true;
+                } catch (ApiKeyAuthenticationException $apiKeyAuthenticationException) {
+                    return false;
+                }
+            }
+        );
+        if (!$isAuthenticated) {
+            throw ApiKeyAuthenticationException::forApiKey($apiKey);
+        }
+    }
+}

--- a/src/Cache/CachedApiKeyAuthenticator.php
+++ b/src/Cache/CachedApiKeyAuthenticator.php
@@ -20,6 +20,7 @@ final class CachedApiKeyAuthenticator implements ApiKeyAuthenticator
         $this->baseApiKeyAuthenticator = $baseApiKeyAuthenticator;
         $this->cache = $cache;
     }
+
     public function authenticate(ApiKey $apiKey): void
     {
         $isAuthenticated = $this->cache->get(

--- a/tests/Cache/CachedApiKeyAuthenticatorTest.php
+++ b/tests/Cache/CachedApiKeyAuthenticatorTest.php
@@ -57,7 +57,7 @@ final class CachedApiKeyAuthenticatorTest extends TestCase
     /**
      * @test
      */
-    public function it_can_get_an_uncached_invalid_api_key_from_the_decoree(): void
+    public function it_can_get_an_uncached_unauthorized_api_key_from_the_decoree(): void
     {
         $uncachedApiKey = new ApiKey('17bd454a-7bf4-4c70-8182-cb7d6b48dfac');
         $this->fallbackApiKeyAuthenticator->expects($this->once())
@@ -72,7 +72,7 @@ final class CachedApiKeyAuthenticatorTest extends TestCase
     /**
      * @test
      */
-    public function it_can_get_an_uncached_valid_api_key_from_the_decoree(): void
+    public function it_can_get_an_uncached_authorized_api_key_from_the_decoree(): void
     {
         $uncachedApiKey = new ApiKey('17bd454a-7bf4-4c70-8182-cb7d6b48dfac');
         $this->fallbackApiKeyAuthenticator->expects($this->once())

--- a/tests/Cache/CachedApiKeyAuthenticatorTest.php
+++ b/tests/Cache/CachedApiKeyAuthenticatorTest.php
@@ -57,7 +57,7 @@ final class CachedApiKeyAuthenticatorTest extends TestCase
     /**
      * @test
      */
-    public function it_can_get_an_uncached_api_key_from_the_decoree(): void
+    public function it_can_get_an_uncached_invalid_api_key_from_the_decoree(): void
     {
         $uncachedApiKey = new ApiKey('17bd454a-7bf4-4c70-8182-cb7d6b48dfac');
         $this->fallbackApiKeyAuthenticator->expects($this->once())
@@ -65,6 +65,18 @@ final class CachedApiKeyAuthenticatorTest extends TestCase
             ->willThrowException(ApiKeyAuthenticationException::forApiKey($uncachedApiKey));
 
         $this->expectException(ApiKeyAuthenticationException::class);
+
+        $this->cachedApiKeyAuthenticator->authenticate($uncachedApiKey);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_an_uncached_valid_api_key_from_the_decoree(): void
+    {
+        $uncachedApiKey = new ApiKey('17bd454a-7bf4-4c70-8182-cb7d6b48dfac');
+        $this->fallbackApiKeyAuthenticator->expects($this->once())
+            ->method('authenticate');
 
         $this->cachedApiKeyAuthenticator->authenticate($uncachedApiKey);
     }

--- a/tests/Cache/CachedApiKeyAuthenticatorTest.php
+++ b/tests/Cache/CachedApiKeyAuthenticatorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Cache;
+
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKeyAuthenticationException;
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKeyAuthenticator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class CachedApiKeyAuthenticatorTest extends TestCase
+{
+    /**
+     * @var ApiKeyAuthenticator&MockObject
+     */
+    private $fallbackApiKeyAuthenticator;
+
+    private ApiKey $cachedApiKey;
+
+    private CachedApiKeyAuthenticator $cachedApiKeyAuthenticator;
+
+    protected function setUp(): void
+    {
+        $this->fallbackApiKeyAuthenticator = $this->createMock(ApiKeyAuthenticator::class);
+        $cache = new ArrayAdapter();
+        $this->cachedApiKey = new ApiKey('b26e5a7b-5e01-46c1-8da8-f45edc51d01a');
+
+        $this->cachedApiKeyAuthenticator = new CachedApiKeyAuthenticator(
+            $this->fallbackApiKeyAuthenticator,
+            $cache
+        );
+
+        $cache->get(
+            $this->cachedApiKey->toString(),
+            function () {
+                return false;
+            }
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_a_cached_api_key(): void
+    {
+        $this->fallbackApiKeyAuthenticator->expects($this->never())
+            ->method('authenticate');
+
+        $this->expectException(ApiKeyAuthenticationException::class);
+
+        $this->cachedApiKeyAuthenticator->authenticate($this->cachedApiKey);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_an_uncached_api_key_from_the_decoree(): void
+    {
+        $uncachedApiKey = new ApiKey('17bd454a-7bf4-4c70-8182-cb7d6b48dfac');
+        $this->fallbackApiKeyAuthenticator->expects($this->once())
+            ->method('authenticate')
+        ->willThrowException(ApiKeyAuthenticationException::forApiKey($uncachedApiKey));
+
+        $this->expectException(ApiKeyAuthenticationException::class);
+
+        $this->cachedApiKeyAuthenticator->authenticate($uncachedApiKey);
+    }
+}

--- a/tests/Cache/CachedApiKeyAuthenticatorTest.php
+++ b/tests/Cache/CachedApiKeyAuthenticatorTest.php
@@ -62,7 +62,7 @@ final class CachedApiKeyAuthenticatorTest extends TestCase
         $uncachedApiKey = new ApiKey('17bd454a-7bf4-4c70-8182-cb7d6b48dfac');
         $this->fallbackApiKeyAuthenticator->expects($this->once())
             ->method('authenticate')
-        ->willThrowException(ApiKeyAuthenticationException::forApiKey($uncachedApiKey));
+            ->willThrowException(ApiKeyAuthenticationException::forApiKey($uncachedApiKey));
 
         $this->expectException(ApiKeyAuthenticationException::class);
 

--- a/tests/Cache/CachedApiKeyAuthenticatorTest.php
+++ b/tests/Cache/CachedApiKeyAuthenticatorTest.php
@@ -44,7 +44,7 @@ final class CachedApiKeyAuthenticatorTest extends TestCase
     /**
      * @test
      */
-    public function it_can_get_a_cached_api_key(): void
+    public function it_can_get_a_cached_unauthorized_api_key(): void
     {
         $this->fallbackApiKeyAuthenticator->expects($this->never())
             ->method('authenticate');


### PR DESCRIPTION
### Added

- `CachedApiKeyAuthenticator`: `ApiKeyAuthenticator` with Caching
- `CachedApiKeyAuthenticatorTest`: Unit tests

### Changed

- `AuthServiceProvider`: Use `CachedApiKeyAuthenticator` instead of `CultureFeedApiKeyAuthenticator `

### Fixed

- Authenticated `apiKeys` are now cached.

---

Ticket: https://jira.publiq.be/browse/III-6511
