### PR TITLE
III-6585 Store approver by ownership change

### DIFF
--- a/app/Migrations/Version20250302072000.php
+++ b/app/Migrations/Version20250302072000.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20250302072000 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('ownership_search');
+        $table->addColumn('approved_by', 'string', ['notnull' => false])->setLength(100);
+        $table->addColumn('rejected_by', 'string', ['notnull' => false])->setLength(100);
+        $table->addColumn('deleted_by', 'string',  ['notnull' => false])->setLength(100);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('ownership_search');
+        $table->dropColumn('approved_by');
+        $table->dropColumn('rejected_by');
+        $table->dropColumn('deleted_by');
+    }
+}

--- a/features/ownership/approve.feature
+++ b/features/ownership/approve.feature
@@ -19,6 +19,7 @@ Feature: Test approving ownership
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
     And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "state" should be "approved"
+    And the JSON response at "approvedById" should be "7a583ed3-cbc1-481d-93b1-d80fff0174dd"
 
   Scenario: Approving ownership of an organizer as creator
     And I am authorized as JWT provider v2 user "invoerder_ownerships"
@@ -33,6 +34,8 @@ Feature: Test approving ownership
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
     And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "state" should be "approved"
+    And the JSON response at "approvedById" should be "auth0|64089494e980aedd96740212"
+    And the JSON response at "approvedByEmail" should be "dev+e2etest@publiq.be"
 
   Scenario: Approving a non-existing ownership
     When I send a POST request to '/ownerships/21a5c45b-78f8-4034-ab4d-5528847860b3/approve'

--- a/features/ownership/delete.feature
+++ b/features/ownership/delete.feature
@@ -19,6 +19,7 @@ Feature: Test deleting ownership
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
     And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "state" should be "deleted"
+    And the JSON response at "deletedById" should be "7a583ed3-cbc1-481d-93b1-d80fff0174dd"
 
   Scenario: Deleting an approved ownership of an organizer as admin
     Given I create a minimal organizer and save the "id" as "organizerId"
@@ -35,6 +36,7 @@ Feature: Test deleting ownership
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
     And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "state" should be "deleted"
+    And the JSON response at "deletedById" should be "7a583ed3-cbc1-481d-93b1-d80fff0174dd"
 
   Scenario: Deleting a rejected ownership of an organizer as admin
     Given I create a minimal organizer and save the "id" as "organizerId"
@@ -51,6 +53,7 @@ Feature: Test deleting ownership
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
     And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "state" should be "deleted"
+    And the JSON response at "deletedById" should be "7a583ed3-cbc1-481d-93b1-d80fff0174dd"
 
   Scenario: Deleting ownership of an organizer as creator
     And I am authorized as JWT provider v2 user "invoerder_ownerships"
@@ -65,6 +68,8 @@ Feature: Test deleting ownership
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
     And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "state" should be "deleted"
+    And the JSON response at "deletedById" should be "auth0|64089494e980aedd96740212"
+    And the JSON response at "deletedByEmail" should be "dev+e2etest@publiq.be"
 
   Scenario: Deleting an approved ownership of an organizer as creator
     And I am authorized as JWT provider v2 user "invoerder_ownerships"
@@ -80,6 +85,8 @@ Feature: Test deleting ownership
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
     And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "state" should be "deleted"
+    And the JSON response at "deletedById" should be "auth0|64089494e980aedd96740212"
+    And the JSON response at "deletedByEmail" should be "dev+e2etest@publiq.be"
 
   Scenario: Deleting a rejected ownership of an organizer as creator
     And I am authorized as JWT provider v2 user "invoerder_ownerships"
@@ -95,6 +102,8 @@ Feature: Test deleting ownership
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
     And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "state" should be "deleted"
+    And the JSON response at "deletedById" should be "auth0|64089494e980aedd96740212"
+    And the JSON response at "deletedByEmail" should be "dev+e2etest@publiq.be"
 
   Scenario: Deleting a non-existing ownership
     When I send a DELETE request to '/ownerships/21a5c45b-78f8-4034-ab4d-5528847860b3'

--- a/features/ownership/reject.feature
+++ b/features/ownership/reject.feature
@@ -19,6 +19,7 @@ Feature: Test rejecting ownership
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
     And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "state" should be "rejected"
+    And the JSON response at "rejectedById" should be "7a583ed3-cbc1-481d-93b1-d80fff0174dd"
 
   Scenario: Rejecting ownership of an organizer as creator
     And I am authorized as JWT provider v2 user "invoerder_ownerships"
@@ -33,6 +34,8 @@ Feature: Test rejecting ownership
     And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
     And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
     And the JSON response at "state" should be "rejected"
+    And the JSON response at "rejectedById" should be "auth0|64089494e980aedd96740212"
+    And the JSON response at "rejectedByEmail" should be "dev+e2etest@publiq.be"
 
   Scenario: Rejecting a non-existing ownership
     When I send a POST request to '/ownerships/21a5c45b-78f8-4034-ab4d-5528847860b3/reject'

