### PR TITLE
III-6550 Formatting issue between MacOS & Jenkins

### DIFF
--- a/features/Steps/MailSteps.php
+++ b/features/Steps/MailSteps.php
@@ -31,6 +31,6 @@ trait MailSteps
 
     private function fixNewLines(string $value): string
     {
-       return str_replace("\r\n", "\n", $value);
+        return str_replace("\r\n", "\n", $value);
     }
 }

--- a/features/Steps/MailSteps.php
+++ b/features/Steps/MailSteps.php
@@ -18,8 +18,8 @@ trait MailSteps
         assertEquals($to, $mailobject->getTo()->getByIndex(0) ->toString());
         assertEquals($subject, $mailobject->getSubject());
         assertEquals(
-            $this->fixtures->loadMail($messageType),
-            $this->removeUuidFilePattern($mailobject->getContent())
+            $this->fixNewLines($this->fixtures->loadMail($messageType)),
+            $this->fixNewLines($this->removeUuidFilePattern($mailobject->getContent()))
         );
     }
 
@@ -27,5 +27,10 @@ trait MailSteps
     {
         $uuidFilePattern = '/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(pdf|xlsx|json)/i';
         return preg_replace($uuidFilePattern, '', $value);
+    }
+
+    private function fixNewLines(string $value): string
+    {
+       return str_replace("\r\n", "\n", $value);
     }
 }

--- a/features/Steps/MailSteps.php
+++ b/features/Steps/MailSteps.php
@@ -18,8 +18,8 @@ trait MailSteps
         assertEquals($to, $mailobject->getTo()->getByIndex(0)->toString());
         assertEquals($subject, $mailobject->getSubject());
         assertEquals(
-            $this->fixNewLines($this->fixtures->loadMail($messageType)),
-            $this->fixNewLines($this->removeUuidFilePattern($mailobject->getContent()))
+            $this->removeCarriageReturn($this->fixtures->loadMail($messageType)),
+            $this->removeCarriageReturn($this->removeUuidFilePattern($mailobject->getContent()))
         );
     }
 
@@ -29,7 +29,9 @@ trait MailSteps
         return preg_replace($uuidFilePattern, '', $value);
     }
 
-    private function fixNewLines(string $value): string
+    // This is needed the handle some quirky differences
+    // between MacOS & Jenkins/Linux on the CI-pipeline.
+    private function removeCarriageReturn(string $value): string
     {
         return str_replace("\r\n", "\n", $value);
     }

--- a/features/Steps/MailSteps.php
+++ b/features/Steps/MailSteps.php
@@ -15,7 +15,7 @@ trait MailSteps
     {
         $mailobject = $this->getMailClient()->getLatestEmail();
         assertEquals($from, $mailobject->getFrom()->toString());
-        assertEquals($to, $mailobject->getTo()->getByIndex(0) ->toString());
+        assertEquals($to, $mailobject->getTo()->getByIndex(0)->toString());
         assertEquals($subject, $mailobject->getSubject());
         assertEquals(
             $this->fixNewLines($this->fixtures->loadMail($messageType)),


### PR DESCRIPTION
### Added

### Changed

- `MailSteps`: add `removeCarriageReturn()` to handle the formatting quirks between `MacOs` used by devlopers & Jenkins/Linux on the CI-pipeline.

### Removed

### Fixed

- The check for emailContent, should now work both on `MacOS` & `Jenkins` 

---

Ticket: https://jira.publiq.be/browse/III-6550
