### PR TITLE
III-6618 ownership cli

### DIFF
--- a/app/Console/Command/AddOwnershipCommand.php
+++ b/app/Console/Command/AddOwnershipCommand.php
@@ -35,7 +35,7 @@ final class AddOwnershipCommand extends AbstractCommand
 
     private const USER = 'user';
 
-    private const SEND_MAILS = 'send-mails';
+    private const ENABLE_MAILS = 'enable-mails';
 
     private UuidFactory $uuidFactory;
 
@@ -78,10 +78,10 @@ final class AddOwnershipCommand extends AbstractCommand
                 InputOption::VALUE_REQUIRED,
                 'The id or email of a user give ownership to.'
             )->AddOption(
-                self::SEND_MAILS,
+                self::ENABLE_MAILS,
                 null,
                 InputOption::VALUE_NONE,
-                'Option to send mails during the CLI Command, default is not sending mails.'
+                'Option to enable mailing during the CLI Command, default is not sending mails.'
             );
     }
 
@@ -90,7 +90,7 @@ final class AddOwnershipCommand extends AbstractCommand
         $itemType = $input->getArgument(self::ITEM_TYPE);
         $itemId = $input->getArgument(self::ITEM_ID);
         $user = $input->getArgument(self::USER);
-        $sendMails = $input->getOption(self::SEND_MAILS);
+        $sendMails = $input->getOption(self::ENABLE_MAILS);
 
         if (!$this->itemExists($itemId)) {
             $output->writeln('Organizer does not exist.');

--- a/app/Console/Command/AddOwnershipCommand.php
+++ b/app/Console/Command/AddOwnershipCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class OwnershipCommand extends AbstractCommand
+final class AddOwnershipCommand extends AbstractCommand
 {
     private const ITEM_TYPE = 'item-type';
 

--- a/app/Console/Command/OwnershipCommand.php
+++ b/app/Console/Command/OwnershipCommand.php
@@ -133,14 +133,11 @@ final class OwnershipCommand extends AbstractCommand
     {
         try {
             $userEmail = new EmailAddress($user);
-            $user = $this->userIdentityResolver->getUserByEmail($userEmail);
-            if (!$user) {
-                return null;
-            }
-            return new UserId($user->getUserId());
+            $userDetails = $this->userIdentityResolver->getUserByEmail($userEmail);
         } catch (InvalidEmailAddress $exception) {
-            return new UserId($user);
+            $userDetails = $this->userIdentityResolver->getUserById($user);
         }
+        return $userDetails !== null ? new UserId($userDetails->getUserId()) : null;
     }
 
     private function itemExists(string $itemId): bool

--- a/app/Console/Command/OwnershipCommand.php
+++ b/app/Console/Command/OwnershipCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Console\Command;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UserId;
+use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UuidFactory\UuidFactory;
+use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
+use CultuurNet\UDB3\Model\ValueObject\Web\InvalidEmailAddress;
+use CultuurNet\UDB3\Ownership\Commands\ApproveOwnership;
+use CultuurNet\UDB3\Ownership\Commands\RequestOwnership;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use CultuurNet\UDB3\User\UserIdentityResolver;
+use Google\Service\Keep\User;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class OwnershipCommand extends AbstractCommand
+{
+    private const ITEM_TYPE = 'item-type';
+
+    private const ITEM_ID = 'item-id';
+
+    private const USER = 'user';
+
+    private UuidFactory $uuidFactory;
+
+    private UserIdentityResolver $userIdentityResolver;
+
+    private DocumentRepository $organizerRepository;
+
+    public function __construct(
+        CommandBus $commandBus,
+        UuidFactory $uuidFactory,
+        UserIdentityResolver $userIdentityResolver,
+        DocumentRepository $organizerRepository
+    ) {
+        parent::__construct($commandBus);
+        $this->uuidFactory = $uuidFactory;
+        $this->userIdentityResolver = $userIdentityResolver;
+        $this->organizerRepository = $organizerRepository;
+    }
+
+    public function configure(): void
+    {
+        $this->setName('ownership:add-ownership')
+            ->setDescription('Add ownership via an UiTID or email')
+            ->addArgument(
+                self::ITEM_TYPE,
+                InputOption::VALUE_REQUIRED,
+                'The type(at present only organizer is allowed) of the item to which you want to add the ownership.'
+            )
+            ->addArgument(
+                self::ITEM_ID,
+                InputOption::VALUE_REQUIRED,
+                'The id of the item to which you want to add the ownership.'
+            )
+            ->addArgument(
+                self::USER,
+                InputOption::VALUE_REQUIRED,
+                'The id or email of a user give ownership to.'
+            );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $itemType = $input->getArgument(self::ITEM_TYPE);
+        $itemId = $input->getArgument(self::ITEM_ID);
+        $user = $input->getArgument(self::USER);
+
+        if (!$this->itemExists($itemId)) {
+            $output->writeln('Organizer does not exist');
+            return self::FAILURE;
+        }
+
+        $userId = $this->getUserId($user);
+        if ($userId === null) {
+            $output->writeln('No user found for ' . $user);
+            return self::FAILURE;
+        }
+
+        $ownerShipId = new Uuid($this->uuidFactory->uuid4()->toString());
+
+        $requestOwnership = new RequestOwnership(
+            $ownerShipId,
+            new Uuid($itemId),
+            new ItemType($itemType),
+            new $userId,
+            new UserId(UUID::NIL)
+        );
+
+        $this->commandBus->dispatch($requestOwnership);
+
+        $approveOwnership = new ApproveOwnership($ownerShipId);
+
+        $this->commandBus->dispatch($approveOwnership);
+
+        return self::SUCCESS;
+    }
+
+    private function getUserId(string $user): ?UserId
+    {
+        try {
+            $userEmail = new EmailAddress($user);
+            $user = $this->userIdentityResolver->getUserByEmail($userEmail);
+            if (!$user) {
+                return null;
+            }
+            return new UserId($user->getUserId());
+        } catch (InvalidEmailAddress $exception) {
+            return new UserId($user);
+        }
+    }
+
+    private function itemExists(string $itemId): bool
+    {
+        try {
+            $this->organizerRepository->fetch($itemId);
+            return true;
+        } catch (DocumentDoesNotExist $e) {
+            return false;
+        }
+    }
+}

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -33,7 +33,7 @@ use CultuurNet\UDB3\Console\Command\ImportOfferAutoClassificationLabels;
 use CultuurNet\UDB3\Console\Command\IncludeLabel;
 use CultuurNet\UDB3\Console\Command\KeycloakCommand;
 use CultuurNet\UDB3\Console\Command\MoveEvents;
-use CultuurNet\UDB3\Console\Command\OwnershipCommand;
+use CultuurNet\UDB3\Console\Command\AddOwnershipCommand;
 use CultuurNet\UDB3\Console\Command\ProcessDuplicatePlaces;
 use CultuurNet\UDB3\Console\Command\PurgeModelCommand;
 use CultuurNet\UDB3\Console\Command\ReindexEventsWithRecommendations;
@@ -492,7 +492,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
 
         $container->addShared(
             'console.ownership:add-ownership',
-            fn () => new OwnershipCommand(
+            fn () => new AddOwnershipCommand(
                 $container->get('event_command_bus'),
                 new GeneratedUuidFactory(),
                 $container->get(CachedUserIdentityResolver::class),

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -33,6 +33,7 @@ use CultuurNet\UDB3\Console\Command\ImportOfferAutoClassificationLabels;
 use CultuurNet\UDB3\Console\Command\IncludeLabel;
 use CultuurNet\UDB3\Console\Command\KeycloakCommand;
 use CultuurNet\UDB3\Console\Command\MoveEvents;
+use CultuurNet\UDB3\Console\Command\OwnershipCommand;
 use CultuurNet\UDB3\Console\Command\ProcessDuplicatePlaces;
 use CultuurNet\UDB3\Console\Command\PurgeModelCommand;
 use CultuurNet\UDB3\Console\Command\ReindexEventsWithRecommendations;
@@ -60,8 +61,10 @@ use CultuurNet\UDB3\Kinepolis\Parser\KinepolisDateParser;
 use CultuurNet\UDB3\Kinepolis\Parser\KinepolisMovieParser;
 use CultuurNet\UDB3\Kinepolis\Parser\KinepolisPriceParser;
 use CultuurNet\UDB3\Kinepolis\Trailer\YoutubeTrailerRepository;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UuidFactory\GeneratedUuidFactory;
 use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Organizer\WebsiteNormalizer;
+use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
 use CultuurNet\UDB3\Place\Canonical\ImportDuplicatePlacesProcessor;
 use CultuurNet\UDB3\Place\Canonical\DuplicatePlaceRemovedFromClusterRepository;
 use CultuurNet\UDB3\Search\EventsSapi3SearchService;
@@ -119,6 +122,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
         'console.offer:import-auto-classification-labels',
         'console.article:replace-publisher',
         'console.organizer:convert-educational-description',
+        'console.ownership:add-ownership',
         'console.execute-command-from-csv',
         'console.movies:fetch',
         'console.movies:add-trailers',
@@ -483,6 +487,17 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
                 $container->get('event_command_bus'),
                 $container->get(EventRelationsRepository::class),
                 $container->get('place_jsonld_repository'),
+            )
+        );
+
+        $container->addShared(
+            'console.ownership:add-ownership',
+            fn () => new OwnershipCommand(
+                $container->get('event_command_bus'),
+                new GeneratedUuidFactory(),
+                $container->get(CachedUserIdentityResolver::class),
+                $container->get(OwnershipSearchRepository::class),
+                $container->get('organizer_jsonld_repository'),
             )
         );
 

--- a/app/EventBus/EventBusServiceProvider.php
+++ b/app/EventBus/EventBusServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\EventBus;
 
 use Broadway\EventHandling\EventBus;
-use CultuurNet\UDB3\ApiName;
 use CultuurNet\UDB3\Broadway\AMQP\AMQPPublisher;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Event\EventJSONLDServiceProvider;

--- a/app/EventBus/EventBusServiceProvider.php
+++ b/app/EventBus/EventBusServiceProvider.php
@@ -102,7 +102,7 @@ final class EventBusServiceProvider extends AbstractServiceProvider
                             $eventBus->subscribe($container->get($subscriberServiceId));
                         }
 
-                        if (($this->container->get('config')['mail']['send_ownernship_mails'] ?? false) && ($container->get(ApiName::class) !== ApiName::CLI)) {
+                        if ($this->container->get('config')['mail']['send_ownernship_mails'] ?? false) {
                             $eventBus->subscribe($container->get(SendMailsForOwnershipEventHandler::class));
                         }
                     }

--- a/app/EventBus/EventBusServiceProvider.php
+++ b/app/EventBus/EventBusServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\EventBus;
 
 use Broadway\EventHandling\EventBus;
+use CultuurNet\UDB3\ApiName;
 use CultuurNet\UDB3\Broadway\AMQP\AMQPPublisher;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Event\EventJSONLDServiceProvider;
@@ -101,7 +102,7 @@ final class EventBusServiceProvider extends AbstractServiceProvider
                             $eventBus->subscribe($container->get($subscriberServiceId));
                         }
 
-                        if ($this->container->get('config')['mail']['send_ownernship_mails'] ?? false) {
+                        if ($container->get(ApiName::class) !== ApiName::CLI && $this->container->get('config')['mail']['send_ownernship_mails'] ?? false ) {
                             $eventBus->subscribe($container->get(SendMailsForOwnershipEventHandler::class));
                         }
                     }

--- a/app/EventBus/EventBusServiceProvider.php
+++ b/app/EventBus/EventBusServiceProvider.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Event\ReadModel\History\HistoryProjector as EventHistoryProj
 use CultuurNet\UDB3\Event\ReadModel\Relations\EventRelationsProjector;
 use CultuurNet\UDB3\Event\RelocateEventToCanonicalPlace;
 use CultuurNet\UDB3\EventBus\Middleware\CallbackOnFirstPublicationMiddleware;
+use CultuurNet\UDB3\EventBus\Middleware\DisableMailsMiddleware;
 use CultuurNet\UDB3\EventBus\Middleware\InterceptingMiddleware;
 use CultuurNet\UDB3\EventBus\Middleware\ReplayFlaggingMiddleware;
 use CultuurNet\UDB3\Label\ReadModels\JSON\LabelVisibilityOnRelatedDocumentsProjector;
@@ -111,6 +112,7 @@ final class EventBusServiceProvider extends AbstractServiceProvider
                 $eventBus->registerMiddleware($callbackMiddleware);
                 $eventBus->registerMiddleware(new ReplayFlaggingMiddleware());
                 $eventBus->registerMiddleware(new InterceptingMiddleware());
+                $eventBus->registerMiddleware(new DisableMailsMiddleware());
 
                 return $eventBus;
             }

