### PR TITLE
III-6541 bugfix nulls

### DIFF
--- a/src/User/Keycloak/CachedUserIdentityResolver.php
+++ b/src/User/Keycloak/CachedUserIdentityResolver.php
@@ -75,7 +75,13 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
                 $this->cache->get(
                     $this->createCacheKey($nick, 'nick'),
                     function () use ($nick) {
-                        return $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserByNick($nick));
+                        $userIdentityDetails = $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserByNick($nick));
+
+                        if ($userIdentityDetails === null) {
+                            throw new CacheException();
+                        }
+
+                        return $userIdentityDetails;
                     }
                 )
             );

--- a/src/User/Keycloak/CachedUserIdentityResolver.php
+++ b/src/User/Keycloak/CachedUserIdentityResolver.php
@@ -30,15 +30,7 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
             return $this->deserializeUserIdentityDetails(
                 $this->cache->get(
                     $this->createCacheKey($userId, 'user_id'),
-                    function () use ($userId) {
-                        $userIdentityDetails = $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserById($userId));
-
-                        if ($userIdentityDetails === null) {
-                            throw new CacheException();
-                        }
-
-                        return $userIdentityDetails;
-                    }
+                    fn () => $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserById($userId))
                 )
             );
         } catch (CacheException $exception) {
@@ -52,15 +44,7 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
             return $this->deserializeUserIdentityDetails(
                 $this->cache->get(
                     $this->createCacheKey($email->toString(), 'email'),
-                    function () use ($email) {
-                        $userIdentityDetails = $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserByEmail($email));
-
-                        if ($userIdentityDetails === null) {
-                            throw new CacheException();
-                        }
-
-                        return $userIdentityDetails;
-                    }
+                    fn () => $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserByEmail($email))
                 )
             );
         } catch (CacheException $exception) {
@@ -74,15 +58,7 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
             return $this->deserializeUserIdentityDetails(
                 $this->cache->get(
                     $this->createCacheKey($nick, 'nick'),
-                    function () use ($nick) {
-                        $userIdentityDetails = $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserByNick($nick));
-
-                        if ($userIdentityDetails === null) {
-                            throw new CacheException();
-                        }
-
-                        return $userIdentityDetails;
-                    }
+                    fn () => $this->getUserIdentityDetailsAsArray($this->userIdentityResolver->getUserByNick($nick))
                 )
             );
         } catch (CacheException $exception) {
@@ -95,12 +71,12 @@ final class CachedUserIdentityResolver implements UserIdentityResolver
         return preg_replace('/[{}()\/\\\\@:]/', '_', $value . '_' . $property);
     }
 
