### PR TITLE
III-6634 bulk update labels

### DIFF
--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -66,6 +66,7 @@ use CultuurNet\UDB3\Http\Offer\UpdateContributorsRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateDescriptionRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateFacilitiesRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateImageRequestHandler;
+use CultuurNet\UDB3\Http\Offer\UpdateLabelsRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateOrganizerFromJsonBodyRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateOrganizerRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdatePriceInfoRequestHandler;
@@ -435,6 +436,7 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
 
         $router->put('/{offerType:events|places}/{offerId}/booking-info/', UpdateBookingInfoRequestHandler::class);
 
+        $router->put('/{offerType:events|places}/{offerId}/labels/', UpdateLabelsRequestHandler::class);
         $router->put('/{offerType:events|places}/{offerId}/labels/{labelName}/', AddLabelRequestHandler::class);
         $router->delete('/{offerType:events|places}/{offerId}/labels/{labelName}/', RemoveLabelRequestHandler::class);
 

--- a/app/Offer/OfferServiceProvider.php
+++ b/app/Offer/OfferServiceProvider.php
@@ -44,6 +44,7 @@ use CultuurNet\UDB3\Http\Offer\UpdateContributorsRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateDescriptionRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateFacilitiesRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateImageRequestHandler;
+use CultuurNet\UDB3\Http\Offer\UpdateLabelsRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateOrganizerFromJsonBodyRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateOrganizerRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdatePriceInfoRequestHandler;
@@ -135,6 +136,7 @@ final class OfferServiceProvider extends AbstractServiceProvider
             AddLabelRequestHandler::class,
             RemoveLabelRequestHandler::class,
             AddLabelFromJsonBodyRequestHandler::class,
+            UpdateLabelsRequestHandler::class,
             UpdateBookingInfoRequestHandler::class,
             UpdateContactPointRequestHandler::class,
             UpdateTitleRequestHandler::class,
@@ -419,6 +421,11 @@ final class OfferServiceProvider extends AbstractServiceProvider
                 $container->get('event_command_bus'),
                 new LabelJSONDeserializer()
             )