--- a/app/EventBus/EventBusServiceProvider.php
+++ b/app/EventBus/EventBusServiceProvider.php
@@ -102,7 +102,7 @@ final class EventBusServiceProvider extends AbstractServiceProvider
                             $eventBus->subscribe($container->get($subscriberServiceId));
                         }
 
-                        if ($container->get(ApiName::class) !== ApiName::CLI && $this->container->get('config')['mail']['send_ownernship_mails'] ?? false ) {
+                        if (($this->container->get('config')['mail']['send_ownernship_mails'] ?? false) && ($container->get(ApiName::class) !== ApiName::CLI)) {
                             $eventBus->subscribe($container->get(SendMailsForOwnershipEventHandler::class));
                         }
                     }

--- a/app/Mailer/MailerServiceProvider.php
+++ b/app/Mailer/MailerServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Mailer;
 
+use CultuurNet\UDB3\Broadway\Domain\DomainMessageHasMailsDisabled;
 use CultuurNet\UDB3\Broadway\Domain\DomainMessageIsReplayed;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Error\LoggerFactory;
@@ -99,6 +100,7 @@ class MailerServiceProvider extends AbstractServiceProvider
                 return new SendMailsForOwnershipEventHandler(
                     $this->container->get('mails_command_bus'),
                     new DomainMessageIsReplayed(),
+                    new DomainMessageHasMailsDisabled()
                 );
             }
         );