--- a/src/Http/Ownership/ApproveOwnershipRequestHandler.php
+++ b/src/Http/Ownership/ApproveOwnershipRequestHandler.php
@@ -39,7 +39,7 @@ final class ApproveOwnershipRequestHandler implements RequestHandlerInterface
         $this->ownershipStatusGuard->isAllowedToApprove($ownershipId, $this->currentUser);
 
         $this->commandBus->dispatch(
-            new ApproveOwnership(new Uuid($ownershipId))
+            new ApproveOwnership(new Uuid($ownershipId), $this->currentUser->getId())
         );
 
         return new JsonResponse(

--- a/src/Http/Ownership/DeleteOwnershipRequestHandler.php
+++ b/src/Http/Ownership/DeleteOwnershipRequestHandler.php
@@ -39,7 +39,7 @@ final class DeleteOwnershipRequestHandler implements RequestHandlerInterface
         $this->ownershipStatusGuard->isAllowedToDelete($ownershipId, $this->currentUser);
 
         $this->commandBus->dispatch(
-            new DeleteOwnership(new Uuid($ownershipId))
+            new DeleteOwnership(new Uuid($ownershipId), $this->currentUser->getId())
         );
 
         return new JsonResponse(

--- a/src/Http/Ownership/RejectOwnershipRequestHandler.php
+++ b/src/Http/Ownership/RejectOwnershipRequestHandler.php
@@ -38,7 +38,7 @@ final class RejectOwnershipRequestHandler implements RequestHandlerInterface
 
         $this->ownershipStatusGuard->isAllowedToReject($ownershipId, $this->currentUser);
 
-        $this->commandBus->dispatch(new RejectOwnership(new Uuid($ownershipId)));
+        $this->commandBus->dispatch(new RejectOwnership(new Uuid($ownershipId), $this->currentUser->getId()));
 
         return new JsonResponse(
             [],

--- a/src/Ownership/CommandHandlers/ApproveOwnershipHandler.php
+++ b/src/Ownership/CommandHandlers/ApproveOwnershipHandler.php
@@ -25,7 +25,7 @@ final class ApproveOwnershipHandler implements CommandHandler
 
         $ownership = $this->ownershipRepository->load($command->getId()->toString());
 
-        $ownership->approve();
+        $ownership->approve($command->getUserId());
 
         $this->ownershipRepository->save($ownership);
     }

--- a/src/Ownership/CommandHandlers/DeleteOwnershipHandler.php
+++ b/src/Ownership/CommandHandlers/DeleteOwnershipHandler.php
@@ -25,7 +25,7 @@ final class DeleteOwnershipHandler implements CommandHandler
 
         $ownership = $this->ownershipRepository->load($command->getId()->toString());
 
-        $ownership->delete();
+        $ownership->delete($command->getUserId());
 
         $this->ownershipRepository->save($ownership);
     }

--- a/src/Ownership/CommandHandlers/RejectOwnershipHandler.php
+++ b/src/Ownership/CommandHandlers/RejectOwnershipHandler.php
@@ -25,7 +25,7 @@ final class RejectOwnershipHandler implements CommandHandler
 
         $ownership = $this->ownershipRepository->load($command->getId()->toString());
 
-        $ownership->reject();
+        $ownership->reject($command->getUserId());
 
         $this->ownershipRepository->save($ownership);
     }

--- a/src/Ownership/Commands/ApproveOwnership.php
+++ b/src/Ownership/Commands/ApproveOwnership.php
@@ -9,14 +9,21 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
 final class ApproveOwnership
 {
     private Uuid $id;
+    private string $userId;
 
-    public function __construct(Uuid $id)
+    public function __construct(Uuid $id, string $userId)
     {
         $this->id = $id;
+        $this->userId = $userId;
     }
 
     public function getId(): Uuid
     {
         return $this->id;
+    }
+
+    public function getUserId(): string
+    {
+        return $this->userId;
     }
 }

--- a/src/Ownership/Commands/DeleteOwnership.php
+++ b/src/Ownership/Commands/DeleteOwnership.php
@@ -9,14 +9,21 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
 final class DeleteOwnership
 {
     private Uuid $id;
+    private string $userId;
 
-    public function __construct(Uuid $id)
+    public function __construct(Uuid $id, string $userId)
     {
         $this->id = $id;
+        $this->userId = $userId;
     }
 
     public function getId(): Uuid
     {
         return $this->id;
+    }
+
+    public function getUserId(): string
+    {
+        return $this->userId;
     }
 }

--- a/src/Ownership/Commands/RejectOwnership.php
+++ b/src/Ownership/Commands/RejectOwnership.php
@@ -9,14 +9,21 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
 final class RejectOwnership
 {
     private Uuid $id;
+    private string $userId;
 
-    public function __construct(Uuid $id)
+    public function __construct(Uuid $id, string $userId)
     {
         $this->id = $id;
+        $this->userId = $userId;
     }
 
     public function getId(): Uuid
     {
         return $this->id;
+    }
+
+    public function getUserId(): string
+    {
+        return $this->userId;
     }
 }

