### PR TITLE
Bugfix/III-4855 Enforce max limit on /labels endpoint

### DIFF
--- a/features/label/get.feature
+++ b/features/label/get.feature
@@ -82,7 +82,7 @@ Feature: Test the UDB3 labels API
   @bugfix # https://jira.uitdatabank.be/browse/III-5006
   Scenario: Search labels with offset beyond result window with at least one result
     When I send a GET request to "/labels/" with parameters:
-      | start   | 999999999999999999999999999999  |
+      | start   | 9223372036854775807  |
       | query   | special |
     Then the response status should be "200"
     And the response body should be valid JSON
@@ -97,6 +97,7 @@ Feature: Test the UDB3 labels API
       | query   | special |
     Then the response status should be "200"
     And the response body should be valid JSON
+    And the JSON response at "itemsPerPage" should be 30
     And the JSON response at "totalItems" should be 4
     And the JSON response at "member/0/name" should be "special_label"
     And the JSON response at "member/1/name" should be "special_label*"

--- a/features/label/get.feature
+++ b/features/label/get.feature
@@ -90,3 +90,15 @@ Feature: Test the UDB3 labels API
     """
     []
     """
+
+  @bugfix # https://jira.publiq.be/browse/III-4855
+  Scenario: Search labels without offset and limit
+    When I send a GET request to "/labels/" with parameters:
+      | query   | special |
+    Then the response status should be "200"
+    And the response body should be valid JSON
+    And the JSON response at "totalItems" should be 4
+    And the JSON response at "member/0/name" should be "special_label"
+    And the JSON response at "member/1/name" should be "special_label*"
+    And the JSON response at "member/2/name" should be "special_label#"
+    And the JSON response at "member/3/name" should be "special-label"

--- a/src/Http/Label/Query/QueryFactory.php
+++ b/src/Http/Label/Query/QueryFactory.php
@@ -32,9 +32,9 @@ class QueryFactory implements QueryFactoryInterface
 
         $userId = $this->userId ?: null;
 
-        $offset = (int) $queryParameters->get(self::START, '0');
+        $offset = $queryParameters->getAsInt(self::START, 0);
 
-        $limit = (int) $queryParameters->get(self::LIMIT, (string) self::MAX_LIMIT);
+        $limit = $queryParameters->getAsInt(self::LIMIT, self::MAX_LIMIT);
 
         $suggestion = filter_var($queryParameters->get(self::SUGGESTION), FILTER_VALIDATE_BOOLEAN);
 

--- a/src/Http/Label/Query/QueryFactory.php
+++ b/src/Http/Label/Query/QueryFactory.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class QueryFactory implements QueryFactoryInterface
 {
+    public const MAX_LIMIT = 30;
     public const QUERY = 'query';
     public const START = 'start';
     public const LIMIT = 'limit';
@@ -31,9 +32,9 @@ class QueryFactory implements QueryFactoryInterface
 
         $userId = $this->userId ?: null;
 
-        $offset = (int) $queryParameters->get(self::START);
+        $offset = (int) $queryParameters->get(self::START, '0');
 
-        $limit = (int) $queryParameters->get(self::LIMIT);
+        $limit = (int) $queryParameters->get(self::LIMIT, (string) self::MAX_LIMIT);
 
         $suggestion = filter_var($queryParameters->get(self::SUGGESTION), FILTER_VALIDATE_BOOLEAN);
 

--- a/src/Http/Label/Query/QueryFactory.php
+++ b/src/Http/Label/Query/QueryFactory.php
@@ -34,7 +34,10 @@ class QueryFactory implements QueryFactoryInterface
 
         $offset = $queryParameters->getAsInt(self::START, 0);
 
-        $limit = $queryParameters->getAsInt(self::LIMIT, self::MAX_LIMIT);
+        $limit = min(
+            $queryParameters->getAsInt(self::LIMIT, self::MAX_LIMIT),
+            self::MAX_LIMIT
+        );
 
         $suggestion = filter_var($queryParameters->get(self::SUGGESTION), FILTER_VALIDATE_BOOLEAN);
 

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -18,8 +18,6 @@ use Doctrine\DBAL\Query\QueryBuilder;
 
 final class DBALReadRepository extends AbstractDBALRepository implements ReadRepositoryInterface
 {
-    private const MAX_RESULTS = 30;
-
     private string $labelRolesTableName;
 
     private string $userRolesTableName;
@@ -124,8 +122,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
                 ->setFirstResult($query->getOffset());
         }
 
-        $queryBuilder
-            ->setMaxResults($query->getLimit() ?? self::MAX_RESULTS);
+        $queryBuilder->setMaxResults($query->getLimit());
 
         return $this->getResults($queryBuilder);
     }