-    private function getUserIdentityDetailsAsArray(?UserIdentityDetails $userIdentityDetails): ?array
+    private function getUserIdentityDetailsAsArray(?UserIdentityDetails $userIdentityDetails): array
     {
-        if ($userIdentityDetails !== null) {
-            return $userIdentityDetails->jsonSerialize();
+        if ($userIdentityDetails === null) {
+            throw new CacheException();
         }
-        return null;
+        return $userIdentityDetails->jsonSerialize();
     }
 
     private function deserializeUserIdentityDetails(?array $cachedUserIdentityDetails): ?UserIdentityDetails

--- a/tests/User/Keycloak/CachedUserIdentityResolverTest.php
+++ b/tests/User/Keycloak/CachedUserIdentityResolverTest.php
@@ -106,7 +106,7 @@ final class CachedUserIdentityResolverTest extends TestCase
         $this->fallbackUserIdentityResolver->expects($this->exactly(2))
             ->method('getUserById')
             ->with('null')
-            ->willReturn(Null);
+            ->willReturn(null);
 
         $this->cachedUserIdentityResolver->getUserById('null');
         $this->cachedUserIdentityResolver->getUserById('null');
@@ -151,7 +151,7 @@ final class CachedUserIdentityResolverTest extends TestCase
         $this->fallbackUserIdentityResolver->expects($this->exactly(2))
             ->method('getUserByEmail')
             ->with($nonExistingUser)
-            ->willReturn(Null);
+            ->willReturn(null);
 
         $this->cachedUserIdentityResolver->getUserByEmail($nonExistingUser);
         $this->cachedUserIdentityResolver->getUserByEmail($nonExistingUser);
@@ -195,7 +195,7 @@ final class CachedUserIdentityResolverTest extends TestCase
         $this->fallbackUserIdentityResolver->expects($this->exactly(2))
             ->method('getUserByNick')
             ->with('null')
-            ->willReturn(Null);
+            ->willReturn(null);
 
         $this->cachedUserIdentityResolver->getUserByNick('null');
         $this->cachedUserIdentityResolver->getUserByNick('null');

--- a/tests/User/Keycloak/CachedUserIdentityResolverTest.php
+++ b/tests/User/Keycloak/CachedUserIdentityResolverTest.php
@@ -101,6 +101,20 @@ final class CachedUserIdentityResolverTest extends TestCase
     /**
      * @test
      */
+    public function it_does_not_cache_when_id_is_null(): void
+    {
+        $this->fallbackUserIdentityResolver->expects($this->exactly(2))
+            ->method('getUserById')
+            ->with('null')
+            ->willReturn(Null);
+
+        $this->cachedUserIdentityResolver->getUserById('null');
+        $this->cachedUserIdentityResolver->getUserById('null');
+    }
+
+    /**
+     * @test
+     */
     public function it_can_get_an_uncached_user_by_email(): void
     {
         $this->fallbackUserIdentityResolver->expects($this->once())
@@ -131,6 +145,21 @@ final class CachedUserIdentityResolverTest extends TestCase
     /**
      * @test
      */
+    public function it_does_not_cache_when_email_is_null(): void
+    {
+        $nonExistingUser = new EmailAddress('null@null.com');
+        $this->fallbackUserIdentityResolver->expects($this->exactly(2))
+            ->method('getUserByEmail')
+            ->with($nonExistingUser)
+            ->willReturn(Null);
+
+        $this->cachedUserIdentityResolver->getUserByEmail($nonExistingUser);
+        $this->cachedUserIdentityResolver->getUserByEmail($nonExistingUser);
+    }
+
+    /**
+     * @test
+     */
     public function it_can_get_an_uncached_user_by_nick(): void
     {
         $this->fallbackUserIdentityResolver->expects($this->once())
@@ -156,5 +185,19 @@ final class CachedUserIdentityResolverTest extends TestCase
             $this->cachedUserIdentityDetails,
             $this->cachedUserIdentityResolver->getUserByNick('Jane Doe')
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_cache_when_nick_is_null(): void
+    {
+        $this->fallbackUserIdentityResolver->expects($this->exactly(2))
+            ->method('getUserByNick')
+            ->with('null')
+            ->willReturn(Null);
+
+        $this->cachedUserIdentityResolver->getUserByNick('null');
+        $this->cachedUserIdentityResolver->getUserByNick('null');
     }
 }

--- a/tests/User/Keycloak/CachedUserIdentityResolverTest.php
+++ b/tests/User/Keycloak/CachedUserIdentityResolverTest.php
@@ -27,7 +27,7 @@ final class CachedUserIdentityResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->fallbackUserIdentityResolver = $this->createMock(UserIdentityResolver::class);
-        $cache =  new ArrayAdapter();
+        $cache = new ArrayAdapter();
 
         $this->cachedUserIdentityResolver = new CachedUserIdentityResolver(
             $this->fallbackUserIdentityResolver,


### PR DESCRIPTION
### Changed

- `CachedUserIdentityResolver`: prevent caching `Null` by throwing an catching an `InvalidArgumentException` & refactor to improve readability.
- `CachedUserIdentityResolverTest`: Add unit tests to check `Null` isn't stored in the cache.

### Fixed

- `Null` is no longer cached.

---

Ticket: https://jira.publiq.be/browse/III-6541