--- a/src/Ownership/Events/OwnershipApproved.php
+++ b/src/Ownership/Events/OwnershipApproved.php
@@ -9,10 +9,12 @@ use Broadway\Serializer\Serializable;
 final class OwnershipApproved implements Serializable
 {
     private string $id;
+    private string $userId;
 
-    public function __construct(string $id)
+    public function __construct(string $id, string $userId)
     {
         $this->id = $id;
+        $this->userId = $userId;
     }
 
     public function getId(): string
@@ -20,15 +22,20 @@ final class OwnershipApproved implements Serializable
         return $this->id;
     }
 
+    public function getUserId(): string
+    {
+        return $this->userId;
+    }
+
     public static function deserialize(array $data): self
     {
-        return new OwnershipApproved($data['ownershipId']);
+        return new OwnershipApproved($data['ownershipId'], $data['userId']);
     }
 
     public function serialize(): array
     {
         return [
             'ownershipId' => $this->id,
-        ];
+            'userId' => $this->userId        ];
     }
 }

--- a/src/Ownership/Events/OwnershipDeleted.php
+++ b/src/Ownership/Events/OwnershipDeleted.php
@@ -9,10 +9,12 @@ use Broadway\Serializer\Serializable;
 final class OwnershipDeleted implements Serializable
 {
     private string $id;
+    private string $userId;
 
-    public function __construct(string $id)
+    public function __construct(string $id, string $userId)
     {
         $this->id = $id;
+        $this->userId = $userId;
     }
 
     public function getId(): string
@@ -20,15 +22,21 @@ final class OwnershipDeleted implements Serializable
         return $this->id;
     }
 
+    public function getUserId(): string
+    {
+        return $this->userId;
+    }
+
     public static function deserialize(array $data): self
     {
-        return new OwnershipDeleted($data['ownershipId']);
+        return new OwnershipDeleted($data['ownershipId'], $data['userId']);
     }
 
     public function serialize(): array
     {
         return [
             'ownershipId' => $this->id,
+            'userId' => $this->userId
         ];
     }
 }

--- a/src/Ownership/Events/OwnershipRejected.php
+++ b/src/Ownership/Events/OwnershipRejected.php
@@ -9,10 +9,12 @@ use Broadway\Serializer\Serializable;
 final class OwnershipRejected implements Serializable
 {
     private string $id;
+    private string $userId;
 
-    public function __construct(string $id)
+    public function __construct(string $id, string $userId)
     {
         $this->id = $id;
+        $this->userId = $userId;
     }
 
     public function getId(): string
@@ -20,15 +22,21 @@ final class OwnershipRejected implements Serializable
         return $this->id;
     }
 
+    public function getUserId(): string
+    {
+        return $this->userId;
+    }
+
     public static function deserialize(array $data): self
     {
-        return new OwnershipRejected($data['ownershipId']);
+        return new OwnershipRejected($data['ownershipId'], $data['userId']);
     }
 
     public function serialize(): array
     {
         return [
             'ownershipId' => $this->id,
+            'userId' => $this->userId
         ];
     }
 }

--- a/src/Ownership/Ownership.php
+++ b/src/Ownership/Ownership.php
@@ -45,26 +45,26 @@ final class Ownership extends EventSourcedAggregateRoot
         return $ownership;
     }
 
-    public function approve(): void
+    public function approve(string $userId): void
     {
         if ($this->state->sameAs(OwnershipState::requested())) {
             $this->apply(
-                new OwnershipApproved($this->id)
+                new OwnershipApproved($this->id, $userId)
             );
         }
     }
 
-    public function reject(): void
+    public function reject(string $userId): void
     {
         if ($this->state->sameAs(OwnershipState::requested())) {
-            $this->apply(new OwnershipRejected($this->id));
+            $this->apply(new OwnershipRejected($this->id, $userId));
         }
     }
 
-    public function delete(): void
+    public function delete(string $userId): void
     {
         if (!$this->state->sameAs(OwnershipState::deleted())) {
-            $this->apply(new OwnershipDeleted($this->id));
+            $this->apply(new OwnershipDeleted($this->id, $userId));
         }
     }
 

--- a/src/Ownership/Readmodels/OwnershipLDProjector.php
+++ b/src/Ownership/Readmodels/OwnershipLDProjector.php
@@ -70,11 +70,19 @@ final class OwnershipLDProjector implements EventListener
         $body->requesterId = $ownershipRequested->getRequesterId();
         $body->requesterEmail = $requesterDetails !== null ? $requesterDetails->getEmailAddress() : null;
         $body->state = OwnershipState::requested()->toString();
-
         $body->created = DateTimeFactory::fromFormat(
             DateTime::FORMAT_STRING,
             $domainMessage->getRecordedOn()->toString()
         )->format('c');
