### PR TITLE
III-6622 Improve ownership Validation for non existing userId's

### DIFF
--- a/features/ownership/request.feature
+++ b/features/ownership/request.feature
@@ -173,3 +173,24 @@ Feature: Test requesting ownership
       "detail": "No user with email nobody@null.com was found in our system."
     }
     """
+
+  Scenario: Requesting the ownership with a non-existing userId
+    When I set the JSON request payload to:
+    """
+    {
+      "itemId": "b192b05f-9294-4c07-a3f9-6a15e267d746",
+      "itemType": "organizer",
+      "ownerId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    }
+    """
+    When I send a POST request to '/ownerships'
+    Then the response status should be 400
+    And the JSON response should be:
+    """
+    {
+      "type": "https://api.publiq.be/probs/body/invalid-data",
+      "title": "Invalid body data",
+      "status": 400,
+      "detail": "No user with id ffffffff-ffff-ffff-ffff-ffffffffffff was found in our system."
+    }
+    """

--- a/features/ownership/request.feature
+++ b/features/ownership/request.feature
@@ -152,3 +152,24 @@ Feature: Test requesting ownership
       "detail": "The Organizer with id \"b192b05f-9294-4c07-a3f9-6a15e267d746\" was not found."
     }
     """
+
+  Scenario: Requesting the ownership with a non-existing email
+    When I set the JSON request payload to:
+    """
+    {
+      "itemId": "b192b05f-9294-4c07-a3f9-6a15e267d746",
+      "itemType": "organizer",
+      "ownerEmail": "nobody@null.com"
+    }
+    """
+    When I send a POST request to '/ownerships'
+    Then the response status should be 400
+    And the JSON response should be:
+    """
+    {
+      "type": "https://api.publiq.be/probs/body/invalid-data",
+      "title": "Invalid body data",
+      "status": 400,
+      "detail": "No user with email nobody@null.com was found in our system."
+    }
+    """

--- a/src/Ownership/Serializers/RequestOwnershipDenormalizer.php
+++ b/src/Ownership/Serializers/RequestOwnershipDenormalizer.php
@@ -30,6 +30,12 @@ final class RequestOwnershipDenormalizer implements DenormalizerInterface
 
     public function denormalize($data, $class, $format = null, array $context = []): RequestOwnership
     {
+        if ($userId = $data['ownerId'] ?? null) {
+            $userDetails = $this->identityResolver->getUserById($userId);
+            if ($userDetails === null) {
+                throw ApiProblem::bodyInvalidDataWithDetail('No user with id ' . $userId . ' was found in our system.');
+            }
+        }
         if ($email = $data['ownerEmail'] ?? null) {
             $user = $this->identityResolver->getUserByEmail(new EmailAddress($email));
             if (!$user) {

--- a/tests/Http/Ownership/RequestOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/RequestOwnershipRequestHandlerTest.php
@@ -200,6 +200,38 @@ class RequestOwnershipRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_prevents_requesting_ownership_for_non_existing_user_id(): void
+    {
+        $this->identityResolver->expects($this->once())
+            ->method('getUserById')
+            ->with('ffffffff-ffff-ffff-ffff-ffffffffffff')
+            ->willReturn(null);
+
+        $request = (new Psr7RequestBuilder())
+            ->withJsonBodyFromArray([
+                'itemId' => 'fc93ceb0-e170-4d92-b496-846b2a194f1c',
+                'itemType' => 'organizer',
+                'ownerId' => 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+            ])
+            ->build('POST');
+
+        $this->permissionVoter->expects($this->never())
+            ->method('isAllowed');
+
+        $this->ownerShipSearchRepository->expects($this->never())
+            ->method('search');
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidDataWithDetail('No user with id ffffffff-ffff-ffff-ffff-ffffffffffff was found in our system.'),
+            fn () => $this->requestOwnershipRequestHandler->handle($request)
+        );
+
+        $this->assertEquals([], $this->commandBus->getRecordedCommands());
+    }
+
+    /**
+     * @test
+     */
     public function it_handles_requesting_ownership_with_email(): void
     {
         CurrentUser::configureGodUserIds([]);

--- a/tests/Http/Ownership/RequestOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/RequestOwnershipRequestHandlerTest.php
@@ -83,6 +83,17 @@ class RequestOwnershipRequestHandlerTest extends TestCase
      */
     public function it_handles_requesting_ownership(): void
     {
+        $this->identityResolver->expects($this->once())
+            ->method('getUserById')
+            ->with('auth0|63e22626e39a8ca1264bd29b')
+            ->willReturn(
+                new UserIdentityDetails(
+                    'auth0|63e22626e39a8ca1264bd29b',
+                    'Jane Doe',
+                    'jane.doe@mail.com'
+                )
+            );
+
         $request = (new Psr7RequestBuilder())
             ->withJsonBodyFromArray([
                 'itemId' => '9e68dafc-01d8-4c1c-9612-599c918b981d',
@@ -265,6 +276,17 @@ class RequestOwnershipRequestHandlerTest extends TestCase
     public function it_allows_requesting_ownership_for_yourself_even_without_permission(): void
     {
         CurrentUser::configureGodUserIds([]);
+
+        $this->identityResolver->expects($this->once())
+            ->method('getUserById')
+            ->with('auth0|63e22626e39a8ca1264bd29b')
+            ->willReturn(
+                new UserIdentityDetails(
+                    'auth0|63e22626e39a8ca1264bd29b',
+                    'Jane Doe',
+                    'jane.doe@mail.com'
+                )
+            );
 
         $request = (new Psr7RequestBuilder())
             ->withJsonBodyFromArray([
@@ -451,6 +473,17 @@ class RequestOwnershipRequestHandlerTest extends TestCase
      */
     public function it_allows_requesting_same_ownership_when_rejected(): void
     {
+        $this->identityResolver->expects($this->once())
+            ->method('getUserById')
+            ->with('auth0|63e22626e39a8ca1264bd29b')
+            ->willReturn(
+                new UserIdentityDetails(
+                    'auth0|63e22626e39a8ca1264bd29b',
+                    'Jane Doe',
+                    'jane.doe@mail.com'
+                )
+            );
+
         $request = (new Psr7RequestBuilder())
             ->withJsonBodyFromArray([
                 'itemId' => '9e68dafc-01d8-4c1c-9612-599c918b981d',

--- a/tests/Http/Ownership/RequestOwnershipRequestHandlerTest.php
+++ b/tests/Http/Ownership/RequestOwnershipRequestHandlerTest.php
@@ -147,6 +147,17 @@ class RequestOwnershipRequestHandlerTest extends TestCase
     {
         CurrentUser::configureGodUserIds([]);
 
+        $this->identityResolver->expects($this->once())
+            ->method('getUserById')
+            ->with('google-oauth2|102486314601596809843')
+            ->willReturn(
+                new UserIdentityDetails(
+                    'google-oauth2|102486314601596809843',
+                    'John Doe',
+                    'john.doe@mail.com'
+                )
+            );
+
         $request = (new Psr7RequestBuilder())
             ->withJsonBodyFromArray([
                 'itemId' => '9e68dafc-01d8-4c1c-9612-599c918b981d',
@@ -310,6 +321,17 @@ class RequestOwnershipRequestHandlerTest extends TestCase
      */
     public function it_prevents_requesting_same_ownership(): void
     {
+        $this->identityResolver->expects($this->once())
+            ->method('getUserById')
+            ->with('auth0|63e22626e39a8ca1264bd29b')
+            ->willReturn(
+                new UserIdentityDetails(
+                    'auth0|63e22626e39a8ca1264bd29b',
+                    'Jane Doe',
+                    'jane.doe@mail.com'
+                )
+            );
+
         $request = (new Psr7RequestBuilder())
             ->withJsonBodyFromArray([
                 'itemId' => '9e68dafc-01d8-4c1c-9612-599c918b981d',
@@ -364,6 +386,17 @@ class RequestOwnershipRequestHandlerTest extends TestCase
      */
     public function it_prevents_requesting_same_ownership_when_approved(): void
     {
+        $this->identityResolver->expects($this->once())
+            ->method('getUserById')
+            ->with('auth0|63e22626e39a8ca1264bd29b')
+            ->willReturn(
+                new UserIdentityDetails(
+                    'auth0|63e22626e39a8ca1264bd29b',
+                    'Jane Doe',
+                    'jane.doe@mail.com'
+                )
+            );
+
         $request = (new Psr7RequestBuilder())
             ->withJsonBodyFromArray([
                 'itemId' => '9e68dafc-01d8-4c1c-9612-599c918b981d',
@@ -473,6 +506,16 @@ class RequestOwnershipRequestHandlerTest extends TestCase
      */
     public function it_allows_requesting_same_ownership_when_deleted(): void
     {
+        $this->identityResolver->expects($this->once())
+            ->method('getUserById')
+            ->with('auth0|63e22626e39a8ca1264bd29b')
+            ->willReturn(
+                new UserIdentityDetails(
+                    'auth0|63e22626e39a8ca1264bd29b',
+                    'Jane Doe',
+                    'jane.doe@mail.com'
+                )
+            );
         $request = (new Psr7RequestBuilder())
             ->withJsonBodyFromArray([
                 'itemId' => '9e68dafc-01d8-4c1c-9612-599c918b981d',
@@ -528,6 +571,17 @@ class RequestOwnershipRequestHandlerTest extends TestCase
      */
     public function it_prevents_requesting_ownership_for_non_existing_organizer(): void
     {
+        $this->identityResolver->expects($this->once())
+            ->method('getUserById')
+            ->with('auth0|63e22626e39a8ca1264bd29b')
+            ->willReturn(
+                new UserIdentityDetails(
+                    'auth0|63e22626e39a8ca1264bd29b',
+                    'Jane Doe',
+                    'jane.doe@mail.com'
+                )
+            );
+
         $request = (new Psr7RequestBuilder())
             ->withJsonBodyFromArray([
                 'itemId' => 'fc93ceb0-e170-4d92-b496-846b2a194f1c',


### PR DESCRIPTION
### Changed

- `RequestOwnershipDenormalizer`: Add check to see if the `ownerId` is known in our system.
- `Ownership/RequestOwnershipRequestHandlerTest`: Refactor existing tests & add 2 new tests for non-existing `email|userId`.
- `features/ownership/request.feature`: Add 2 acceptance tests to check non-existing `email|userId`

### Fixed

- A request can no longer be made with an non existing userId.

### Note

- We could improve this code with a refactor to dedepulicate the validation => https://jira.publiq.be/browse/III-6633

---

Ticket: https://jira.publiq.be/browse/III-6622
