### PR TITLE
Docker MySQL volume location in is invalid, use correct location

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
     volumes:
-      - 'udb3-mysql:/bitnami/mysql/data'
+      - 'udb3-mysql:/opt/bitnami/mysql/data'
       - ./docker/mysql:/docker-entrypoint-initdb.d
     ports:
       - '3306:3306'


### PR DESCRIPTION
### Fixed
A recent change has moved the docker mysql volume to `/bitnami/mysql/data`.
On my machine this gives permission issues that it cannot write to this location, but `/opt/bitnami/mysql/data` does work.
I think this location is incorrect, but if somebody else could test both paths on their machine, I would be grateful.