+
+        $body->approvedById = null;
+        $body->approvedByEmail = null;
+
+        $body->rejectedById = null;
+        $body->rejectedByEmail = null;
+
+        $body->deletedById = null;
+        $body->deletedByEmail = null;
 
         return $jsonDocument->withBody($body);
     }
@@ -86,6 +94,10 @@ final class OwnershipLDProjector implements EventListener
         $body = $jsonDocument->getBody();
         $body->state = OwnershipState::approved()->toString();
 
+        $approverDetails = $this->userIdentityResolver->getUserById($ownershipApproved->getUserId());
+        $body->approvedById = $ownershipApproved->getUserId();
+        $body->approvedByEmail = $approverDetails !== null ? $approverDetails->getEmailAddress() : null;
+
         return $jsonDocument->withBody($body);
     }
 
@@ -96,6 +108,10 @@ final class OwnershipLDProjector implements EventListener
         $body = $jsonDocument->getBody();
         $body->state = OwnershipState::rejected()->toString();
 
+        $rejecterDetails = $this->userIdentityResolver->getUserById($ownershipRejected->getUserId());
+        $body->rejectedById = $ownershipRejected->getUserId();
+        $body->rejectedByEmail = $rejecterDetails !== null ? $rejecterDetails->getEmailAddress() : null;
+
         return $jsonDocument->withBody($body);
     }
 
@@ -105,6 +121,10 @@ final class OwnershipLDProjector implements EventListener
 
         $body = $jsonDocument->getBody();
         $body->state = OwnershipState::deleted()->toString();
+
+        $deleterDetails = $this->userIdentityResolver->getUserById($ownershipDeleted->getUserId());
+        $body->deletedById = $ownershipDeleted->getUserId();
+        $body->deletedByEmail = $deleterDetails !== null ? $deleterDetails->getEmailAddress() : null;
 
         return $jsonDocument->withBody($body);
     }

--- a/src/Ownership/Readmodels/OwnershipSearchProjector.php
+++ b/src/Ownership/Readmodels/OwnershipSearchProjector.php
@@ -57,7 +57,8 @@ final class OwnershipSearchProjector implements EventListener
     {
         $this->ownershipSearchRepository->updateState(
             $ownershipApproved->getId(),
-            OwnershipState::approved()
+            OwnershipState::approved(),
+            $ownershipApproved->getUserId(),
         );
     }
 
@@ -65,7 +66,8 @@ final class OwnershipSearchProjector implements EventListener
     {
         $this->ownershipSearchRepository->updateState(
             $ownershipRejected->getId(),
-            OwnershipState::rejected()
+            OwnershipState::rejected(),
+            $ownershipRejected->getUserId(),
         );
     }
 
@@ -73,7 +75,8 @@ final class OwnershipSearchProjector implements EventListener
     {
         $this->ownershipSearchRepository->updateState(
             $ownershipDeleted->getId(),
-            OwnershipState::deleted()
+            OwnershipState::deleted(),
+            $ownershipDeleted->getUserId(),
         );
     }
 }

--- a/src/Ownership/Repositories/OwnershipItem.php
+++ b/src/Ownership/Repositories/OwnershipItem.php
@@ -13,7 +13,10 @@ final class OwnershipItem
     private string $itemType;
     private string $ownerId;
     private string $state;
-    private ?Uuid $roleId;
+    private ?Uuid $roleId = null;
+    private ?string $approvedBy = null;
+    private ?string $rejectedBy = null;
+    private ?string $deletedBy = null;
 
     public function __construct(
         string $id,
@@ -27,7 +30,6 @@ final class OwnershipItem
         $this->itemType = $itemType;
         $this->ownerId = $ownerId;
         $this->state = $state;
-        $this->roleId = null;
     }
 
     public function withRoleId(Uuid $roleId): self
@@ -65,5 +67,41 @@ final class OwnershipItem
     public function getRoleId(): ?Uuid
     {
         return $this->roleId;
+    }
+
+    public function getApprovedBy(): ?string
+    {
+        return $this->approvedBy;
+    }
+
+    public function getRejectedBy(): ?string
+    {
+        return $this->rejectedBy;
+    }
+
+    public function getDeletedBy(): ?string
+    {
+        return $this->deletedBy;
+    }
+
+    public function withApprovedBy(string $userId): self
+    {
+        $ownershipItem = clone $this;
+        $ownershipItem->approvedBy = $userId;
+        return $ownershipItem;
+    }
+
+    public function withRejectedBy(string $userId): self
+    {
+        $ownershipItem = clone $this;
+        $ownershipItem->rejectedBy = $userId;
+        return $ownershipItem;
+    }
+
+    public function withDeletedBy(string $userId): self
+    {
+        $ownershipItem = clone $this;
+        $ownershipItem->deletedBy = $userId;
+        return $ownershipItem;
     }
 }

