### PR TITLE
III-6511 cache api key consumer read repository

### DIFF
--- a/app/Authentication/AuthServiceProvider.php
+++ b/app/Authentication/AuthServiceProvider.php
@@ -164,7 +164,7 @@ final class AuthServiceProvider extends AbstractServiceProvider
                     new CultureFeedConsumerReadRepository($container->get('culturefeed'), true),
                     CacheFactory::create(
                         $container->get(RedisClient::class),
-                        'consumer_repository',
+                        'culturefeed_consumer',
                         86400
                     )
                 );

--- a/app/Authentication/AuthServiceProvider.php
+++ b/app/Authentication/AuthServiceProvider.php
@@ -8,10 +8,10 @@ use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
 use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
 use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
 use CultuurNet\UDB3\ApiGuard\Consumer\CultureFeedConsumerReadRepository;
-use CultuurNet\UDB3\ApiGuard\Consumer\InMemoryConsumerRepository;
 use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerIsInPermissionGroup;
 use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedApiKeyAuthenticator;
 use CultuurNet\UDB3\Cache\CachedApiKeyAuthenticator;
+use CultuurNet\UDB3\Cache\CachedConsumerReadRepository;
 use CultuurNet\UDB3\Cache\CacheFactory;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
@@ -160,8 +160,13 @@ final class AuthServiceProvider extends AbstractServiceProvider
         $container->addShared(
             ConsumerReadRepository::class,
             function () use ($container): ConsumerReadRepository {
-                return new InMemoryConsumerRepository(
-                    new CultureFeedConsumerReadRepository($container->get('culturefeed'), true)
+                return new CachedConsumerReadRepository(
+                    new CultureFeedConsumerReadRepository($container->get('culturefeed'), true),
+                    CacheFactory::create(
+                        $container->get(RedisClient::class),
+                        'consumer_repository',
+                        86400
+                    )
                 );
             }
         );

--- a/src/Cache/CachedConsumerReadRepository.php
+++ b/src/Cache/CachedConsumerReadRepository.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Cache;
 
-use CultureFeed_Consumer;
 use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
 use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
 use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
-use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedConsumerAdapter;
 use Symfony\Contracts\Cache\CacheInterface;
 
 final class CachedConsumerReadRepository implements ConsumerReadRepository
@@ -25,39 +23,16 @@ final class CachedConsumerReadRepository implements ConsumerReadRepository
 
     public function getConsumer(ApiKey $apiKey): ?Consumer
     {
-        $consumerAsArray = $this->cache->get(
+        $serializableConsumer = $this->cache->get(
             $apiKey->toString(),
             function () use ($apiKey) {
                 $consumer = $this->baseConsumerReadRepository->getConsumer($apiKey);
-                return $consumer !== null ? $this->consumerAsArray($consumer) : null;
+                return $consumer !== null ? SerializableConsumer::serialize($consumer) : null;
             }
         );
-        if ($consumerAsArray !== null) {
-            return $this->arrayToConsumer($consumerAsArray);
+        if ($serializableConsumer !== null) {
+            return SerializableConsumer::deserialize($serializableConsumer);
         }
         return null;
-    }
-
-    private function consumerAsArray(Consumer $consumer): array
-    {
-        return [
-            'api_key' => $consumer->getApiKey()->toString(),
-            'default_query' => $consumer->getDefaultQuery(),
-            'permission_group_ids' => $consumer->getPermissionGroupIds(),
-            'name' => $consumer->getName(),
-            'status' => $consumer->isBlocked() ? 'BLOCKED' :
-                ($consumer->isRemoved() ? 'REMOVED' : 'ACTIVE'),
-        ];
-    }
-
-    private function arrayToConsumer(array $consumerAsArray): Consumer
-    {
-        $consumer = new CultureFeed_Consumer();
-        $consumer->apiKeySapi3 = $consumerAsArray['api_key'];
-        $consumer->searchPrefixSapi3 = $consumerAsArray['default_query'];
-        $consumer->group = $consumerAsArray['permission_group_ids'];
-        $consumer->name = $consumerAsArray['name'];
-        $consumer->status = $consumerAsArray['status'];
-        return new CultureFeedConsumerAdapter($consumer);
     }
 }

--- a/src/Cache/CachedConsumerReadRepository.php
+++ b/src/Cache/CachedConsumerReadRepository.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Cache;
+
+use CultureFeed_Consumer;
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
+use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
+use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedConsumerAdapter;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class CachedConsumerReadRepository implements ConsumerReadRepository
+{
+    private ConsumerReadRepository $baseConsumerReadRepository;
+
+    private CacheInterface $cache;
+
+    public function __construct(ConsumerReadRepository $baseConsumerReadRepository, CacheInterface $cache)
+    {
+        $this->baseConsumerReadRepository = $baseConsumerReadRepository;
+        $this->cache = $cache;
+    }
+
+    public function getConsumer(ApiKey $apiKey): ?Consumer
+    {
+        $consumerAsArray = $this->cache->get(
+            $apiKey->toString(),
+            function () use ($apiKey) {
+                $consumer = $this->baseConsumerReadRepository->getConsumer($apiKey);
+                return $consumer !== null ? $this->consumerAsArray($consumer) : null;
+            }
+        );
+        if ($consumerAsArray !== null) {
+            return $this->arrayToConsumer($consumerAsArray);
+        }
+        return null;
+    }
+
+    private function consumerAsArray(Consumer $consumer): array
+    {
+        return [
+            'api_key' => $consumer->getApiKey(),
+            'default_query' => $consumer->getDefaultQuery(),
+            'permission_group_ids' => $consumer->getPermissionGroupIds(),
+            'name' => $consumer->getName(),
+            'blocked' => $consumer->isBlocked(),
+            'removed' => $consumer->isRemoved(),
+        ];
+    }
+
+    private function arrayToConsumer(array $consumerAsArray): Consumer
+    {
+        $consumer = new CultureFeed_Consumer();
+        $consumer->apiKeySapi3 = $consumerAsArray['api_key'];
+        $consumer->searchPrefixSapi3 = $consumerAsArray['default_query'];
+        $consumer->group = $consumerAsArray['permission_group_ids'];
+        $consumer->name = $consumerAsArray['name'];
+        if ($consumerAsArray['blocked']) {
+            $consumer->status = 'BLOCKED';
+        }
+        if ($consumerAsArray['removed']) {
+            $consumer->status = 'REMOVED';
+        }
+        return new CultureFeedConsumerAdapter($consumer);
+    }
+}

--- a/src/Cache/CachedConsumerReadRepository.php
+++ b/src/Cache/CachedConsumerReadRepository.php
@@ -45,8 +45,8 @@ final class CachedConsumerReadRepository implements ConsumerReadRepository
             'default_query' => $consumer->getDefaultQuery(),
             'permission_group_ids' => $consumer->getPermissionGroupIds(),
             'name' => $consumer->getName(),
-            'blocked' => $consumer->isBlocked(),
-            'removed' => $consumer->isRemoved(),
+            'status' => $consumer->isBlocked() ? 'BLOCKED' :
+                ($consumer->isRemoved() ? 'REMOVED' : 'ACTIVE'),
         ];
     }
 