--- a/tests/Http/Label/Query/QueryFactoryTest.php
+++ b/tests/Http/Label/Query/QueryFactoryTest.php
@@ -75,7 +75,7 @@ final class QueryFactoryTest extends TestCase
         $expectedQuery = new Query(
             self::QUERY_VALUE,
             self::USER_ID_VALUE,
-            null,
+            0,
             self::LIMIT_VALUE
         );
 
@@ -105,7 +105,7 @@ final class QueryFactoryTest extends TestCase
             self::QUERY_VALUE,
             self::USER_ID_VALUE,
             self::START_VALUE,
-            null
+            QueryFactory::MAX_LIMIT,
         );
 
         $this->assertEquals($expectedQuery, $query);
@@ -131,8 +131,8 @@ final class QueryFactoryTest extends TestCase
         $expectedQuery = new Query(
             self::QUERY_VALUE,
             self::USER_ID_VALUE,
-            null,
-            null
+            0,
+            QueryFactory::MAX_LIMIT,
         );
 
         $this->assertEquals($expectedQuery, $query);

--- a/tests/Http/Label/Query/QueryFactoryTest.php
+++ b/tests/Http/Label/Query/QueryFactoryTest.php
@@ -172,6 +172,37 @@ final class QueryFactoryTest extends TestCase
     /**
      * @test
      */
+    public function it_enforces_a_maximum_limit(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString(
+                sprintf(
+                    '/?%s=%s&%s=%s&%s=%s',
+                    QueryFactory::QUERY,
+                    self::QUERY_VALUE,
+                    QueryFactory::START,
+                    0,
+                    QueryFactory::LIMIT,
+                    9223372036854775807,
+                )
+            )
+            ->build('GET');
+
+        $query = $this->queryFactory->createFromRequest($request);
+
+        $expectedQuery = new Query(
+            self::QUERY_VALUE,
+            self::USER_ID_VALUE,
+            0,
+            30,
+        );
+
+        $this->assertEquals($expectedQuery, $query);
+    }
+
+    /**
+     * @test
+     */
     public function it_can_return_a_query_without_user_id(): void
     {
         $queryFactory = new QueryFactory(null);

--- a/tests/Http/Label/SearchLabelsRequestHandlerTest.php
+++ b/tests/Http/Label/SearchLabelsRequestHandlerTest.php
@@ -113,4 +113,35 @@ final class SearchLabelsRequestHandlerTest extends TestCase
             $response,
         );
     }
+
+    /**
+     * @test https://jira.publiq.be/browse/III-4855
+     */
+    public function it_uses_default_start_and_limit_when_not_provided(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('labels')
+            ->build('GET');
+
+        $this->labelRepository->expects($this->once())
+            ->method('searchTotalLabels')
+            ->with(new Query('', '123', 0, 30))
+            ->willReturn(count($this->labels));
+
+        $this->labelRepository->expects($this->once())
+            ->method('search')
+            ->with(new Query('', '123', 0, 30))
+            ->willReturn($this->labels);
+
+        $response = $this->searchLabelsRequestHandler->handle($request);
+
+        $this->assertJsonResponse(
+            new PagedCollectionResponse(
+                30,
+                2,
+                $this->labels
+            ),
+            $response,
+        );
+    }
 }


### PR DESCRIPTION
### Changed
- Calling the `/labels` endpoint without start and limit will now use sensible defaults.
- Calling the `/labels` endpoint with a high limit will reduce this to 30 so that DOS attacks are less likely.

---

Ticket: https://jira.publiq.be/browse/III-4855