--- a/src/Ownership/Repositories/Search/OwnershipSearchRepository.php
+++ b/src/Ownership/Repositories/Search/OwnershipSearchRepository.php
@@ -15,7 +15,7 @@ interface OwnershipSearchRepository
 {
     public function save(OwnershipItem $ownershipSearchItem): void;
 
-    public function updateState(string $id, OwnershipState $state): void;
+    public function updateState(string $id, OwnershipState $state, string $actionBy): void;
 
     public function updateRoleId(string $id, ?Uuid $roleId): void;
 

--- a/tests/Http/Ownership/ApproveOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/ApproveOwnershipRequestHandlerTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\TestCase;
 
 class ApproveOwnershipRequestHandlerTest extends TestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     use AssertApiProblemTrait;
 
     private TraceableCommandBus $commandBus;
@@ -83,7 +85,7 @@ class ApproveOwnershipRequestHandlerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
-                new ApproveOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')),
+                new ApproveOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'), self::USER_ID),
             ],
             $this->commandBus->getRecordedCommands()
         );
@@ -119,7 +121,7 @@ class ApproveOwnershipRequestHandlerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
-                new ApproveOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')),
+                new ApproveOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'), self::USER_ID),
             ],
             $this->commandBus->getRecordedCommands()
         );

--- a/tests/Http/Ownership/DeleteOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/DeleteOwnershipRequestHandlerTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\TestCase;
 
 class DeleteOwnershipRequestHandlerTest extends TestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     use AssertApiProblemTrait;
 
     private TraceableCommandBus $commandBus;
@@ -83,7 +85,7 @@ class DeleteOwnershipRequestHandlerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
-                new DeleteOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')),
+                new DeleteOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'), self::USER_ID),
             ],
             $this->commandBus->getRecordedCommands()
         );
@@ -119,7 +121,7 @@ class DeleteOwnershipRequestHandlerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
-                new DeleteOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')),
+                new DeleteOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'), self::USER_ID),
             ],
             $this->commandBus->getRecordedCommands()
         );

--- a/tests/Http/Ownership/RejectOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/RejectOwnershipRequestHandlerTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\TestCase;
 
 class RejectOwnershipRequestHandlerTest extends TestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     use AssertApiProblemTrait;
 
     private TraceableCommandBus $commandBus;
@@ -83,7 +85,7 @@ class RejectOwnershipRequestHandlerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
-                new RejectOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')),
+                new RejectOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'), self::USER_ID),
             ],
             $this->commandBus->getRecordedCommands()
         );
@@ -119,7 +121,7 @@ class RejectOwnershipRequestHandlerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals(
             [
-                new RejectOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')),
+                new RejectOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'), self::USER_ID),
             ],
             $this->commandBus->getRecordedCommands()
         );

--- a/tests/Ownership/CommandHandlers/ApproveOwnershipHandlerTest.php
+++ b/tests/Ownership/CommandHandlers/ApproveOwnershipHandlerTest.php
@@ -16,6 +16,8 @@ use CultuurNet\UDB3\Ownership\OwnershipRepository;
 
 class ApproveOwnershipHandlerTest extends CommandHandlerScenarioTestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
     {
         return new ApproveOwnershipHandler(new OwnershipRepository($eventStore, $eventBus));
@@ -38,10 +40,11 @@ class ApproveOwnershipHandlerTest extends CommandHandlerScenarioTestCase
                 ),
             ])
             ->when(new ApproveOwnership(
-                new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
+                new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                self::USER_ID
             ))
             ->then([
-                new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID),
             ]);
     }
 }

--- a/tests/Ownership/CommandHandlers/DeleteOwnershipHandlerTest.php
+++ b/tests/Ownership/CommandHandlers/DeleteOwnershipHandlerTest.php
@@ -16,6 +16,8 @@ use CultuurNet\UDB3\Ownership\OwnershipRepository;
 
 class DeleteOwnershipHandlerTest extends CommandHandlerScenarioTestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
     {
         return new DeleteOwnershipHandler(new OwnershipRepository($eventStore, $eventBus));
@@ -38,10 +40,11 @@ class DeleteOwnershipHandlerTest extends CommandHandlerScenarioTestCase
                 ),
             ])
             ->when(new DeleteOwnership(
-                new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
+                new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                self::USER_ID,
             ))
             ->then([
-                new OwnershipDeleted('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                new OwnershipDeleted('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',  self::USER_ID),
             ]);
     }
 }

--- a/tests/Ownership/CommandHandlers/RejectOwnershipHandlerTest.php
+++ b/tests/Ownership/CommandHandlers/RejectOwnershipHandlerTest.php
@@ -16,6 +16,8 @@ use CultuurNet\UDB3\Ownership\OwnershipRepository;
 
 class RejectOwnershipHandlerTest extends CommandHandlerScenarioTestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
     {
         return new RejectOwnershipHandler(new OwnershipRepository($eventStore, $eventBus));
@@ -38,10 +40,10 @@ class RejectOwnershipHandlerTest extends CommandHandlerScenarioTestCase
                 ),
             ])
             ->when(
-                new RejectOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'))
+                new RejectOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'), self::USER_ID)
             )
             ->then([
-                new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID),
             ]);
     }
 }