--- a/src/Broadway/Domain/DomainMessageHasMailsDisabled.php
+++ b/src/Broadway/Domain/DomainMessageHasMailsDisabled.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Broadway\Domain;
+
+use Broadway\Domain\DomainMessage;
+
+class DomainMessageHasMailsDisabled implements DomainMessageSpecificationInterface
+{
+    public const METADATA_MAILS_DISABLED_KEY = 'disable_mails';
+
+    public function isSatisfiedBy(DomainMessage $domainMessage): bool
+    {
+        $metadata = $domainMessage->getMetadata()->serialize();
+        return isset($metadata[self::METADATA_MAILS_DISABLED_KEY]) && $metadata[self::METADATA_MAILS_DISABLED_KEY];
+    }
+}

--- a/src/Broadway/Domain/DomainMessageHasMailsDisabled.php
+++ b/src/Broadway/Domain/DomainMessageHasMailsDisabled.php
@@ -12,7 +12,7 @@ class DomainMessageHasMailsDisabled implements DomainMessageSpecificationInterfa
 
     public function isSatisfiedBy(DomainMessage $domainMessage): bool
     {
-        $metadata = $domainMessage->getMetadata()->serialize();
-        return isset($metadata[self::METADATA_MAILS_DISABLED_KEY]) && $metadata[self::METADATA_MAILS_DISABLED_KEY];
+        $metadata = $domainMessage->getMetadata();
+        return $metadata->get(self::METADATA_MAILS_DISABLED_KEY) ?? false;
     }
 }

