### PR TITLE
III-6622 Replace non-existing users

### DIFF
--- a/docker.md
+++ b/docker.md
@@ -57,3 +57,13 @@ You can run the actual acceptance tests with:
 ```
 $ make feature
 ```
+We created some dummy users that can be used in tests:
+
+| E-mail               | UserId                               |
+| -------------------- | ------------------------------------ |
+| dummyuser1@publiq.be | 02566c96-8fd3-4b7e-aa35-cbebe6663b2d |
+| dummyuser2@publiq.be | 79dd2821-3b89-4dbb-9143-920ff2edfa34 |
+| dummyuser3@publiq.be | 92650bd8-037f-4722-a40e-7e0a0bf39a8e |
+| dummyuser4@publiq.be | c9f2a19f-3dd7-401c-ad4d-73db7a9d1748 |
+| dummyuser5@publiq.be | edf305f8-69b6-4553-914e-9ecedcba418e |
+| dummyuser6@publiq.be | 67aebd9b-3033-459c-818e-ca684b3a27b3 |

--- a/docker.md
+++ b/docker.md
@@ -59,11 +59,11 @@ $ make feature
 ```
 We created some dummy users that can be used in tests:
 
-| E-mail               | UserId                               |
-| -------------------- | ------------------------------------ |
-| dummyuser1@publiq.be | 02566c96-8fd3-4b7e-aa35-cbebe6663b2d |
-| dummyuser2@publiq.be | 79dd2821-3b89-4dbb-9143-920ff2edfa34 |
-| dummyuser3@publiq.be | 92650bd8-037f-4722-a40e-7e0a0bf39a8e |
-| dummyuser4@publiq.be | c9f2a19f-3dd7-401c-ad4d-73db7a9d1748 |
-| dummyuser5@publiq.be | edf305f8-69b6-4553-914e-9ecedcba418e |
-| dummyuser6@publiq.be | 67aebd9b-3033-459c-818e-ca684b3a27b3 |
+| E-mail               | UserId                               | Notes                                     |
+| -------------------- | ------------------------------------ |-------------------------------------------| 
+| dummyuser1@publiq.be | 02566c96-8fd3-4b7e-aa35-cbebe6663b2d |                                           |
+| dummyuser2@publiq.be | 79dd2821-3b89-4dbb-9143-920ff2edfa34 |                                           |
+| dummyuser3@publiq.be | 92650bd8-037f-4722-a40e-7e0a0bf39a8e |                                           |
+| dummyuser4@publiq.be | c9f2a19f-3dd7-401c-ad4d-73db7a9d1748 |                                           |
+| dummyuser5@publiq.be | edf305f8-69b6-4553-914e-9ecedcba418e |                                           |
+| dummyuser6@publiq.be | 67aebd9b-3033-459c-818e-ca684b3a27b3 | Cannot be used to create extra Ownerships |

--- a/features/data/organizers/rdf/organizer-with-address.ttl
+++ b/features/data/organizers/rdf/organizer-with-address.ttl
@@ -19,7 +19,7 @@
   cpr:naam "%{name}"@nl ;
   foaf:homepage "https://www.%{name}.be" ;
   locn:address <http://data.uitdatabank.local:80/organizers/%{organizerId}#address-8b181138> ;
-  locn:geometry <http://data.uitdatabank.local:80/organizers/%{organizerId}#geometry-3e08914b> .
+  locn:geometry <http://data.uitdatabank.local:80/organizers/%{organizerId}#geometry-dbec4cfd> .
 
 <http://data.uitdatabank.local:80/organizers/%{organizerId}#identifier-%{identifier}>
   a adms:Identifier ;
@@ -40,6 +40,6 @@
   locn:postCode "1080" ;
   locn:locatorDesignator "41" .
 
-<http://data.uitdatabank.local:80/organizers/%{organizerId}#geometry-3e08914b>
+<http://data.uitdatabank.local:80/organizers/%{organizerId}#geometry-dbec4cfd>
   a locn:Geometry ;
-  geosparql:asGML "<gml:Point srsName='http://www.opengis.net/def/crs/OGC/1.3/CRS84'><gml:coordinates>4.3379778, 50.8509636</gml:coordinates></gml:Point>"^^geosparql:gmlLiteral .
+  geosparql:asGML "<gml:Point srsName='http://www.opengis.net/def/crs/OGC/1.3/CRS84'><gml:coordinates>4.3380041, 50.8509352</gml:coordinates></gml:Point>"^^geosparql:gmlLiteral .

--- a/features/ownership/search.feature
+++ b/features/ownership/search.feature
@@ -72,8 +72,8 @@ Feature: Test searching ownerships
     And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I request ownership for "79dd2821-3b89-4dbb-9143-920ff2edfa34" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
     And I request ownership for "92650bd8-037f-4722-a40e-7e0a0bf39a8e" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
-    And I request ownership for "auth0|631748dba64ea78e3983b204" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId4"
-    And I request ownership for "auth0|631748dba64ea78e3983b205" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId5"
+    And I request ownership for "c9f2a19f-3dd7-401c-ad4d-73db7a9d1748" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId4"
+    And I request ownership for "edf305f8-69b6-4553-914e-9ecedcba418e" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId5"
     And I approve the ownership with ownershipId "%{ownershipId1}"
     And I approve the ownership with ownershipId "%{ownershipId2}"
     When I send a GET request to '/ownerships/?state=requested&itemId=%{organizerId}&imit=2&start=1'
@@ -81,10 +81,10 @@ Feature: Test searching ownerships
     And the JSON response at "itemsPerPage" should be 2
     And the JSON response at "totalItems" should be 3
     And the JSON response at "member/0/id" should be "%{ownershipId4}"
-    And the JSON response at "member/0/ownerId" should be "auth0|631748dba64ea78e3983b204"
+    And the JSON response at "member/0/ownerId" should be "c9f2a19f-3dd7-401c-ad4d-73db7a9d1748"
     And the JSON response at "member/0/state" should be "requested"
     And the JSON response at "member/1/id" should be "%{ownershipId5}"
-    And the JSON response at "member/1/ownerId" should be "auth0|631748dba64ea78e3983b205"
+    And the JSON response at "member/1/ownerId" should be "edf305f8-69b6-4553-914e-9ecedcba418e"
     And the JSON response at "member/1/state" should be "requested"
 
   Scenario: Searching ownership of an organizer takes into permission organisaties bewerken

--- a/features/ownership/search.feature
+++ b/features/ownership/search.feature
@@ -46,11 +46,10 @@ Feature: Test searching ownerships
   Scenario: Searching ownership of an organizer by ownerId
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
-    And I create a random name of 10 characters and keep it as "ownerId"
-    And I request ownership for "%{ownerId}" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
+    And I request ownership for "67aebd9b-3033-459c-818e-ca684b3a27b3" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I create a minimal organizer and save the "id" as "anotherOrganizerId"
-    And I request ownership for "%{ownerId}" on the organizer with organizerId "%{anotherOrganizerId}" and save the "id" as "ownershipId2"
-    When I send a GET request to '/ownerships/?ownerId=%{ownerId}'
+    And I request ownership for "67aebd9b-3033-459c-818e-ca684b3a27b3" on the organizer with organizerId "%{anotherOrganizerId}" and save the "id" as "ownershipId2"
+    When I send a GET request to '/ownerships/?ownerId=67aebd9b-3033-459c-818e-ca684b3a27b3&state=requested'
     Then the response status should be 200
     And the JSON response at "itemsPerPage" should be 2
     And the JSON response at "totalItems" should be 2
@@ -62,10 +61,12 @@ Feature: Test searching ownerships
     """
     "%{ownershipId2}"
     """
-    And the JSON response at "member/0/ownerId" should be "%{ownerId}"
+    And the JSON response at "member/0/ownerId" should be "67aebd9b-3033-459c-818e-ca684b3a27b3"
     And the JSON response at "member/0/state" should be "requested"
-    And the JSON response at "member/1/ownerId" should be "%{ownerId}"
+    And the JSON response at "member/1/ownerId" should be "67aebd9b-3033-459c-818e-ca684b3a27b3"
     And the JSON response at "member/1/state" should be "requested"
+    And I delete the ownership with ownershipId "%{ownershipId1}"
+    And I delete the ownership with ownershipId "%{ownershipId2}"
 
   Scenario: Searching ownership of an organizer by state and with start and limit
     Given I create a minimal organizer and save the "id" as "organizerId"

--- a/features/ownership/search.feature
+++ b/features/ownership/search.feature
@@ -8,7 +8,7 @@ Feature: Test searching ownerships
   Scenario: Searching ownership of an organizer by item id
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
-    And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
+    And I request ownership for "79dd2821-3b89-4dbb-9143-920ff2edfa34" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
     And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
     When I send a GET request to '/ownerships/?itemId=%{organizerId}'
     Then the response status should be 200
@@ -18,7 +18,7 @@ Feature: Test searching ownerships
     And the JSON response at "member/0/ownerId" should be "02566c96-8fd3-4b7e-aa35-cbebe6663b2d"
     And the JSON response at "member/0/state" should be "requested"
     And the JSON response at "member/1/id" should be "%{ownershipId2}"
-    And the JSON response at "member/1/ownerId" should be "auth0|631748dba64ea78e3983b202"
+    And the JSON response at "member/1/ownerId" should be "79dd2821-3b89-4dbb-9143-920ff2edfa34"
     And the JSON response at "member/1/state" should be "requested"
     And the JSON response at "member/2/id" should be "%{ownershipId3}"
     And the JSON response at "member/2/ownerId" should be "auth0|631748dba64ea78e3983b203"
@@ -27,7 +27,7 @@ Feature: Test searching ownerships
   Scenario: Searching ownership of an organizer by state
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
-    And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
+    And I request ownership for "79dd2821-3b89-4dbb-9143-920ff2edfa34" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
     And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
     When I reject the ownership with ownershipId "%{ownershipId1}"
     When I approve the ownership with ownershipId "%{ownershipId2}"
@@ -37,7 +37,7 @@ Feature: Test searching ownerships
     And the JSON response at "itemsPerPage" should be 2
     And the JSON response at "totalItems" should be 2
     And the JSON response at "member/0/id" should be "%{ownershipId2}"
-    And the JSON response at "member/0/ownerId" should be "auth0|631748dba64ea78e3983b202"
+    And the JSON response at "member/0/ownerId" should be "79dd2821-3b89-4dbb-9143-920ff2edfa34"
     And the JSON response at "member/0/state" should be "approved"
     And the JSON response at "member/1/id" should be "%{ownershipId3}"
     And the JSON response at "member/1/ownerId" should be "auth0|631748dba64ea78e3983b203"
@@ -70,7 +70,7 @@ Feature: Test searching ownerships
   Scenario: Searching ownership of an organizer by state and with start and limit
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
-    And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
+    And I request ownership for "79dd2821-3b89-4dbb-9143-920ff2edfa34" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
     And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
     And I request ownership for "auth0|631748dba64ea78e3983b204" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId4"
     And I request ownership for "auth0|631748dba64ea78e3983b205" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId5"
@@ -91,7 +91,7 @@ Feature: Test searching ownerships
     Given I create a minimal organizer and save the "id" as "organizerId1"
     And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId1}" and save the "id" as "ownershipId1"
     Given I create a minimal organizer and save the "id" as "organizerId2"
-    And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId2}" and save the "id" as "ownershipId2"
+    And I request ownership for "79dd2821-3b89-4dbb-9143-920ff2edfa34" on the organizer with organizerId "%{organizerId2}" and save the "id" as "ownershipId2"
     And I request ownership for "d759fd36-fb28-4fe3-8ec6-b4aaf990371d" on the organizer with organizerId "%{organizerId2}" and save the "id" as "ownershipId3"
     And I approve the ownership with ownershipId "%{ownershipId3}"
     When I am authorized as JWT provider v2 user "invoerder"
@@ -100,7 +100,7 @@ Feature: Test searching ownerships
     And the JSON response at "itemsPerPage" should be 2
     And the JSON response at "totalItems" should be 2
     And the JSON response at "member/0/id" should be "%{ownershipId2}"
-    And the JSON response at "member/0/ownerId" should be "auth0|631748dba64ea78e3983b202"
+    And the JSON response at "member/0/ownerId" should be "79dd2821-3b89-4dbb-9143-920ff2edfa34"
     And the JSON response at "member/0/state" should be "requested"
     And the JSON response at "member/1/id" should be "%{ownershipId3}"
     And the JSON response at "member/1/ownerId" should be "d759fd36-fb28-4fe3-8ec6-b4aaf990371d"
@@ -110,7 +110,7 @@ Feature: Test searching ownerships
     Given I create a minimal organizer and save the "id" as "organizerId1"
     And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId1}" and save the "id" as "ownershipId1"
     Given I create a minimal organizer and save the "id" as "organizerId2"
-    And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId2}" and save the "id" as "ownershipId2"
+    And I request ownership for "79dd2821-3b89-4dbb-9143-920ff2edfa34" on the organizer with organizerId "%{organizerId2}" and save the "id" as "ownershipId2"
     And I request ownership for "d759fd36-fb28-4fe3-8ec6-b4aaf990371d" on the organizer with organizerId "%{organizerId2}" and save the "id" as "ownershipId3"
     When I am authorized as JWT provider v2 user "invoerder"
     When I send a GET request to '/ownerships/?itemId=%{organizerId2}'

--- a/features/ownership/search.feature
+++ b/features/ownership/search.feature
@@ -9,7 +9,7 @@ Feature: Test searching ownerships
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I request ownership for "79dd2821-3b89-4dbb-9143-920ff2edfa34" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
-    And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
+    And I request ownership for "92650bd8-037f-4722-a40e-7e0a0bf39a8e" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
     When I send a GET request to '/ownerships/?itemId=%{organizerId}'
     Then the response status should be 200
     And the JSON response at "itemsPerPage" should be 3
@@ -21,14 +21,14 @@ Feature: Test searching ownerships
     And the JSON response at "member/1/ownerId" should be "79dd2821-3b89-4dbb-9143-920ff2edfa34"
     And the JSON response at "member/1/state" should be "requested"
     And the JSON response at "member/2/id" should be "%{ownershipId3}"
-    And the JSON response at "member/2/ownerId" should be "auth0|631748dba64ea78e3983b203"
+    And the JSON response at "member/2/ownerId" should be "92650bd8-037f-4722-a40e-7e0a0bf39a8e"
     And the JSON response at "member/2/state" should be "requested"
 
   Scenario: Searching ownership of an organizer by state
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I request ownership for "79dd2821-3b89-4dbb-9143-920ff2edfa34" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
-    And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
+    And I request ownership for "92650bd8-037f-4722-a40e-7e0a0bf39a8e" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
     When I reject the ownership with ownershipId "%{ownershipId1}"
     When I approve the ownership with ownershipId "%{ownershipId2}"
     When I approve the ownership with ownershipId "%{ownershipId3}"
@@ -40,7 +40,7 @@ Feature: Test searching ownerships
     And the JSON response at "member/0/ownerId" should be "79dd2821-3b89-4dbb-9143-920ff2edfa34"
     And the JSON response at "member/0/state" should be "approved"
     And the JSON response at "member/1/id" should be "%{ownershipId3}"
-    And the JSON response at "member/1/ownerId" should be "auth0|631748dba64ea78e3983b203"
+    And the JSON response at "member/1/ownerId" should be "92650bd8-037f-4722-a40e-7e0a0bf39a8e"
     And the JSON response at "member/1/state" should be "approved"
 
   Scenario: Searching ownership of an organizer by ownerId
@@ -71,7 +71,7 @@ Feature: Test searching ownerships
     Given I create a minimal organizer and save the "id" as "organizerId"
     And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I request ownership for "79dd2821-3b89-4dbb-9143-920ff2edfa34" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
-    And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
+    And I request ownership for "92650bd8-037f-4722-a40e-7e0a0bf39a8e" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
     And I request ownership for "auth0|631748dba64ea78e3983b204" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId4"
     And I request ownership for "auth0|631748dba64ea78e3983b205" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId5"
     And I approve the ownership with ownershipId "%{ownershipId1}"

--- a/features/ownership/search.feature
+++ b/features/ownership/search.feature
@@ -7,7 +7,7 @@ Feature: Test searching ownerships
 
   Scenario: Searching ownership of an organizer by item id
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
+    And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
     And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
     When I send a GET request to '/ownerships/?itemId=%{organizerId}'
@@ -15,7 +15,7 @@ Feature: Test searching ownerships
     And the JSON response at "itemsPerPage" should be 3
     And the JSON response at "totalItems" should be 3
     And the JSON response at "member/0/id" should be "%{ownershipId1}"
-    And the JSON response at "member/0/ownerId" should be "auth0|631748dba64ea78e3983b201"
+    And the JSON response at "member/0/ownerId" should be "02566c96-8fd3-4b7e-aa35-cbebe6663b2d"
     And the JSON response at "member/0/state" should be "requested"
     And the JSON response at "member/1/id" should be "%{ownershipId2}"
     And the JSON response at "member/1/ownerId" should be "auth0|631748dba64ea78e3983b202"
@@ -26,7 +26,7 @@ Feature: Test searching ownerships
 
   Scenario: Searching ownership of an organizer by state
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
+    And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
     And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
     When I reject the ownership with ownershipId "%{ownershipId1}"
@@ -45,7 +45,7 @@ Feature: Test searching ownerships
 
   Scenario: Searching ownership of an organizer by ownerId
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+    And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
     And I create a random name of 10 characters and keep it as "ownerId"
     And I request ownership for "%{ownerId}" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I create a minimal organizer and save the "id" as "anotherOrganizerId"
@@ -69,7 +69,7 @@ Feature: Test searching ownerships
 
   Scenario: Searching ownership of an organizer by state and with start and limit
     Given I create a minimal organizer and save the "id" as "organizerId"
-    And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
+    And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId1"
     And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId2"
     And I request ownership for "auth0|631748dba64ea78e3983b203" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId3"
     And I request ownership for "auth0|631748dba64ea78e3983b204" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId4"
@@ -89,7 +89,7 @@ Feature: Test searching ownerships
 
   Scenario: Searching ownership of an organizer takes into permission organisaties bewerken
     Given I create a minimal organizer and save the "id" as "organizerId1"
-    And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId1}" and save the "id" as "ownershipId1"
+    And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId1}" and save the "id" as "ownershipId1"
     Given I create a minimal organizer and save the "id" as "organizerId2"
     And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId2}" and save the "id" as "ownershipId2"
     And I request ownership for "d759fd36-fb28-4fe3-8ec6-b4aaf990371d" on the organizer with organizerId "%{organizerId2}" and save the "id" as "ownershipId3"
@@ -108,7 +108,7 @@ Feature: Test searching ownerships
 
   Scenario: Searching ownership of an organizer takes into account current owner
     Given I create a minimal organizer and save the "id" as "organizerId1"
-    And I request ownership for "auth0|631748dba64ea78e3983b201" on the organizer with organizerId "%{organizerId1}" and save the "id" as "ownershipId1"
+    And I request ownership for "02566c96-8fd3-4b7e-aa35-cbebe6663b2d" on the organizer with organizerId "%{organizerId1}" and save the "id" as "ownershipId1"
     Given I create a minimal organizer and save the "id" as "organizerId2"
     And I request ownership for "auth0|631748dba64ea78e3983b202" on the organizer with organizerId "%{organizerId2}" and save the "id" as "ownershipId2"
     And I request ownership for "d759fd36-fb28-4fe3-8ec6-b4aaf990371d" on the organizer with organizerId "%{organizerId2}" and save the "id" as "ownershipId3"


### PR DESCRIPTION
### Changed

- `search.feature`: Replace non-existing `userIds`
- `docker.md`: Add table with dummyUsers.
- `organizer-with-address.ttl`: Updating RDF checksums & coordinates.

### Fixed

- Acceptance tests should work again.

---

Ticket: https://jira.publiq.be/browse/III-6622