--- a/tests/Ownership/Commands/ApproveOwnershipTest.php
+++ b/tests/Ownership/Commands/ApproveOwnershipTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 class ApproveOwnershipTest extends TestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     private ApproveOwnership $approveOwnership;
 
     protected function setUp(): void
@@ -16,7 +18,8 @@ class ApproveOwnershipTest extends TestCase
         parent::setUp();
 
         $this->approveOwnership = new ApproveOwnership(
-            new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
+            new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+            self::USER_ID
         );
     }
 
@@ -28,6 +31,15 @@ class ApproveOwnershipTest extends TestCase
         $this->assertEquals(
             new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
             $this->approveOwnership->getId()
+        );
+    }
+
+    /** @test */
+    public function it_stores_a_user_id(): void
+    {
+        $this->assertEquals(
+            self::USER_ID,
+            $this->approveOwnership->getUserId()
         );
     }
 }

--- a/tests/Ownership/Commands/DeleteOwnershipTest.php
+++ b/tests/Ownership/Commands/DeleteOwnershipTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 class DeleteOwnershipTest extends TestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     private DeleteOwnership $deleteOwnership;
 
     protected function setUp(): void
@@ -16,7 +18,8 @@ class DeleteOwnershipTest extends TestCase
         parent::setUp();
 
         $this->deleteOwnership = new DeleteOwnership(
-            new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
+            new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+            self::USER_ID
         );
     }
 
@@ -28,6 +31,15 @@ class DeleteOwnershipTest extends TestCase
         $this->assertEquals(
             new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
             $this->deleteOwnership->getId()
+        );
+    }
+
+    /** @test */
+    public function it_stores_a_user_id(): void
+    {
+        $this->assertEquals(
+            self::USER_ID,
+            $this->deleteOwnership->getUserId()
         );
     }
 }

--- a/tests/Ownership/Commands/RejectOwnershipTest.php
+++ b/tests/Ownership/Commands/RejectOwnershipTest.php
@@ -9,13 +9,15 @@ use PHPUnit\Framework\TestCase;
 
 class RejectOwnershipTest extends TestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     private RejectOwnership $rejectOwnership;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->rejectOwnership = new RejectOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'));
+        $this->rejectOwnership = new RejectOwnership(new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'), self::USER_ID);
     }
 
     /**
@@ -26,6 +28,15 @@ class RejectOwnershipTest extends TestCase
         $this->assertEquals(
             new Uuid('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
             $this->rejectOwnership->getId()
+        );
+    }
+
+    /** @test */
+    public function it_stores_a_user_id(): void
+    {
+        $this->assertEquals(
+            self::USER_ID,
+            $this->rejectOwnership->getUserId()
         );
     }
 }

--- a/tests/Ownership/Events/OwnershipApprovedTest.php
+++ b/tests/Ownership/Events/OwnershipApprovedTest.php
@@ -8,13 +8,15 @@ use PHPUnit\Framework\TestCase;
 
 class OwnershipApprovedTest extends TestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     private OwnershipApproved $ownershipApproved;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->ownershipApproved = new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e');
+        $this->ownershipApproved = new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID);
     }
 
     /**
@@ -28,6 +30,15 @@ class OwnershipApprovedTest extends TestCase
         );
     }
 
+    /** @test */
+    public function it_stores_a_user_id(): void
+    {
+        $this->assertEquals(
+            self::USER_ID,
+            $this->ownershipApproved->getUserId()
+        );
+    }
+
     /**
      * @test
     */
@@ -36,6 +47,7 @@ class OwnershipApprovedTest extends TestCase
         $this->assertEquals(
             [
                 'ownershipId' => 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+                'userId' => self::USER_ID,
             ],
             $this->ownershipApproved->serialize()
         );
@@ -48,6 +60,7 @@ class OwnershipApprovedTest extends TestCase
     {
         $serialized = [
             'ownershipId' => 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+            'userId' => self::USER_ID,
         ];
 
         $this->assertEquals($this->ownershipApproved, OwnershipApproved::deserialize($serialized));

--- a/tests/Ownership/Events/OwnershipDeletedTest.php
+++ b/tests/Ownership/Events/OwnershipDeletedTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 class OwnershipDeletedTest extends TestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     private OwnershipDeleted $ownershipDeleted;
 
     protected function setUp(): void
@@ -15,7 +17,8 @@ class OwnershipDeletedTest extends TestCase
         parent::setUp();
 
         $this->ownershipDeleted = new OwnershipDeleted(
-            'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'
+            'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+            self::USER_ID
         );
     }
 
