### PR TITLE
III-6531 Cast `terms` object to array

### DIFF
--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -443,7 +443,7 @@ final class EventLDProjector extends OfferLDProjector implements
 
         // Remove old theme and event type.
         $jsonLD->terms = array_filter(
-            $jsonLD->terms,
+            (array) $jsonLD->terms,
             function ($term) {
                 return $term->domain !== CategoryDomain::eventType()->toString()
                     && $term->domain !== CategoryDomain::theme()->toString();

--- a/src/Place/ReadModel/JSONLD/PlaceLDProjector.php
+++ b/src/Place/ReadModel/JSONLD/PlaceLDProjector.php
@@ -261,7 +261,7 @@ class PlaceLDProjector extends OfferLDProjector implements EventListener
         )->format(DateTimeInterface::ATOM);
 
         // Remove old theme and event type.
-        $jsonLD->terms = array_filter($jsonLD->terms, function ($term) {
+        $jsonLD->terms = array_filter((array) $jsonLD->terms, function ($term) {
             return $term->domain !== CategoryDomain::eventType()->toString() &&  $term->domain !== CategoryDomain::theme()->toString();
         });
 


### PR DESCRIPTION
### Changed
- Cast `terms` object to array

### Note
- This was broken a long time ago but update major info commands are no longer dispatched, so only when doing a replay was this noticed

---

Ticket: https://jira.uitdatabank.be/browse/III-6531