--- a/src/EventBus/Middleware/DisableMailsMiddleware.php
+++ b/src/EventBus/Middleware/DisableMailsMiddleware.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\EventBus\Middleware;
+
+use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\EventBus\EventBusMiddleware;
+
+final class DisableMailsMiddleware implements EventBusMiddleware
+{
+    private static bool $disableMails = false;
+
+    public static function disableMails(): void
+    {
+        self::$disableMails = true;
+    }
+
+    public static function enableMails(): void
+    {
+        self::$disableMails = false;
+    }
+
+    public function beforePublish(DomainEventStream $domainEventStream): DomainEventStream
+    {
+        if (!self::$disableMails) {
+            return $domainEventStream;
+        }
+
+        $messages = [];
+        foreach ($domainEventStream as $domainMessage) {
+            if ($domainMessage instanceof DomainMessage) {
+                $domainMessage = $domainMessage->andMetadata(
+                    new Metadata(['disable_mails' => true])
+                );
+            }
+            $messages[] = $domainMessage;
+        }
+        return new DomainEventStream($messages);
+    }
+}

--- a/src/Mailer/Handler/SendMailsForOwnershipEventHandler.php
+++ b/src/Mailer/Handler/SendMailsForOwnershipEventHandler.php
@@ -43,7 +43,6 @@ final class SendMailsForOwnershipEventHandler implements EventListener
             }
         }
 