@@ -27,6 +30,15 @@ class OwnershipDeletedTest extends TestCase
         $this->assertEquals(
             'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
             $this->ownershipDeleted->getId()
+        );
+    }
+
+    /** @test */
+    public function it_stores_a_user_id(): void
+    {
+        $this->assertEquals(
+            self::USER_ID,
+            $this->ownershipDeleted->getUserId()
         );
     }
 }

--- a/tests/Ownership/Events/OwnershipRejectedTest.php
+++ b/tests/Ownership/Events/OwnershipRejectedTest.php
@@ -8,13 +8,15 @@ use PHPUnit\Framework\TestCase;
 
 class OwnershipRejectedTest extends TestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     private OwnershipRejected $ownershipRejected;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->ownershipRejected = new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e');
+        $this->ownershipRejected = new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID);
     }
 
     /**
@@ -28,6 +30,15 @@ class OwnershipRejectedTest extends TestCase
         );
     }
 
+    /** @test */
+    public function it_stores_a_user_id(): void
+    {
+        $this->assertEquals(
+            self::USER_ID,
+            $this->ownershipRejected->getUserId()
+        );
+    }
+
     /**
      * @test
      */
@@ -36,6 +47,7 @@ class OwnershipRejectedTest extends TestCase
         $this->assertEquals(
             [
                 'ownershipId' => 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+                'userId' => self::USER_ID,
             ],
             $this->ownershipRejected->serialize()
         );
@@ -48,6 +60,7 @@ class OwnershipRejectedTest extends TestCase
     {
         $serialized = [
             'ownershipId' => 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+            'userId' => self::USER_ID,
         ];
 
         $this->assertEquals($this->ownershipRejected, OwnershipRejected::deserialize($serialized));

--- a/tests/Ownership/OwnershipTest.php
+++ b/tests/Ownership/OwnershipTest.php
@@ -15,6 +15,8 @@ use CultuurNet\UDB3\Ownership\Events\OwnershipRequested;
 
 class OwnershipTest extends AggregateRootScenarioTestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
+
     protected function getAggregateRootClass(): string
     {
         return Ownership::class;
@@ -63,10 +65,10 @@ class OwnershipTest extends AggregateRootScenarioTestCase
                 ),
             ])
             ->when(function (Ownership $ownership) {
-                $ownership->approve();
+                $ownership->approve(self::USER_ID);
             })
             ->then([
-                new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID),
             ]);
     }
 
@@ -85,10 +87,10 @@ class OwnershipTest extends AggregateRootScenarioTestCase
                     'auth0|63e22626e39a8ca1264bd29b',
                     'google-oauth2|102486314601596809843'
                 ),
-                new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID),
             ])
             ->when(function (Ownership $ownership) {
-                $ownership->approve();
+                $ownership->approve(self::USER_ID);
             })
             ->then([]);
     }
@@ -110,10 +112,10 @@ class OwnershipTest extends AggregateRootScenarioTestCase
                 ),
             ])
             ->when(function (Ownership $ownership) {
-                $ownership->reject();
+                $ownership->reject(self::USER_ID);
             })
             ->then([
-                new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID),
             ]);
     }
 
@@ -132,10 +134,10 @@ class OwnershipTest extends AggregateRootScenarioTestCase
                     'auth0|63e22626e39a8ca1264bd29b',
                     'google-oauth2|102486314601596809843'
                 ),
-                new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID),
             ])
             ->when(function (Ownership $ownership) {
-                $ownership->reject();
+                $ownership->reject(self::USER_ID);
             })
             ->then([]);
     }
@@ -150,10 +152,10 @@ class OwnershipTest extends AggregateRootScenarioTestCase
             ->withAggregateId('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e')
             ->given($givens)
             ->when(function (Ownership $ownership) {
-                $ownership->delete();
+                $ownership->delete(self::USER_ID);
             })
             ->then([
-                new OwnershipDeleted('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                new OwnershipDeleted('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID),
             ]);
     }
 
@@ -176,13 +178,13 @@ class OwnershipTest extends AggregateRootScenarioTestCase
             'approved' => [
                 [
                     $ownershipRequested,
-                    new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                    new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID),
                 ],
             ],
             'rejected' => [
                 [
                     $ownershipRequested,
-                    new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                    new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID),
                 ],
             ],
         ];
@@ -203,10 +205,10 @@ class OwnershipTest extends AggregateRootScenarioTestCase
                     'auth0|63e22626e39a8ca1264bd29b',
                     'google-oauth2|102486314601596809843'
                 ),
-                new OwnershipDeleted('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e'),
+                new OwnershipDeleted('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', self::USER_ID),
             ])
             ->when(function (Ownership $ownership) {
-                $ownership->delete();
+                $ownership->delete(self::USER_ID);
             })
             ->then([]);
     }

