### PR TITLE
III-6300 Improve name ownership user

### DIFF
--- a/features/organizer/get-creator.feature
+++ b/features/organizer/get-creator.feature
@@ -2,7 +2,7 @@ Feature: Test getting creator of organizer
     Background:
         Given I am using the UDB3 base URL
         And I am using an UiTID v1 API key of consumer "uitdatabank"
-        And I am authorized as JWT provider v2 user "dev_e2e_test"
+        And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
         And I send and accept "application/json"
 
     Scenario: Getting the creator of an organizer as creator

--- a/features/ownership/approve.feature
+++ b/features/ownership/approve.feature
@@ -7,7 +7,7 @@ Feature: Test approving ownership
 
   Scenario: Approving ownership of an organizer as admin
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I am authorized as JWT provider v1 user "centraal_beheerder"
     When I approve the ownership with ownershipId "%{ownershipId}"
@@ -21,7 +21,7 @@ Feature: Test approving ownership
     And the JSON response at "state" should be "approved"
 
   Scenario: Approving ownership of an organizer as creator
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     When I approve the ownership with ownershipId "%{ownershipId}"
@@ -49,7 +49,7 @@ Feature: Test approving ownership
 
   Scenario: Approving an organizer as non-authorized user
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     When I send a POST request to '/ownerships/%{ownershipId}/approve'
     Then the response status should be 403

--- a/features/ownership/delete.feature
+++ b/features/ownership/delete.feature
@@ -7,7 +7,7 @@ Feature: Test deleting ownership
 
   Scenario: Deleting ownership of an organizer as admin
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I am authorized as JWT provider v1 user "centraal_beheerder"
     When I delete the ownership with ownershipId "%{ownershipId}"
@@ -22,7 +22,7 @@ Feature: Test deleting ownership
 
   Scenario: Deleting an approved ownership of an organizer as admin
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I am authorized as JWT provider v1 user "centraal_beheerder"
     And I approve the ownership with ownershipId "%{ownershipId}"
@@ -38,7 +38,7 @@ Feature: Test deleting ownership
 
   Scenario: Deleting a rejected ownership of an organizer as admin
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I am authorized as JWT provider v1 user "centraal_beheerder"
     And I reject the ownership with ownershipId "%{ownershipId}"
@@ -53,7 +53,7 @@ Feature: Test deleting ownership
     And the JSON response at "state" should be "deleted"
 
   Scenario: Deleting ownership of an organizer as creator
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     When I delete the ownership with ownershipId "%{ownershipId}"
@@ -67,7 +67,7 @@ Feature: Test deleting ownership
     And the JSON response at "state" should be "deleted"
 
   Scenario: Deleting an approved ownership of an organizer as creator
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I approve the ownership with ownershipId "%{ownershipId}"
@@ -82,7 +82,7 @@ Feature: Test deleting ownership
     And the JSON response at "state" should be "deleted"
 
   Scenario: Deleting a rejected ownership of an organizer as creator
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I reject the ownership with ownershipId "%{ownershipId}"
@@ -111,7 +111,7 @@ Feature: Test deleting ownership
 
   Scenario: Deleting an organizer as non-authorized user
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     When I send a DELETE request to '/ownerships/%{ownershipId}'
     Then the response status should be 403

--- a/features/ownership/get.feature
+++ b/features/ownership/get.feature
@@ -21,7 +21,7 @@ Feature: Test getting a single ownership by ID
   Scenario: Get the ownership as owner
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
-    When I am authorized as JWT provider v2 user "dev_e2e_test"
+    When I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I send a GET request to '/ownerships/%{ownershipId}'
     Then the response status should be 200
     And the JSON response at id should be "%{ownershipId}"

--- a/features/ownership/permission.feature
+++ b/features/ownership/permission.feature
@@ -7,7 +7,7 @@ Feature: Test permissions based on ownership
 
   Scenario: Approving the ownership of an organizer gives permission on the organizer
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
@@ -17,7 +17,7 @@ Feature: Test permissions based on ownership
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     When I am authorized as JWT provider v1 user "centraal_beheerder"
     And I approve the ownership with ownershipId "%{ownershipId}"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
@@ -29,7 +29,7 @@ Feature: Test permissions based on ownership
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I approve the ownership with ownershipId "%{ownershipId}"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
@@ -38,7 +38,7 @@ Feature: Test permissions based on ownership
     And the response status should be "204"
     And I am authorized as JWT provider v1 user "centraal_beheerder"
     And I delete the ownership with ownershipId "%{ownershipId}"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
@@ -50,7 +50,7 @@ Feature: Test permissions based on ownership
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I create a minimal place and save the "id" as "placeId"
     And I create an event from "events/event-with-organizer.json" and save the "id" as "eventId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
@@ -60,7 +60,7 @@ Feature: Test permissions based on ownership
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     When I am authorized as JWT provider v1 user "centraal_beheerder"
     And I approve the ownership with ownershipId "%{ownershipId}"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
@@ -75,7 +75,7 @@ Feature: Test permissions based on ownership
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I am authorized as JWT provider v1 user "centraal_beheerder"
     And I approve the ownership with ownershipId "%{ownershipId}"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
@@ -84,7 +84,7 @@ Feature: Test permissions based on ownership
     And the response status should be "204"
     When I am authorized as JWT provider v1 user "centraal_beheerder"
     And I delete the ownership with ownershipId "%{ownershipId}"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
@@ -96,7 +96,7 @@ Feature: Test permissions based on ownership
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I keep the value of the JSON response at "url" as "organizerUrl"
     And I create a place from "places/place-with-organizer.json" and save the "id" as "placeId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}
@@ -106,7 +106,7 @@ Feature: Test permissions based on ownership
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     When I am authorized as JWT provider v1 user "centraal_beheerder"
     And I approve the ownership with ownershipId "%{ownershipId}"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I set the JSON request payload to:
     """
         {"name": "madewithlove"}

--- a/features/ownership/reject.feature
+++ b/features/ownership/reject.feature
@@ -7,7 +7,7 @@ Feature: Test rejecting ownership
 
   Scenario: Rejecting ownership of an organizer as admin
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I am authorized as JWT provider v1 user "centraal_beheerder"
     When I reject the ownership with ownershipId "%{ownershipId}"
@@ -21,7 +21,7 @@ Feature: Test rejecting ownership
     And the JSON response at "state" should be "rejected"
 
   Scenario: Rejecting ownership of an organizer as creator
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     When I reject the ownership with ownershipId "%{ownershipId}"
@@ -49,7 +49,7 @@ Feature: Test rejecting ownership
 
   Scenario: Rejecting an organizer as non-authorized user
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I am authorized as JWT provider v2 user "dev_e2e_test"
+    And I am authorized as JWT provider v2 user "udbtestinvoerder_ownerships"
     And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     When I send a POST request to '/ownerships/%{ownershipId}/reject'
     Then the response status should be 403


### PR DESCRIPTION
### Changed
- Renamed `dev_e2e_test` to `udbtestinvoerder_ownerships` to make it more clear this user is used for ownerships only

---
Ticket: https://jira.uitdatabank.be/browse/III-6300
