### PR TITLE
III-6587 Cannot re-approve user for ownership

### DIFF
--- a/app/Migrations/Version20250302072001.php
+++ b/app/Migrations/Version20250302072001.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20250302072001 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('mails_sent');
+
+        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+
+        $table->dropPrimaryKey();
+        $table->setPrimaryKey(['id']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('mails_sent');
+
+        $table->dropPrimaryKey();
+        $table->dropColumn('id');
+        $table->setPrimaryKey(['identifier', 'type']);
+    }
+}

--- a/features/ownership/approve.feature
+++ b/features/ownership/approve.feature
@@ -65,3 +65,23 @@ Feature: Test approving ownership
         "detail": "You are not allowed to approve this ownership"
       }
       """
+
+  Scenario: Re approve a rejected ownership
+    Given I create a minimal organizer and save the "id" as "organizerId"
+    And I am authorized as JWT provider v2 user "invoerder_ownerships"
+    And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    And I am authorized as JWT provider v1 user "centraal_beheerder"
+    When I approve the ownership with ownershipId "%{ownershipId}"
+
+    When I reject the ownership with ownershipId "%{ownershipId}"
+
+    When I approve the ownership with ownershipId "%{ownershipId}"
+    And I get the ownership with ownershipId "%{ownershipId}"
+    Then the JSON response at "id" should be "%{ownershipId}"
+    And the JSON response at "itemId" should be "%{organizerId}"
+    And the JSON response at "itemType" should be "organizer"
+    And the JSON response at "ownerId" should be "auth0|64089494e980aedd96740212"
+    And the JSON response at "ownerEmail" should be "dev+e2etest@publiq.be"
+    And the JSON response at "requesterId" should be "auth0|64089494e980aedd96740212"
+    And the JSON response at "state" should be "approved"
+    And the JSON response at "approvedById" should be "7a583ed3-cbc1-481d-93b1-d80fff0174dd"

--- a/src/Mailer/Handler/SendOwnershipMailCommandHandler.php
+++ b/src/Mailer/Handler/SendOwnershipMailCommandHandler.php
@@ -101,11 +101,6 @@ final class SendOwnershipMailCommandHandler implements CommandHandler
     {
         $uuid = new Uuid($command->getUuid());
 
-        if ($this->mailsSentRepository->isMailSent($uuid, get_class($command))) {
-            $this->logger->info(sprintf('[ownership-mail] Mail %s about %s was already sent', $uuid->toString(), get_class($command)));
-            return;
-        }
-
         try {
             $ownershipItem = $this->ownershipSearchRepository->getById($uuid->toString());
         } catch (OwnershipItemNotFound $e) {

--- a/src/Mailer/MailsSentRepository.php
+++ b/src/Mailer/MailsSentRepository.php
@@ -9,7 +9,5 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 
 interface MailsSentRepository
 {
-    public function isMailSent(Uuid $identifier, string $type): bool;
-
     public function addMailSent(Uuid $identifier, EmailAddress $email, string $type, \DateTimeInterface $dateTime): void;
 }

--- a/tests/Mailer/Handler/SendOwnershipMailCommandHandlerTest.php
+++ b/tests/Mailer/Handler/SendOwnershipMailCommandHandlerTest.php
@@ -85,12 +85,6 @@ class SendOwnershipMailCommandHandlerTest extends TestCase
 
         $this->mailsSentRepository
             ->expects($this->once())
-            ->method('isMailSent')
-            ->with(new Uuid(self::OWNERSHIP_ITEM_ID), get_class($command))
-            ->willReturn(false);
-
-        $this->mailsSentRepository
-            ->expects($this->once())
             ->method('addMailSent')
             ->with(
                 new Uuid(self::OWNERSHIP_ITEM_ID),
@@ -202,41 +196,8 @@ class SendOwnershipMailCommandHandlerTest extends TestCase
     }
 
     /** @test */
-    public function it_handles_mail_already_sent(): void
-    {
-        $id = self::OWNERSHIP_ITEM_ID;
-
-        $this->mailsSentRepository
-            ->expects($this->once())
-            ->method('isMailSent')
-            ->with(new Uuid(self::OWNERSHIP_ITEM_ID), SendOwnershipRequestedMail::class)
-            ->willReturn(true);
-
-        $this->mailsSentRepository
-            ->expects($this->never())
-            ->method('addMailSent');
-
-        $this->mailer
-            ->expects($this->never())
-            ->method('send');
-
-        $this->logger
-            ->expects($this->once())
-            ->method('info')
-            ->with(sprintf('[ownership-mail] Mail %s about %s was already sent', $id, SendOwnershipRequestedMail::class));
-
-        $this->commandHandler->handle(new SendOwnershipRequestedMail($id));
-    }
-
-    /** @test */
     public function it_fails_when_it_cannot_find_ownership_request(): void
     {
-        $this->mailsSentRepository
-            ->expects($this->once())
-            ->method('isMailSent')
-            ->with(new Uuid(self::OWNERSHIP_ITEM_ID), SendOwnershipRequestedMail::class)
-            ->willReturn(false);
-
         $this->ownershipSearchRepository
             ->expects($this->once())
             ->method('getById')
@@ -256,12 +217,6 @@ class SendOwnershipMailCommandHandlerTest extends TestCase
     /** @test */
     public function it_fails_when_organiser_is_not_found(): void
     {
-        $this->mailsSentRepository
-            ->expects($this->once())
-            ->method('isMailSent')
-            ->with(new Uuid(self::OWNERSHIP_ITEM_ID), SendOwnershipRequestedMail::class)
-            ->willReturn(false);
-
         $ownershipItem = new OwnershipItem(
             self::OWNERSHIP_ITEM_ID,
             self::ORGANIZER_ID,
@@ -305,12 +260,6 @@ class SendOwnershipMailCommandHandlerTest extends TestCase
         $id = 'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e';
         $ownerId = 'd6e21fa4-8d8d-4f23-b0cc-c63e34e43a01';
         $organizerId = 'd146a8cb-14c8-4364-9207-9d32d36f6959';
-
-        $this->mailsSentRepository
-            ->expects($this->once())
-            ->method('isMailSent')
-            ->with(new Uuid($id), SendOwnershipRequestedMail::class)
-            ->willReturn(false);
 
         $ownershipItem = new OwnershipItem(
             $id,
@@ -357,12 +306,6 @@ class SendOwnershipMailCommandHandlerTest extends TestCase
         $subject = 'Beheers aanvraag voor organisatie Publiq VZW';
         $html = '<p>body</p>';
         $text = 'body';
-
-        $this->mailsSentRepository
-            ->expects($this->once())
-            ->method('isMailSent')
-            ->with(new Uuid($id), SendOwnershipRequestedMail::class)
-            ->willReturn(false);
 
         $this->mailsSentRepository
             ->expects($this->never())


### PR DESCRIPTION
There was a bug where you could not re-approve a denied/deleted user for ownership, because the mail could not be sent twice. This was both a problem with the DB structure (primary key too strict) and domain code.

### Changed
- Change PK of mails_sent table
- Removed check in code if mail is already sent
- Added a feature test as proof

---

Ticket: https://jira.uitdatabank.be/browse/III-6587