--- a/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
+++ b/tests/Ownership/Readmodels/OwnershipPermissionProjectorTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework\TestCase;
 
 class OwnershipPermissionProjectorTest extends TestCase
 {
+    private const USER_ID = 'auth0|63e22626e39a8ca1264bd29b';
     private const ROLE_ID = '8d17cffe-6f28-459c-8627-1f6345f8b296';
     private TraceableAuthorizedCommandBus $commandBus;
 
@@ -71,7 +72,7 @@ class OwnershipPermissionProjectorTest extends TestCase
         $roleId = new Uuid(self::ROLE_ID);
         $recordedOn = RecordedOn::fromBroadwayDateTime(DateTime::fromString('2024-02-19T14:15:16Z'));
 
-        $ownershipRequested = new OwnershipApproved($ownershipId);
+        $ownershipRequested = new OwnershipApproved($ownershipId, self::USER_ID);
 
         $domainMessage = new DomainMessage(
             $ownershipId,
@@ -150,7 +151,7 @@ class OwnershipPermissionProjectorTest extends TestCase
         $roleId = new Uuid(self::ROLE_ID);
         $recordedOn = RecordedOn::fromBroadwayDateTime(DateTime::fromString('2024-02-19T14:15:16Z'));
 
-        $ownershipRequested = new OwnershipApproved($ownershipId);
+        $ownershipRequested = new OwnershipApproved($ownershipId, self::USER_ID);
 
         $domainMessage = new DomainMessage(
             $ownershipId,
@@ -222,7 +223,7 @@ class OwnershipPermissionProjectorTest extends TestCase
         $itemId = '9e68dafc-01d8-4c1c-9612-599c918b981d';
         $recordedOn = RecordedOn::fromBroadwayDateTime(DateTime::fromString('2024-02-19T14:15:16Z'));
 
-        $ownershipRequested = new OwnershipDeleted($ownershipId);
+        $ownershipRequested = new OwnershipDeleted($ownershipId, self::USER_ID);
 
         $domainMessage = new DomainMessage(
             $ownershipId,

--- a/tests/Ownership/Readmodels/OwnershipSearchProjectorTest.php
+++ b/tests/Ownership/Readmodels/OwnershipSearchProjectorTest.php
@@ -65,7 +65,7 @@ class OwnershipSearchProjectorTest extends TestCase
      */
     public function it_handles_ownership_approved(): void
     {
-        $ownershipApproved = new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e');
+        $ownershipApproved = new OwnershipApproved('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', 'auth0|63e22626e39a8ca1264bd29b');
 
         $this->ownershipSearchRepository->expects($this->once())
             ->method('updateState')
@@ -82,7 +82,7 @@ class OwnershipSearchProjectorTest extends TestCase
      */
     public function it_handles_ownership_rejected(): void
     {
-        $ownershipRejected = new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e');
+        $ownershipRejected = new OwnershipRejected('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', 'auth0|63e22626e39a8ca1264bd29b');
 
         $this->ownershipSearchRepository->expects($this->once())
             ->method('updateState')
@@ -99,7 +99,7 @@ class OwnershipSearchProjectorTest extends TestCase
      */
     public function it_handles_ownership_deleted(): void
     {
-        $ownershipDeleted = new OwnershipDeleted('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e');
+        $ownershipDeleted = new OwnershipDeleted('e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e', 'auth0|63e22626e39a8ca1264bd29b');
 
         $this->ownershipSearchRepository->expects($this->once())
             ->method('updateState')

--- a/tests/Ownership/Repositories/OwnershipItemTest.php
+++ b/tests/Ownership/Repositories/OwnershipItemTest.php
@@ -64,4 +64,28 @@ class OwnershipItemTest extends TestCase
             $this->ownershipItem->getState()
         );
     }
+
+    public function it_can_set_approved_by(): void
+    {
+        $this->assertEquals(
+            'auth0|63e22626e39a8ca1264bd29b',
+            $this->ownershipItem->withApprovedBy('auth0|63e22626e39a8ca1264bd29b')
+        );
+    }
+
+    public function it_can_set_denied_by(): void
+    {
+        $this->assertEquals(
+            'auth0|63e22626e39a8ca1264bd29b',
+            $this->ownershipItem->withRejectedBy('auth0|63e22626e39a8ca1264bd29b')
+        );
+    }
+
+    public function it_can_set_deleted_by(): void
+    {
+        $this->assertEquals(
+            'auth0|63e22626e39a8ca1264bd29b',
+            $this->ownershipItem->withDeletedBy('auth0|63e22626e39a8ca1264bd29b')
+        );
+    }
 }


### PR DESCRIPTION
### Added
- Added 3 new fields to ownership table approved_by, rejected_by and deleted_by, storing the userid of the person doing the respective action.
- Also updated the matching JSON projections, I also fetch the emails of the relevant person from Keycloak
- Update feature tests to prove working concept

### Know limitation
Currently I am just tracking the last approved/rejecter/deleter, not the entire history. If this would really be necessary we could retrieve it from the event store.

---

Ticket: https://jira.uitdatabank.be/browse/III-6585