-
         $event = $domainMessage->getPayload();
         switch (true) {
             case $event instanceof OwnershipRequested:

--- a/src/Mailer/Handler/SendMailsForOwnershipEventHandler.php
+++ b/src/Mailer/Handler/SendMailsForOwnershipEventHandler.php
@@ -22,25 +22,26 @@ final class SendMailsForOwnershipEventHandler implements EventListener
 
     private ContextDecoratedCommandBus $mailerCommandBus;
 
-    /**
-     * @var DomainMessageSpecificationInterface[]
-     */
-    private array $domainMessageSpecifications;
+    private DomainMessageSpecificationInterface $isReplay;
+
+    private DomainMessageSpecificationInterface $mailsDisabled;
 
     public function __construct(
         ContextDecoratedCommandBus $mailerCommandBus,
-        DomainMessageSpecificationInterface ...$domainMessageSpecification
+        DomainMessageSpecificationInterface $isReplay,
+        DomainMessageSpecificationInterface $mailsDisabled
     ) {
         $this->mailerCommandBus = $mailerCommandBus;
-        $this->domainMessageSpecifications = $domainMessageSpecification;
+        $this->isReplay = $isReplay;
+        $this->mailsDisabled = $mailsDisabled;
     }
 
     public function handle(DomainMessage $domainMessage): void
     {
-        foreach ($this->domainMessageSpecifications as $domainMessageSpecification) {
-            if ($domainMessageSpecification->isSatisfiedBy($domainMessage)) {
-                return;
-            }
+        if (
+            $this->isReplay->isSatisfiedBy($domainMessage) ||
+            $this->mailsDisabled->isSatisfiedBy($domainMessage)) {
+            return;
         }
 
         $event = $domainMessage->getPayload();

--- a/src/Mailer/Handler/SendMailsForOwnershipEventHandler.php
+++ b/src/Mailer/Handler/SendMailsForOwnershipEventHandler.php
@@ -37,6 +37,10 @@ final class SendMailsForOwnershipEventHandler implements EventListener
             return;
         }
 
+        if ($domainMessage->getMetadata()->get('disable_mails')) {
+            return;
+        }
+
         $event = $domainMessage->getPayload();
         switch (true) {
             case $event instanceof OwnershipRequested:

--- a/src/Mailer/Handler/SendMailsForOwnershipEventHandler.php
+++ b/src/Mailer/Handler/SendMailsForOwnershipEventHandler.php
@@ -21,25 +21,28 @@ final class SendMailsForOwnershipEventHandler implements EventListener
     use AsyncDispatchTrait;
 
     private ContextDecoratedCommandBus $mailerCommandBus;
-    private DomainMessageSpecificationInterface $isReplay;
+
+    /**
+     * @var DomainMessageSpecificationInterface[]
+     */
+    private array $domainMessageSpecifications;
 
     public function __construct(
         ContextDecoratedCommandBus $mailerCommandBus,
-        DomainMessageSpecificationInterface $domainMessageSpecification
+        DomainMessageSpecificationInterface ...$domainMessageSpecification
     ) {
         $this->mailerCommandBus = $mailerCommandBus;
-        $this->isReplay = $domainMessageSpecification;
+        $this->domainMessageSpecifications = $domainMessageSpecification;
     }
 
     public function handle(DomainMessage $domainMessage): void
     {
-        if ($this->isReplay->isSatisfiedBy($domainMessage)) {
-            return;
+        foreach ($this->domainMessageSpecifications as $domainMessageSpecification) {
+            if ($domainMessageSpecification->isSatisfiedBy($domainMessage)) {
+                return;
+            }
         }
 
-        if ($domainMessage->getMetadata()->get('disable_mails')) {
-            return;
-        }
 
         $event = $domainMessage->getPayload();
         switch (true) {

--- a/tests/EventBus/Middleware/DisableMailsMiddlewareTest.php
+++ b/tests/EventBus/Middleware/DisableMailsMiddlewareTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\EventBus\Middleware;
+
+use Broadway\Domain\DateTime;
+use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
+use PHPUnit\Framework\TestCase;
+
+final class DisableMailsMiddlewareTest extends TestCase
+{
+    private DisableMailsMiddleware $disableMailsMiddleware;
+
+    protected function setUp(): void
+    {
+        $this->disableMailsMiddleware = new DisableMailsMiddleware();
+    }
+
+    /**
+     * @test
+     */
+    public function it_works(): void
+    {
+        $stream1 = new DomainEventStream([$this->createDomainMessage(1)]);
+        $stream2 = new DomainEventStream([$this->createDomainMessage(2)]);
+        $stream3 = new DomainEventStream([$this->createDomainMessage(3)]);
+
+        $expectedReplayMetadata = [
+            false,
+            true,
+            false,
+        ];
+
+        $processedStreams = [];
+
+        $processedStreams[] = $this->disableMailsMiddleware->beforePublish($stream1);
+        DisableMailsMiddleware::disableMails();
+        $processedStreams[] = $this->disableMailsMiddleware->beforePublish($stream2);
+        DisableMailsMiddleware::enableMails();
+        $processedStreams[] = $this->disableMailsMiddleware->beforePublish($stream3);
+
+        $actualReplayMetadata = [];
+        foreach ($processedStreams as $stream) {
+            /** @var DomainMessage $domainMessage */
+            foreach ($stream as $domainMessage) {
+                $metadata = $domainMessage->getMetadata();
+                $actualReplayMetadata[] = $metadata->get('disable_mails');
+            }
+        }
+
+        $this->assertEquals($expectedReplayMetadata, $actualReplayMetadata);
+    }
+
+    private function createDomainMessage(int $id): DomainMessage
+    {
+        return new DomainMessage(
+            Uuid::uuid4()->toString(),
+            0,
+            new Metadata(),
+            (object) ['id' => $id],
+            DateTime::now()
+        );
+    }
+}

--- a/tests/EventBus/Middleware/DisableMailsMiddlewareTest.php
+++ b/tests/EventBus/Middleware/DisableMailsMiddlewareTest.php
@@ -23,7 +23,7 @@ final class DisableMailsMiddlewareTest extends TestCase
     /**
      * @test
      */
-    public function it_works(): void
+    public function it_can_enable_and_disable_mails(): void
     {
         $stream1 = new DomainEventStream([$this->createDomainMessage(1)]);
         $stream2 = new DomainEventStream([$this->createDomainMessage(2)]);

--- a/tests/Mailer/Handler/SendMailsForOwnershipEventHandlerTest.php
+++ b/tests/Mailer/Handler/SendMailsForOwnershipEventHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Mailer\Handler;
 
+use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Broadway\Domain\DomainMessageSpecificationInterface;
 use CultuurNet\UDB3\CommandHandling\ContextDecoratedCommandBus;
 use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
@@ -107,6 +108,34 @@ class SendMailsForOwnershipEventHandlerTest extends TestCase
             ->method('isSatisfiedBy')
             ->with($domainMessage)
             ->willReturn(true);
+
+        $this->commandBus->expects($this->never())->method('dispatch');
+
+        $this->sendMailsForOwnership->handle(
+            $domainMessage
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_send_mails_when_disabled_in_middleware(): void
+    {
+        $domainMessage = (new DomainMessageBuilder())
+            ->create(
+                $this->givenAnOwnershipRequested(
+                    'e6e1f3a0-3e5e-4b3e-8e3e-3f3e3e3e3e3e',
+                    '9e68dafc-01d8-4c1c-9612-599c918b981d',
+                    'auth0|63e22626e39a8ca1264bd29b'
+                )
+            )
+            ->andMetadata(new Metadata(['disable_mails' => true]));
+
+        $this->domainMessageSpecification
+            ->expects($this->once())
+            ->method('isSatisfiedBy')
+            ->with($domainMessage)
+            ->willReturn(false);
 
         $this->commandBus->expects($this->never())->method('dispatch');
 

--- a/tests/Mailer/Handler/SendMailsForOwnershipEventHandlerTest.php
+++ b/tests/Mailer/Handler/SendMailsForOwnershipEventHandlerTest.php
@@ -163,12 +163,6 @@ class SendMailsForOwnershipEventHandlerTest extends TestCase
                 new Description('description-456')
             ));
 
-        $this->domainMessageSpecificationForReplays
-            ->expects($this->once())
-            ->method('isSatisfiedBy')
-            ->with($domainMessage)
-            ->willReturn(true);
-
         $this->commandBus->expects($this->never())->method('dispatch');
 
         $this->sendMailsForOwnership->handle(


### PR DESCRIPTION
### Added

- `AddOwnershipCommand`: CLI Command to add `ownerships`.
- `DomainMessageHasMailsDisabled`: Add new `DomainMessageSpecificationInterface`
- `DisableMailsMiddleware`: MiddleWare to disable sending mails, when changing `Ownership`
- `DisableMailsMiddlewareTest`: Unit test for `DisableMailsMiddleware`

### Changed

- `ConsoleServiceProvider`: Register new Command `AddOwnershipCommand`.
- `EventBusServiceProvider`: register new MiddleWare `DisableMailsMiddleware`
- `SendMailsForOwnershipEventHandler`: Check if mails are disabled in MiddleWare.
- `SendMailsForOwnershipEventHandlerTest`: Add unit test to see if mails disabled in MiddleWare work
- `MailerServiceProvider`: Updated `constructor` of `SendMailsForOwnershipEventHandler`
 
---

Ticket: https://jira.publiq.be/browse/III-6618