+        );
+
+        $container->addShared(
+            UpdateLabelsRequestHandler::class,
+            fn () => new UpdateLabelsRequestHandler($container->get('event_command_bus'))
         );
 
         $container->addShared(

--- a/features/event/labels.feature
+++ b/features/event/labels.feature
@@ -445,3 +445,33 @@ Feature: Test labelling events
     """
     ["public-invisible", "private-invisible"]
     """
+
+  Scenario: Bulk update labels with private label as normal user
+    Given I am authorized as JWT provider v1 user "invoerder_lgm"
+    And I create a minimal place and save the "url" as "placeUrl"
+    And the response status should be "201"
+    And I create a minimal permanent event and save the "id" as "eventId"
+    And I keep the value of the JSON response at "url" as "eventUrl"
+    And the response status should be "201"
+    When I set the JSON request payload to:
+    """
+    {
+      "labels": [
+        "public-visible",
+        "private-visible",
+        "public-invisible",
+        "private-invisible"
+      ]
+    }
+    """
+    And I send a PUT request to "/events/%{eventId}/labels/"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "labels" should be:
+    """
+    ["public-visible"]
+    """
+    And the JSON response at "hiddenLabels" should be:
+    """
+    ["public-invisible"]
+    """

--- a/features/event/labels.feature
+++ b/features/event/labels.feature
@@ -384,3 +384,64 @@ Feature: Test labelling events
     """
     ["%{name}"]
     """
+
+  Scenario: Bulk update labels on an event with initially no labels
+    Given I create a minimal place and save the "url" as "placeUrl"
+    And the response status should be "201"
+    And I create a minimal permanent event and save the "id" as "eventId"
+    And I keep the value of the JSON response at "url" as "eventUrl"
+    And the response status should be "201"
+    When I set the JSON request payload to:
+    """
+    {
+      "labels": [
+        "public-visible",
+        "private-visible",
+        "public-invisible",
+        "private-invisible"
+      ]
+    }
+    """
+    And I send a PUT request to "/events/%{eventId}/labels/"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "labels" should be:
+    """
+    ["public-visible", "private-visible"]
+    """
+    And the JSON response at "hiddenLabels" should be:
+    """
+    ["public-invisible", "private-invisible"]
+    """
+
+  Scenario: Bulk update labels on an event with initial labels
+    Given I create a minimal place and save the "url" as "placeUrl"
+    And the response status should be "201"
+    And I create a minimal permanent event and save the "id" as "eventId"
+    And the response status should be "201"
+    And I keep the value of the JSON response at "url" as "eventUrl"
+    And I create a random name of 10 characters
+    And I send a PUT request to "/events/%{eventId}/labels/%{name}"
+    Then the response status should be "204"
+    When I set the JSON request payload to:
+    """
+    {
+      "labels": [
+        "public-visible",
+        "private-visible",
+        "public-invisible",
+        "private-invisible"
+      ]
+    }
+    """
+    And I send a PUT request to "/events/%{eventId}/labels/"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "labels" should be:
+    """
+    ["%{name}", "public-visible", "private-visible"]
+    """
+    And the JSON response at "hiddenLabels" should be:
+    """
+    ["public-invisible", "private-invisible"]
+    """

--- a/src/Http/Offer/UpdateLabelsRequestHandler.php
+++ b/src/Http/Offer/UpdateLabelsRequestHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Offer;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Model\Serializer\ValueObject\Taxonomy\Label\LabelsDenormalizer;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
+use CultuurNet\UDB3\Offer\Commands\ImportLabels;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class UpdateLabelsRequestHandler implements RequestHandlerInterface
+{
+    private CommandBus $commandBus;
+
+    public function __construct(CommandBus $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+        $offerId = $routeParameters->getOfferId();
+
+        /** @var Labels $labels */
+        $labels = RequestBodyParserFactory::createBaseParser(
+            new DenormalizingRequestBodyParser(new LabelsDenormalizer(), Labels::class)
+        )
+            ->parse($request)
+            ->getParsedBody();
+
+        $this->commandBus->dispatch(new ImportLabels($offerId, $labels));
+
+        return new NoContentResponse();
+    }
+}

--- a/tests/Http/Offer/UpdateLabelsRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateLabelsRequestHandlerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Offer;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
+use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
+use CultuurNet\UDB3\Offer\Commands\ImportLabels;
+use PHPUnit\Framework\TestCase;
+
+class UpdateLabelsRequestHandlerTest extends TestCase
+{
+    use AssertJsonResponseTrait;
+
+    private TraceableCommandBus $commandBus;
+
+    private UpdateLabelsRequestHandler $updateLabelsRequestHandler;
+
+    private Psr7RequestBuilder $psr7RequestBuilder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->commandBus = new TraceableCommandBus();
+
+        $this->updateLabelsRequestHandler = new UpdateLabelsRequestHandler($this->commandBus);
+
+        $this->psr7RequestBuilder = new Psr7RequestBuilder();
+
+        $this->commandBus->record();
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_adding_labels_to_an_offer(): void
+    {
+        $updateLabelsRequest = $this->psr7RequestBuilder
+            ->withRouteParameter('offerType', 'event')
+            ->withRouteParameter('offerId', 'd2a039e9-f4d6-4080-ae33-a106b5d3d47b')
+            ->withJsonBodyFromArray(['labels' => ['label1', 'label2']])
+            ->build('PUT');
+
+        $response = $this->updateLabelsRequestHandler->handle($updateLabelsRequest);
+
+        $this->assertEquals(
+            [
+                new ImportLabels(
+                    'd2a039e9-f4d6-4080-ae33-a106b5d3d47b',
+                    new Labels(
+                        new Label(new LabelName('label1')),
+                        new Label(new LabelName('label2'))
+                    )
+                ),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+
+        $this->assertJsonResponse(new NoContentResponse(), $response);
+    }
+}


### PR DESCRIPTION
### Added
- Added new endpoint `PUT '/{offerType:events|places}/{offerId}/labels/'` to update all labels on an event or place

### Note
- For now the API docs and the JSON schema validation is still missing

---

Ticket: https://jira.uitdatabank.be/browse/III-6634