@@ -57,12 +57,7 @@ final class CachedConsumerReadRepository implements ConsumerReadRepository
         $consumer->searchPrefixSapi3 = $consumerAsArray['default_query'];
         $consumer->group = $consumerAsArray['permission_group_ids'];
         $consumer->name = $consumerAsArray['name'];
-        if ($consumerAsArray['blocked']) {
-            $consumer->status = 'BLOCKED';
-        }
-        if ($consumerAsArray['removed']) {
-            $consumer->status = 'REMOVED';
-        }
+        $consumer->status = $consumerAsArray['status'];
         return new CultureFeedConsumerAdapter($consumer);
     }
 }

--- a/src/Cache/CachedConsumerReadRepository.php
+++ b/src/Cache/CachedConsumerReadRepository.php
@@ -41,7 +41,7 @@ final class CachedConsumerReadRepository implements ConsumerReadRepository
     private function consumerAsArray(Consumer $consumer): array
     {
         return [
-            'api_key' => $consumer->getApiKey(),
+            'api_key' => $consumer->getApiKey()->toString(),
             'default_query' => $consumer->getDefaultQuery(),
             'permission_group_ids' => $consumer->getPermissionGroupIds(),
             'name' => $consumer->getName(),

--- a/src/Cache/SerializableConsumer.php
+++ b/src/Cache/SerializableConsumer.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Cache;
+
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
+
+final class SerializableConsumer implements Consumer
+{
+    private ApiKey $apiKey;
+
+    private ?string $defaultQuery;
+
+    private array $permissionGroupIds;
+
+    private ?string $name;
+
+    private bool $isBlocked;
+
+    private bool $isRemoved;
+
+    private function __construct(
+        ApiKey $apiKey,
+        ?string $defaultQuery,
+        array $permissionGroupIds,
+        ?string $name,
+        bool $isBlocked,
+        bool $isRemoved
+    ) {
+        $this->apiKey = $apiKey;
+        $this->defaultQuery = $defaultQuery;
+        $this->permissionGroupIds = $permissionGroupIds;
+        $this->name = $name;
+        $this->isBlocked = $isBlocked;
+        $this->isRemoved = $isRemoved;
+    }
+
+    public static function serialize(Consumer $consumer): array
+    {
+        return [
+            'api_key' => $consumer->getApiKey(),
+            'default_query' => $consumer->getDefaultQuery(),
+            'permission_group_ids' => $consumer->getPermissionGroupIds(),
+            'name' => $consumer->getName(),
+            'is_blocked' => $consumer->isBlocked(),
+            'is_removed' => $consumer->isRemoved(),
+        ];
+    }
+
+    public static function deserialize(array $consumerAsArray): Consumer
+    {
+        return new SerializableConsumer(
+            $consumerAsArray['api_key'],
+            $consumerAsArray['default_query'],
+            $consumerAsArray['permission_group_ids'],
+            $consumerAsArray['name'],
+            $consumerAsArray['is_blocked'],
+            $consumerAsArray['is_removed']
+        );
+    }
+
+    public function getApiKey(): ApiKey
+    {
+        return $this->apiKey;
+    }
+
+    public function getDefaultQuery(): ?string
+    {
+        return $this->defaultQuery;
+    }
+
+    public function getPermissionGroupIds(): array
+    {
+        return $this->permissionGroupIds;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function isBlocked(): bool
+    {
+        return $this->isBlocked;
+    }
+
+    public function isRemoved(): bool
+    {
+        return $this->isRemoved;
+    }
+}

--- a/tests/Cache/CachedConsumerReadRepositoryTest.php
+++ b/tests/Cache/CachedConsumerReadRepositoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Cache;
+
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
+use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
+use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedConsumerAdapter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class CachedConsumerReadRepositoryTest extends TestCase
+{
+    /**
+     * @var ConsumerReadRepository&MockObject
+     */
+    private $fallbackConsumerReadRepository;
+
+    private ApiKey $cachedApiKey;
+
+    private CachedConsumerReadRepository $cachedConsumerReadRepository;
+
+    protected function setUp(): void
+    {
+        $this->fallbackConsumerReadRepository = $this->createMock(ConsumerReadRepository::class);
+        $cache = new ArrayAdapter();
+        $this->cachedApiKey = new ApiKey('b26e5a7b-5e01-46c1-8da8-f45edc51d01a');
+
+        $this->cachedConsumerReadRepository = new CachedConsumerReadRepository(
+            $this->fallbackConsumerReadRepository,
+            $cache
+        );
+
+        $cache->get(
+            $this->cachedApiKey->toString(),
+            function () {
+                return [
+                    'api_key' => $this->cachedApiKey->toString(),
+                    'default_query' => '',
+                    'permission_group_ids' => [1, 2, 3],
+                    'name' => 'FOOBAR',
+                    'blocked' => false,
+                    'removed' => false,
+                ];
+            }
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_a_cached_consumer(): void
+    {
+        $this->fallbackConsumerReadRepository->expects($this->never())
+            ->method('getConsumer');
+
+        $this->assertEquals(
+            new CultureFeedConsumerAdapter(
+                new CultureFeed_Consumer()
+            ),
+            $this->cachedConsumerReadRepository->getConsumer($this->cachedApiKey)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_an_uncached_consumer_from_the_decoretee(): void
+    {
+
+    }
+}

--- a/tests/Cache/CachedConsumerReadRepositoryTest.php
+++ b/tests/Cache/CachedConsumerReadRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Cache;
 
+use CultureFeed_Consumer;
 use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
 use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
 use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedConsumerAdapter;
@@ -56,9 +57,14 @@ final class CachedConsumerReadRepositoryTest extends TestCase
         $this->fallbackConsumerReadRepository->expects($this->never())
             ->method('getConsumer');
 
+        $cultureFeedConsumer = new CultureFeed_Consumer();
+        $cultureFeedConsumer->apiKeySapi3 = $this->cachedApiKey->toString();
+        $cultureFeedConsumer->searchPrefixSapi3 = '';
+        $cultureFeedConsumer->group = [1, 2, 3];
+        $cultureFeedConsumer->name = 'FOOBAR';
         $this->assertEquals(
             new CultureFeedConsumerAdapter(
-                new CultureFeed_Consumer()
+                $cultureFeedConsumer
             ),
             $this->cachedConsumerReadRepository->getConsumer($this->cachedApiKey)
         );

--- a/tests/Cache/CachedConsumerReadRepositoryTest.php
+++ b/tests/Cache/CachedConsumerReadRepositoryTest.php
@@ -36,6 +36,7 @@ final class CachedConsumerReadRepositoryTest extends TestCase
         $this->cachedConsumer->searchPrefixSapi3 = 'regions:nis-44021';
         $this->cachedConsumer->group = [1, 2, 3];
         $this->cachedConsumer->name = 'Foobar';
+        $this->cachedConsumer->status = 'ACTIVE';
 
         $cache->get(
             $this->cachedApiKey->toString(),
@@ -47,6 +48,7 @@ final class CachedConsumerReadRepositoryTest extends TestCase
                     'name' => $this->cachedConsumer->name,
                     'blocked' => false,
                     'removed' => false,
+                    'status' => 'ACTIVE',
                 ];
             }
         );
@@ -82,6 +84,7 @@ final class CachedConsumerReadRepositoryTest extends TestCase
         $uncachedConsumer->searchPrefixSapi3 = 'regions:nis-44021';
         $uncachedConsumer->group = [4, 5, 6];
         $uncachedConsumer->name = 'Bar Foo';
+        $uncachedConsumer->status = 'ACTIVE';
 
         $this->fallbackConsumerReadRepository->expects($this->once())
             ->method('getConsumer')

--- a/tests/Cache/CachedConsumerReadRepositoryTest.php
+++ b/tests/Cache/CachedConsumerReadRepositoryTest.php
@@ -84,6 +84,7 @@ final class CachedConsumerReadRepositoryTest extends TestCase
 
         $this->fallbackConsumerReadRepository->expects($this->once())
             ->method('getConsumer')
+            ->with($uncachedApiKey)
             ->willReturn($uncachedConsumer);
 
         $this->assertEquals(

--- a/tests/Cache/CachedConsumerReadRepositoryTest.php
+++ b/tests/Cache/CachedConsumerReadRepositoryTest.php
@@ -76,5 +76,20 @@ final class CachedConsumerReadRepositoryTest extends TestCase
      */
     public function it_can_get_an_uncached_consumer_from_the_decoretee(): void
     {
+        $uncachedApiKey = new ApiKey('c90fbc92-a572-4c39-a002-53f02f58844c');
+        $uncachedConsumer = new CultureFeed_Consumer();
+        $uncachedConsumer->apiKeySapi3 = $uncachedApiKey->toString();
+        $uncachedConsumer->searchPrefixSapi3 = 'regions:nis-44021';
+        $uncachedConsumer->group = [4, 5, 6];
+        $uncachedConsumer->name = 'Bar Foo';
+
+        $this->fallbackConsumerReadRepository->expects($this->once())
+            ->method('getConsumer')
+            ->willReturn(new CultureFeedConsumerAdapter($uncachedConsumer));
+
+        $this->assertEquals(
+            new CultureFeedConsumerAdapter($uncachedConsumer),
+            $this->cachedConsumerReadRepository->getConsumer($uncachedApiKey)
+        );
     }
 }

--- a/tests/Cache/CachedConsumerReadRepositoryTest.php
+++ b/tests/Cache/CachedConsumerReadRepositoryTest.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Cache;
 
-use CultureFeed_Consumer;
 use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
 use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
-use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedConsumerAdapter;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -23,7 +22,7 @@ final class CachedConsumerReadRepositoryTest extends TestCase
 
     private CachedConsumerReadRepository $cachedConsumerReadRepository;
 
-    private CultureFeed_Consumer $cachedConsumer;
+    private Consumer $cachedConsumer;
 
     protected function setUp(): void
     {
@@ -31,25 +30,19 @@ final class CachedConsumerReadRepositoryTest extends TestCase
         $cache = new ArrayAdapter();
         $this->cachedApiKey = new ApiKey('b26e5a7b-5e01-46c1-8da8-f45edc51d01a');
 
-        $this->cachedConsumer = new CultureFeed_Consumer();
-        $this->cachedConsumer->apiKeySapi3 = $this->cachedApiKey->toString();
-        $this->cachedConsumer->searchPrefixSapi3 = 'regions:nis-44021';
-        $this->cachedConsumer->group = [1, 2, 3];
-        $this->cachedConsumer->name = 'Foobar';
-        $this->cachedConsumer->status = 'ACTIVE';
+        $this->cachedConsumer = SerializableConsumer::deserialize([
+            'api_key' => $this->cachedApiKey,
+            'default_query' => 'regions:nis-44021',
+            'permission_group_ids' => [1, 2, 3],
+            'name' => 'Foobar',
+            'is_blocked' => false,
+            'is_removed' => false,
+        ]);
 
         $cache->get(
             $this->cachedApiKey->toString(),
             function () {
-                return [
-                    'api_key' => $this->cachedConsumer->apiKeySapi3,
-                    'default_query' => $this->cachedConsumer->searchPrefixSapi3,
-                    'permission_group_ids' => $this->cachedConsumer->group,
-                    'name' => $this->cachedConsumer->name,
-                    'blocked' => false,
-                    'removed' => false,
-                    'status' => 'ACTIVE',
-                ];
+                return SerializableConsumer::serialize($this->cachedConsumer);
             }
         );
 
@@ -68,7 +61,7 @@ final class CachedConsumerReadRepositoryTest extends TestCase
             ->method('getConsumer');
 
         $this->assertEquals(
-            new CultureFeedConsumerAdapter($this->cachedConsumer),
+            $this->cachedConsumer,
             $this->cachedConsumerReadRepository->getConsumer($this->cachedApiKey)
         );
     }
@@ -79,19 +72,22 @@ final class CachedConsumerReadRepositoryTest extends TestCase
     public function it_can_get_an_uncached_consumer_from_the_decoretee(): void
     {
         $uncachedApiKey = new ApiKey('c90fbc92-a572-4c39-a002-53f02f58844c');
-        $uncachedConsumer = new CultureFeed_Consumer();
-        $uncachedConsumer->apiKeySapi3 = $uncachedApiKey->toString();
-        $uncachedConsumer->searchPrefixSapi3 = 'regions:nis-44021';
-        $uncachedConsumer->group = [4, 5, 6];
-        $uncachedConsumer->name = 'Bar Foo';
-        $uncachedConsumer->status = 'ACTIVE';
+
+        $uncachedConsumer = SerializableConsumer::deserialize([
+            'api_key' => $uncachedApiKey,
+            'default_query' => 'regions:nis-44021',
+            'permission_group_ids' => [4, 5, 6],
+            'name' => 'Bar Foo',
+            'is_blocked' => false,
+            'is_removed' => false,
+        ]);
 
         $this->fallbackConsumerReadRepository->expects($this->once())
             ->method('getConsumer')
-            ->willReturn(new CultureFeedConsumerAdapter($uncachedConsumer));
+            ->willReturn($uncachedConsumer);
 
         $this->assertEquals(
-            new CultureFeedConsumerAdapter($uncachedConsumer),
+            $uncachedConsumer,
             $this->cachedConsumerReadRepository->getConsumer($uncachedApiKey)
         );
     }


### PR DESCRIPTION
### Added

- `CachedConsumerReadRepository`: `ConsumerReadRepository` with caching
- `CachedConsumerReadRepositoryTest`: Unit tests
- `SerializableConsumer`: New implementation of `Consumer`

### Changed

- `AuthServiceProvider`: Use `CachedConsumerReadRepository` instead of `InMemoryConsumerReadRepository`

---

Ticket: https://jira.publiq.be/browse/III-6511
