### PR TITLE
III-6579 Updated cultuurkuur endpoints

### DIFF
--- a/src/Cultuurkuur/data/education-levels.json
+++ b/src/Cultuurkuur/data/education-levels.json
@@ -1,209 +1,193 @@
 [
     {
         "name": {
-            "nl": "Basisonderwijs"
+            "nl": "Gewoon basisonderwijs (kleuter- en basis)"
         },
-        "label": "cultuurkuur_basisonderwijs",
+        "label": "cultuurkuur_Gewoon-basisonderwijs",
         "children": [
             {
                 "name": {
-                    "nl": "Gewoon basisonderwijs"
+                    "nl": "Gewoon kleuteronderwijs"
                 },
-                "label": "cultuurkuur_Gewoon-basisonderwijs",
+                "label": "cultuurkuur_Gewoon-kleuteronderwijs",
                 "children": [
                     {
                         "name": {
-                            "nl": "Gewoon kleuteronderwijs"
+                            "nl": "Kleuter (2-3 jaar)"
                         },
-                        "label": "cultuurkuur_Gewoon-kleuteronderwijs",
-                        "children": [
-                            {
-                                "name": {
-                                    "nl": "Kleuter (2-3 jaar)"
-                                },
-                                "label": "cultuurkuur_Kleuter-2-3-jaar"
-                            },
-                            {
-                                "name": {
-                                    "nl": "Kleuter (3-4 jaar)"
-                                },
-                                "label": "cultuurkuur_Kleuter-3-4-jaar"
-                            },
-                            {
-                                "name": {
-                                    "nl": "Kleuter (4-5 jaar)"
-                                },
-                                "label": "cultuurkuur_Kleuter-4-5-jaar"
-                            }
-                        ]
+                        "label": "cultuurkuur_Kleuter-2-3-jaar"
                     },
                     {
                         "name": {
-                            "nl": "Gewoon lager onderwijs"
+                            "nl": "Kleuter (3-4 jaar)"
                         },
-                        "label": "cultuurkuur_Gewoon-lager-onderwijs",
-                        "children": [
-                            {
-                                "name": {
-                                    "nl": "Eerste graad"
-                                },
-                                "label": "cultuurkuur_1ste-graad"
-                            },
-                            {
-                                "name": {
-                                    "nl": "Tweede graad"
-                                },
-                                "label": "cultuurkuur_2de-graad"
-                            },
-                            {
-                                "name": {
-                                    "nl": "Derde graad"
-                                },
-                                "label": "cultuurkuur_3de-graad"
-                            }
-                        ]
+                        "label": "cultuurkuur_Kleuter-3-4-jaar"
                     },
                     {
                         "name": {
-                            "nl": "Onthaalonderwijs voor anderstalige nieuwkomers (OKAN)"
+                            "nl": "Kleuter (4-5 jaar)"
                         },
-                        "label": "cultuurkuur_Onthaalonderwijs-voor-anderstalige-nieuwkomers (OKAN)"
+                        "label": "cultuurkuur_Kleuter-4-5-jaar"
                     }
                 ]
             },
             {
                 "name": {
-                    "nl": "Buitengewoon basisonderwijs"
+                    "nl": "Gewoon lager onderwijs"
                 },
-                "label": "cultuurkuur_Buitengewoon-basisonderwijs",
-                "children": [
-                    {
-                        "name": {
-                            "nl": "Buitengewoon kleuteronderwijs"
-                        },
-                        "label": "cultuurkuur_Buitengewoon-kleuteronderwijs"
-                    },
-                    {
-                        "name": {
-                            "nl": "Buitengewoon lager onderwijs"
-                        },
-                        "label": "cultuurkuur_Buitengewoon-lager-onderwijs"
-                    }
-                ]
-            }
-        ]
-    },
-    {
-        "name": {
-            "nl": "Secundair onderwijs"
-        },
-        "label": "cultuurkuur_Secundair-onderwijs",
-        "children": [
-            {
-                "name": {
-                    "nl": "Voltijds gewoon secundair onderwijs"
-                },
-                "label": "cultuurkuur_Voltijds-gewoon-secundair-onderwijs",
+                "label": "cultuurkuur_Gewoon-lager-onderwijs",
                 "children": [
                     {
                         "name": {
                             "nl": "Eerste graad"
                         },
-                        "label": "cultuurkuur_eerste-graad",
-                        "children": [
-                            {
-                                "name": {
-                                    "nl": "A-stroom"
-                                },
-                                "label": "cultuurkuur_A-stroom"
-                            },
-                            {
-                                "name": {
-                                    "nl": "B-stroom"
-                                },
-                                "label": "cultuurkuur_B-stroom"
-                            }
-                        ]
+                        "label": "cultuurkuur_1ste-graad"
                     },
                     {
                         "name": {
                             "nl": "Tweede graad"
                         },
-                        "label": "cultuurkuur_tweede-graad",
-                        "children": [
-                            {
-                                "name": {
-                                    "nl": "Finaliteit doorstroom"
-                                },
-                                "label": "cultuurkuur_finaliteit-tweede-doorstroom"
-                            },
-                            {
-                                "name": {
-                                    "nl": "Finaliteit arbeidsmarkt"
-                                },
-                                "label": "cultuurkuur_finaliteit-tweede-arbeidsmarkt"
-                            },
-                            {
-                                "name": {
-                                    "nl": "Dubbele finaliteit"
-                                },
-                                "label": "cultuurkuur_dubbele-tweede-finaliteit"
-                            }
-                        ]
+                        "label": "cultuurkuur_2de-graad"
                     },
                     {
                         "name": {
                             "nl": "Derde graad"
                         },
-                        "label": "cultuurkuur_derde-graad",
-                        "children": [
-                            {
-                                "name": {
-                                    "nl": "Finaliteit doorstroom"
-                                },
-                                "label": "cultuurkuur_finaliteit-derdre-doorstroom"
-                            },
-                            {
-                                "name": {
-                                    "nl": "Finaliteit arbeidsmarkt"
-                                },
-                                "label": "cultuurkuur_finaliteit-derdre-arbeidsmarkt"
-                            },
-                            {
-                                "name": {
-                                    "nl": "Dubbele finaliteit"
-                                },
-                                "label": "cultuurkuur_dubbele-derdre-finaliteit"
-                            }
-                        ]
-                    },
-                    {
-                        "name": {
-                            "nl": "Secundair na Secundair (Se-n-Se)"
-                        },
-                        "label": "cultuurkuur_Secundair-na-secundair-(Se-n-Se)"
-                    },
-                    {
-                        "name": {
-                            "nl": "Onthaalonderwijs voor anderstalige nieuwkomers (OKAN)"
-                        },
-                        "label": "cultuurkuur_Onthaalonderwijs-voor-anderstalige-nieuwkomers-OKAN"
+                        "label": "cultuurkuur_3de-graad"
                     }
                 ]
             },
             {
                 "name": {
-                    "nl": "Buitengewoon secundair onderwijs"
+                    "nl": "Onthaalonderwijs voor anderstalige nieuwkomers (OKAN)"
                 },
-                "label": "cultuurkuur_Buitengewoon-secundair-onderwijs"
+                "label": "cultuurkuur_Onthaalonderwijs-voor-anderstalige-nieuwkomers (OKAN)"
+            }
+        ]
+    },
+    {
+        "name": {
+            "nl": "Buitengewoon basisonderwijs"
+        },
+        "label": "cultuurkuur_Buitengewoon-basisonderwijs",
+        "children": [
+            {
+                "name": {
+                    "nl": "Buitengewoon kleuteronderwijs"
+                },
+                "label": "cultuurkuur_Buitengewoon-kleuteronderwijs"
             },
             {
                 "name": {
-                    "nl": "Deeltijds leren en werken"
+                    "nl": "Buitengewoon lager onderwijs"
                 },
-                "label": "cultuurkuur_Deeltijds-leren-en-werken"
+                "label": "cultuurkuur_Buitengewoon-lager-onderwijs"
             }
         ]
+    },
+    {
+        "name": {
+            "nl": "Gewoon secundair onderwijs"
+        },
+        "label": "cultuurkuur_Voltijds-gewoon-secundair-onderwijs",
+        "children": [
+            {
+                "name": {
+                    "nl": "Eerste graad"
+                },
+                "label": "cultuurkuur_eerste-graad",
+                "children": [
+                    {
+                        "name": {
+                            "nl": "A-stroom"
+                        },
+                        "label": "cultuurkuur_eerste-graad-A-stroom"
+                    },
+                    {
+                        "name": {
+                            "nl": "B-stroom"
+                        },
+                        "label": "cultuurkuur_eerste-graad-B-stroom"
+                    }
+                ]
+            },
+            {
+                "name": {
+                    "nl": "Tweede graad"
+                },
+                "label": "cultuurkuur_tweede-graad",
+                "children": [
+                    {
+                        "name": {
+                            "nl": "Finaliteit doorstroom"
+                        },
+                        "label": "cultuurkuur_tweede-graad-finaliteit-doorstroom"
+                    },
+                    {
+                        "name": {
+                            "nl": "Finaliteit arbeidsmarkt"
+                        },
+                        "label": "cultuurkuur_tweede-graad-finaliteit-arbeidsmarkt"
+                    },
+                    {
+                        "name": {
+                            "nl": "Dubbele finaliteit"
+                        },
+                        "label": "cultuurkuur_tweede-graad-dubbele-finaliteit"
+                    }
+                ]
+            },
+            {
+                "name": {
+                    "nl": "Derde graad"
+                },
+                "label": "cultuurkuur_derde-graad",
+                "children": [
+                    {
+                        "name": {
+                            "nl": "Finaliteit doorstroom"
+                        },
+                        "label": "cultuurkuur_derde-graad-finaliteit-doorstroom"
+                    },
+                    {
+                        "name": {
+                            "nl": "Finaliteit arbeidsmarkt"
+                        },
+                        "label": "cultuurkuur_derde-graad-finaliteit-arbeidsmarkt"
+                    },
+                    {
+                        "name": {
+                            "nl": "Dubbele finaliteit"
+                        },
+                        "label": "cultuurkuur_derde-graad-dubbele-finaliteit"
+                    }
+                ]
+            },
+            {
+                "name": {
+                    "nl": "Secundair na Secundair (Se-n-Se)"
+                },
+                "label": "cultuurkuur_Secundair-na-secundair-(Se-n-Se)"
+            },
+            {
+                "name": {
+                    "nl": "Onthaalonderwijs voor anderstalige nieuwkomers (OKAN)"
+                },
+                "label": "cultuurkuur_Onthaalonderwijs-voor-anderstalige-nieuwkomers-OKAN"
+            }
+        ]
+    },
+    {
+        "name": {
+            "nl": "Buitengewoon secundair onderwijs"
+        },
+        "label": "cultuurkuur_Buitengewoon-secundair-onderwijs"
+    },
+    {
+        "name": {
+            "nl": "Deeltijds leren en werken"
+        },
+        "label": "cultuurkuur_Deeltijds-leren-en-werken"
     },
     {
         "name": {

--- a/src/Cultuurkuur/data/regions.json
+++ b/src/Cultuurkuur/data/regions.json
@@ -4,124 +4,124 @@
             "nl": "Brussels Hoofdstedelijk Gewest"
         },
         "label": "cultuurkuur_werkingsregio_provincie_nis-01000",
+        "extraLabel": "cultuurkuur_werkingsregio_nis-01000",
         "children": [
             {
                 "name": {
                     "nl": "Regio Brussel"
                 },
-                "label": "reg-brussel",
                 "children": [
                     {
                         "name": {
-                            "nl": "Anderlecht + deelgemeenten"
+                            "nl": "Anderlecht"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21001"
                     },
                     {
                         "name": {
-                            "nl": "Brussel + deelgemeenten"
+                            "nl": "Brussel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21004"
                     },
                     {
                         "name": {
-                            "nl": "Elsene + deelgemeenten"
+                            "nl": "Elsene"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21009"
                     },
                     {
                         "name": {
-                            "nl": "Etterbeek + deelgemeenten"
+                            "nl": "Etterbeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21005"
                     },
                     {
                         "name": {
-                            "nl": "Evere + deelgemeenten"
+                            "nl": "Evere"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21006"
                     },
                     {
                         "name": {
-                            "nl": "Ganshoren + deelgemeenten"
+                            "nl": "Ganshoren"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21008"
                     },
                     {
                         "name": {
-                            "nl": "Jette + deelgemeenten"
+                            "nl": "Jette"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21010"
                     },
                     {
                         "name": {
-                            "nl": "Koekelberg + deelgemeenten"
+                            "nl": "Koekelberg"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21011"
                     },
                     {
                         "name": {
-                            "nl": "Oudergem + deelgemeenten"
+                            "nl": "Oudergem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21002"
                     },
                     {
                         "name": {
-                            "nl": "Schaarbeek + deelgemeenten"
+                            "nl": "Schaarbeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21015"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Agatha-Berchem + deelgemeenten"
+                            "nl": "Sint-Agatha-Berchem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21003"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Gillis + deelgemeenten"
+                            "nl": "Sint-Gillis"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21013"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Jans-Molenbeek + deelgemeenten"
+                            "nl": "Sint-Jans-Molenbeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21012"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Joost-ten-Node + deelgemeenten"
+                            "nl": "Sint-Joost-ten-Node"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21014"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Lambrechts-Woluwe + deelgemeenten"
+                            "nl": "Sint-Lambrechts-Woluwe"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21018"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Pieters-Woluwe + deelgemeenten"
+                            "nl": "Sint-Pieters-Woluwe"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21019"
                     },
                     {
                         "name": {
-                            "nl": "Ukkel + deelgemeenten"
+                            "nl": "Ukkel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21016"
                     },
                     {
                         "name": {
-                            "nl": "Vorst + deelgemeenten"
+                            "nl": "Vorst"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21007"
                     },
                     {
                         "name": {
-                            "nl": "Watermaal-Bosvoorde + deelgemeenten"
+                            "nl": "Watermaal-Bosvoorde"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21017"
                     }
@@ -134,414 +134,66 @@
             "nl": "Provincie Antwerpen"
         },
         "label": "cultuurkuur_werkingsregio_provincie_nis-10000",
+        "extraLabel": "cultuurkuur_werkingsregio_nis-10000",
         "children": [
             {
                 "name": {
                     "nl": "Regio Antwerpen"
                 },
-                "label": "reg-antwerpen",
                 "children": [
                     {
                         "name": {
-                            "nl": "Antwerpen + deelgemeenten"
+                            "nl": "Antwerpen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11002"
                     },
                     {
                         "name": {
-                            "nl": "Wommelgem + deelgemeenten"
+                            "nl": "Wommelgem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11052"
                     },
                     {
                         "name": {
-                            "nl": "Boechout + deelgemeenten"
+                            "nl": "Boechout"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11004"
                     },
                     {
                         "name": {
-                            "nl": "Hove + deelgemeenten"
+                            "nl": "Hove"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11021"
                     },
                     {
                         "name": {
-                            "nl": "Lint + deelgemeenten"
+                            "nl": "Lint"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11025"
                     },
                     {
                         "name": {
-                            "nl": "Kontich + deelgemeenten"
+                            "nl": "Kontich"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11024"
                     },
                     {
                         "name": {
-                            "nl": "Aartselaar + deelgemeenten"
+                            "nl": "Aartselaar"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11001"
                     },
                     {
                         "name": {
-                            "nl": "Mortsel + deelgemeenten"
+                            "nl": "Mortsel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11029"
                     },
                     {
                         "name": {
-                            "nl": "Edegem + deelgemeenten"
+                            "nl": "Edegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mechelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hemiksem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Schelle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Rumst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Niel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Boom + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Willebroek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bornem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Puurs-Sint-Amands + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wijnegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11050"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zandhoven + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11054"
-                    },
-                    {
-                        "name": {
-                            "nl": "Malle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11057"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ranst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Schoten + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Essen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kalmthout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brasschaat + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Stabroek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11044"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kapellen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brecht + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Schilde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zoersel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11055"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wuustwezel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11053"
-                    },
-                    {
-                        "name": {
-                            "nl": "Duffel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bonheiden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Katelijne-Waver + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herentals + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hulshout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Olen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Westerlo + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13049"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herenthout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lille + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Grobbendonk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Vorselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13044"
-                    },
-                    {
-                        "name": {
-                            "nl": "Turnhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Rijkevorsel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hoogstraten + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Merksplas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beerse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Vosselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13046"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oud-Turnhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13031"
-                    },
-                    {
-                        "name": {
-                            "nl": "Arendonk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ravels + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Baarle-Hertog + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mol + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Laakdal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13053"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Meerhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kasterlee + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Retie + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13036"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dessel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Balen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heist-op-den-Berg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lier + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nijlen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12026"
-                    },
-                    {
-                        "name": {
-                            "nl": "Putte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Berlaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12002"
                     }
                 ]
             },
@@ -549,409 +201,12 @@
                 "name": {
                     "nl": "Regio Mechelen"
                 },
-                "label": "reg-mechelen",
                 "children": [
                     {
                         "name": {
-                            "nl": "Antwerpen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wommelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11052"
-                    },
-                    {
-                        "name": {
-                            "nl": "Boechout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hove + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lint + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kontich + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aartselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mortsel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Edegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mechelen + deelgemeenten"
+                            "nl": "Mechelen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hemiksem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Schelle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Rumst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Niel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Boom + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Willebroek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bornem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Puurs-Sint-Amands + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wijnegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11050"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zandhoven + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11054"
-                    },
-                    {
-                        "name": {
-                            "nl": "Malle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11057"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ranst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Schoten + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Essen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kalmthout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brasschaat + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Stabroek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11044"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kapellen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brecht + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Schilde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zoersel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11055"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wuustwezel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11053"
-                    },
-                    {
-                        "name": {
-                            "nl": "Duffel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bonheiden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Katelijne-Waver + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herentals + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hulshout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Olen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Westerlo + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13049"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herenthout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lille + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Grobbendonk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Vorselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13044"
-                    },
-                    {
-                        "name": {
-                            "nl": "Turnhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Rijkevorsel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hoogstraten + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Merksplas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beerse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Vosselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13046"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oud-Turnhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13031"
-                    },
-                    {
-                        "name": {
-                            "nl": "Arendonk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ravels + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Baarle-Hertog + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mol + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Laakdal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13053"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Meerhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kasterlee + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Retie + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13036"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dessel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Balen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heist-op-den-Berg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lier + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nijlen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12026"
-                    },
-                    {
-                        "name": {
-                            "nl": "Putte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Berlaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12002"
                     }
                 ]
             },
@@ -959,409 +214,54 @@
                 "name": {
                     "nl": "Regio Scheldeland Antwerpen"
                 },
-                "label": "reg-scheldeland-antwerpen",
                 "children": [
                     {
                         "name": {
-                            "nl": "Antwerpen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wommelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11052"
-                    },
-                    {
-                        "name": {
-                            "nl": "Boechout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hove + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lint + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kontich + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aartselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mortsel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Edegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mechelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hemiksem + deelgemeenten"
+                            "nl": "Hemiksem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11018"
                     },
                     {
                         "name": {
-                            "nl": "Schelle + deelgemeenten"
+                            "nl": "Schelle"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11038"
                     },
                     {
                         "name": {
-                            "nl": "Rumst + deelgemeenten"
+                            "nl": "Rumst"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11037"
                     },
                     {
                         "name": {
-                            "nl": "Niel + deelgemeenten"
+                            "nl": "Niel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11030"
                     },
                     {
                         "name": {
-                            "nl": "Boom + deelgemeenten"
+                            "nl": "Boom"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11005"
                     },
                     {
                         "name": {
-                            "nl": "Willebroek + deelgemeenten"
+                            "nl": "Willebroek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12040"
                     },
                     {
                         "name": {
-                            "nl": "Bornem + deelgemeenten"
+                            "nl": "Bornem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12007"
                     },
                     {
                         "name": {
-                            "nl": "Puurs-Sint-Amands + deelgemeenten"
+                            "nl": "Puurs-Sint-Amands"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wijnegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11050"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zandhoven + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11054"
-                    },
-                    {
-                        "name": {
-                            "nl": "Malle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11057"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ranst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Schoten + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Essen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kalmthout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brasschaat + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Stabroek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11044"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kapellen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brecht + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Schilde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zoersel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11055"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wuustwezel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11053"
-                    },
-                    {
-                        "name": {
-                            "nl": "Duffel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bonheiden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Katelijne-Waver + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herentals + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hulshout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Olen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Westerlo + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13049"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herenthout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lille + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Grobbendonk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Vorselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13044"
-                    },
-                    {
-                        "name": {
-                            "nl": "Turnhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Rijkevorsel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hoogstraten + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Merksplas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beerse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Vosselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13046"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oud-Turnhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13031"
-                    },
-                    {
-                        "name": {
-                            "nl": "Arendonk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ravels + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Baarle-Hertog + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mol + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Laakdal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13053"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Meerhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kasterlee + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Retie + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13036"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dessel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Balen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-13003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heist-op-den-Berg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lier + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nijlen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12026"
-                    },
-                    {
-                        "name": {
-                            "nl": "Putte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Berlaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12002"
                     }
                 ]
             },
@@ -1369,407 +269,298 @@
                 "name": {
                     "nl": "Regio Kempen"
                 },
-                "label": "reg-kempen",
                 "children": [
                     {
                         "name": {
-                            "nl": "Antwerpen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wommelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11052"
-                    },
-                    {
-                        "name": {
-                            "nl": "Boechout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hove + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lint + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kontich + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aartselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mortsel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Edegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mechelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hemiksem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Schelle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Rumst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Niel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Boom + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-11005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Willebroek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bornem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Puurs-Sint-Amands + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-12041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wijnegem + deelgemeenten"
+                            "nl": "Wijnegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11050"
                     },
                     {
                         "name": {
-                            "nl": "Zandhoven + deelgemeenten"
+                            "nl": "Zandhoven"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11054"
                     },
                     {
                         "name": {
-                            "nl": "Malle + deelgemeenten"
+                            "nl": "Malle"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11057"
                     },
                     {
                         "name": {
-                            "nl": "Ranst + deelgemeenten"
+                            "nl": "Ranst"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11035"
                     },
                     {
                         "name": {
-                            "nl": "Schoten + deelgemeenten"
+                            "nl": "Schoten"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11040"
                     },
                     {
                         "name": {
-                            "nl": "Essen + deelgemeenten"
+                            "nl": "Essen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11016"
                     },
                     {
                         "name": {
-                            "nl": "Kalmthout + deelgemeenten"
+                            "nl": "Kalmthout"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11022"
                     },
                     {
                         "name": {
-                            "nl": "Brasschaat + deelgemeenten"
+                            "nl": "Brasschaat"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11008"
                     },
                     {
                         "name": {
-                            "nl": "Stabroek + deelgemeenten"
+                            "nl": "Stabroek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11044"
                     },
                     {
                         "name": {
-                            "nl": "Kapellen + deelgemeenten"
+                            "nl": "Kapellen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11023"
                     },
                     {
                         "name": {
-                            "nl": "Brecht + deelgemeenten"
+                            "nl": "Brecht"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11009"
                     },
                     {
                         "name": {
-                            "nl": "Schilde + deelgemeenten"
+                            "nl": "Schilde"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11039"
                     },
                     {
                         "name": {
-                            "nl": "Zoersel + deelgemeenten"
+                            "nl": "Zoersel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11055"
                     },
                     {
                         "name": {
-                            "nl": "Wuustwezel + deelgemeenten"
+                            "nl": "Wuustwezel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-11053"
                     },
                     {
                         "name": {
-                            "nl": "Duffel + deelgemeenten"
+                            "nl": "Duffel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12009"
                     },
                     {
                         "name": {
-                            "nl": "Bonheiden + deelgemeenten"
+                            "nl": "Bonheiden"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12005"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Katelijne-Waver + deelgemeenten"
+                            "nl": "Sint-Katelijne-Waver"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12035"
                     },
                     {
                         "name": {
-                            "nl": "Herentals + deelgemeenten"
+                            "nl": "Herentals"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13011"
                     },
                     {
                         "name": {
-                            "nl": "Herselt + deelgemeenten"
+                            "nl": "Herselt"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13013"
                     },
                     {
                         "name": {
-                            "nl": "Hulshout + deelgemeenten"
+                            "nl": "Hulshout"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13016"
                     },
                     {
                         "name": {
-                            "nl": "Olen + deelgemeenten"
+                            "nl": "Olen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13029"
                     },
                     {
                         "name": {
-                            "nl": "Westerlo + deelgemeenten"
+                            "nl": "Westerlo"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13049"
                     },
                     {
                         "name": {
-                            "nl": "Herenthout + deelgemeenten"
+                            "nl": "Herenthout"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13012"
                     },
                     {
                         "name": {
-                            "nl": "Lille + deelgemeenten"
+                            "nl": "Lille"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13019"
                     },
                     {
                         "name": {
-                            "nl": "Grobbendonk + deelgemeenten"
+                            "nl": "Grobbendonk"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13010"
                     },
                     {
                         "name": {
-                            "nl": "Vorselaar + deelgemeenten"
+                            "nl": "Vorselaar"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13044"
                     },
                     {
                         "name": {
-                            "nl": "Turnhout + deelgemeenten"
+                            "nl": "Turnhout"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13040"
                     },
                     {
                         "name": {
-                            "nl": "Rijkevorsel + deelgemeenten"
+                            "nl": "Rijkevorsel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13037"
                     },
                     {
                         "name": {
-                            "nl": "Hoogstraten + deelgemeenten"
+                            "nl": "Hoogstraten"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13014"
                     },
                     {
                         "name": {
-                            "nl": "Merksplas + deelgemeenten"
+                            "nl": "Merksplas"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13023"
                     },
                     {
                         "name": {
-                            "nl": "Beerse + deelgemeenten"
+                            "nl": "Beerse"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13004"
                     },
                     {
                         "name": {
-                            "nl": "Vosselaar + deelgemeenten"
+                            "nl": "Vosselaar"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13046"
                     },
                     {
                         "name": {
-                            "nl": "Oud-Turnhout + deelgemeenten"
+                            "nl": "Oud-Turnhout"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13031"
                     },
                     {
                         "name": {
-                            "nl": "Arendonk + deelgemeenten"
+                            "nl": "Arendonk"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13001"
                     },
                     {
                         "name": {
-                            "nl": "Ravels + deelgemeenten"
+                            "nl": "Ravels"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13035"
                     },
                     {
                         "name": {
-                            "nl": "Baarle-Hertog + deelgemeenten"
+                            "nl": "Baarle-Hertog"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13002"
                     },
                     {
                         "name": {
-                            "nl": "Mol + deelgemeenten"
+                            "nl": "Mol"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13025"
                     },
                     {
                         "name": {
-                            "nl": "Laakdal + deelgemeenten"
+                            "nl": "Laakdal"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13053"
                     },
                     {
                         "name": {
-                            "nl": "Geel + deelgemeenten"
+                            "nl": "Geel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13008"
                     },
                     {
                         "name": {
-                            "nl": "Meerhout + deelgemeenten"
+                            "nl": "Meerhout"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13021"
                     },
                     {
                         "name": {
-                            "nl": "Kasterlee + deelgemeenten"
+                            "nl": "Kasterlee"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13017"
                     },
                     {
                         "name": {
-                            "nl": "Retie + deelgemeenten"
+                            "nl": "Retie"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13036"
                     },
                     {
                         "name": {
-                            "nl": "Dessel + deelgemeenten"
+                            "nl": "Dessel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13006"
                     },
                     {
                         "name": {
-                            "nl": "Balen + deelgemeenten"
+                            "nl": "Balen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-13003"
                     },
                     {
                         "name": {
-                            "nl": "Heist-op-den-Berg + deelgemeenten"
+                            "nl": "Heist-op-den-Berg"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12014"
                     },
                     {
                         "name": {
-                            "nl": "Lier + deelgemeenten"
+                            "nl": "Lier"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12021"
                     },
                     {
                         "name": {
-                            "nl": "Nijlen + deelgemeenten"
+                            "nl": "Nijlen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12026"
                     },
                     {
                         "name": {
-                            "nl": "Putte + deelgemeenten"
+                            "nl": "Putte"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12029"
                     },
                     {
                         "name": {
-                            "nl": "Berlaar + deelgemeenten"
+                            "nl": "Berlaar"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-12002"
                     }
@@ -1782,384 +573,264 @@
             "nl": "Provincie Vlaams-Brabant"
         },
         "label": "cultuurkuur_werkingsregio_provincie_nis-20001",
+        "extraLabel": "cultuurkuur_werkingsregio_nis-20001",
         "children": [
             {
                 "name": {
                     "nl": "Regio Groene Gordel"
                 },
-                "label": "reg-groene-gordel",
                 "children": [
                     {
                         "name": {
-                            "nl": "Vilvoorde + deelgemeenten"
+                            "nl": "Vilvoorde"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23088"
                     },
                     {
                         "name": {
-                            "nl": "Steenokkerzeel + deelgemeenten"
+                            "nl": "Steenokkerzeel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23081"
                     },
                     {
                         "name": {
-                            "nl": "Machelen + deelgemeenten"
+                            "nl": "Machelen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23047"
                     },
                     {
                         "name": {
-                            "nl": "Grimbergen + deelgemeenten"
+                            "nl": "Grimbergen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23025"
                     },
                     {
                         "name": {
-                            "nl": "Meise + deelgemeenten"
+                            "nl": "Meise"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23050"
                     },
                     {
                         "name": {
-                            "nl": "Kapelle-op-den-Bos + deelgemeenten"
+                            "nl": "Kapelle-op-den-Bos"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23039"
                     },
                     {
                         "name": {
-                            "nl": "Kampenhout + deelgemeenten"
+                            "nl": "Kampenhout"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23038"
                     },
                     {
                         "name": {
-                            "nl": "Zaventem + deelgemeenten"
+                            "nl": "Zaventem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23094"
                     },
                     {
                         "name": {
-                            "nl": "Kraainem + deelgemeenten"
+                            "nl": "Kraainem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23099"
                     },
                     {
                         "name": {
-                            "nl": "Wezembeek-Oppem + deelgemeenten"
+                            "nl": "Wezembeek-Oppem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23103"
                     },
                     {
                         "name": {
-                            "nl": "Zemst + deelgemeenten"
+                            "nl": "Zemst"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23096"
                     },
                     {
                         "name": {
-                            "nl": "Halle + deelgemeenten"
+                            "nl": "Halle"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23027"
                     },
                     {
                         "name": {
-                            "nl": "Pajottegem + deelgemeenten"
+                            "nl": "Pajottegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21001"
                     },
                     {
                         "name": {
-                            "nl": "Bever + deelgemeenten"
+                            "nl": "Bever"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23009"
                     },
                     {
                         "name": {
-                            "nl": "Hoeilaart + deelgemeenten"
+                            "nl": "Hoeilaart"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23033"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Pieters-Leeuw + deelgemeenten"
+                            "nl": "Sint-Pieters-Leeuw"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23077"
                     },
                     {
                         "name": {
-                            "nl": "Drogenbos + deelgemeenten"
+                            "nl": "Drogenbos"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23098"
                     },
                     {
                         "name": {
-                            "nl": "Linkebeek + deelgemeenten"
+                            "nl": "Linkebeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23100"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Genesius-Rode + deelgemeenten"
+                            "nl": "Sint-Genesius-Rode"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23101"
                     },
                     {
                         "name": {
-                            "nl": "Beersel + deelgemeenten"
+                            "nl": "Beersel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23003"
                     },
                     {
                         "name": {
-                            "nl": "Pepingen + deelgemeenten"
+                            "nl": "Pepingen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23064"
                     },
                     {
                         "name": {
-                            "nl": "Dilbeek + deelgemeenten"
+                            "nl": "Dilbeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23016"
                     },
                     {
                         "name": {
-                            "nl": "Asse + deelgemeenten"
+                            "nl": "Asse"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23002"
                     },
                     {
                         "name": {
-                            "nl": "Ternat + deelgemeenten"
+                            "nl": "Ternat"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23086"
                     },
                     {
                         "name": {
-                            "nl": "Opwijk + deelgemeenten"
+                            "nl": "Opwijk"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23060"
                     },
                     {
                         "name": {
-                            "nl": "Lennik + deelgemeenten"
+                            "nl": "Lennik"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23104"
                     },
                     {
                         "name": {
-                            "nl": "Roosdaal + deelgemeenten"
+                            "nl": "Roosdaal"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23097"
                     },
                     {
                         "name": {
-                            "nl": "Liedekerke + deelgemeenten"
+                            "nl": "Liedekerke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23044"
                     },
                     {
                         "name": {
-                            "nl": "Wemmel + deelgemeenten"
+                            "nl": "Wemmel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23102"
                     },
                     {
                         "name": {
-                            "nl": "Merchtem + deelgemeenten"
+                            "nl": "Merchtem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23052"
                     },
                     {
                         "name": {
-                            "nl": "Affligem + deelgemeenten"
+                            "nl": "Affligem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23105"
                     },
                     {
                         "name": {
-                            "nl": "Londerzeel + deelgemeenten"
+                            "nl": "Londerzeel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23045"
                     },
                     {
                         "name": {
-                            "nl": "Herent + deelgemeenten"
+                            "nl": "Herent"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24038"
                     },
                     {
                         "name": {
-                            "nl": "Huldenberg + deelgemeenten"
+                            "nl": "Huldenberg"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24045"
                     },
                     {
                         "name": {
-                            "nl": "Oud-Heverlee + deelgemeenten"
+                            "nl": "Oud-Heverlee"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24086"
                     },
                     {
                         "name": {
-                            "nl": "Bertem + deelgemeenten"
+                            "nl": "Bertem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24009"
                     },
                     {
                         "name": {
-                            "nl": "Kortenberg + deelgemeenten"
+                            "nl": "Kortenberg"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24055"
                     },
                     {
                         "name": {
-                            "nl": "Tervuren + deelgemeenten"
+                            "nl": "Tervuren"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24104"
                     },
                     {
                         "name": {
-                            "nl": "Overijse + deelgemeenten"
+                            "nl": "Overijse"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-23062"
                     },
                     {
                         "name": {
-                            "nl": "Keerbergen + deelgemeenten"
+                            "nl": "Keerbergen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24048"
                     },
                     {
                         "name": {
-                            "nl": "Haacht + deelgemeenten"
+                            "nl": "Haacht"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24033"
                     },
                     {
                         "name": {
-                            "nl": "Boortmeerbeek + deelgemeenten"
+                            "nl": "Boortmeerbeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aarschot + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Scherpenheuvel-Zichem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24134"
-                    },
-                    {
-                        "name": {
-                            "nl": "Diest + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tienen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24107"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hoegaarden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Linter + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24133"
-                    },
-                    {
-                        "name": {
-                            "nl": "Glabbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24137"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tielt-Winge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24135"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zoutleeuw + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24130"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geetbets + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bekkevoort + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortenaken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24054"
-                    },
-                    {
-                        "name": {
-                            "nl": "Rotselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24094"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tremelo + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24109"
-                    },
-                    {
-                        "name": {
-                            "nl": "Begijnendijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lubbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24066"
-                    },
-                    {
-                        "name": {
-                            "nl": "Holsbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bierbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Boutersem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Leuven + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24062"
                     }
                 ]
             },
@@ -2167,379 +838,120 @@
                 "name": {
                     "nl": "Regio Hageland"
                 },
-                "label": "reg-hageland",
                 "children": [
                     {
                         "name": {
-                            "nl": "Vilvoorde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23088"
-                    },
-                    {
-                        "name": {
-                            "nl": "Steenokkerzeel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Machelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23047"
-                    },
-                    {
-                        "name": {
-                            "nl": "Grimbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Meise + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23050"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kapelle-op-den-Bos + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kampenhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zaventem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23094"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kraainem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23099"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wezembeek-Oppem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23103"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zemst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23096"
-                    },
-                    {
-                        "name": {
-                            "nl": "Halle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pajottegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bever + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hoeilaart + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23033"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Pieters-Leeuw + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23077"
-                    },
-                    {
-                        "name": {
-                            "nl": "Drogenbos + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23098"
-                    },
-                    {
-                        "name": {
-                            "nl": "Linkebeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23100"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Genesius-Rode + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23101"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beersel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pepingen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dilbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Asse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ternat + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23086"
-                    },
-                    {
-                        "name": {
-                            "nl": "Opwijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23060"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lennik + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23104"
-                    },
-                    {
-                        "name": {
-                            "nl": "Roosdaal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23097"
-                    },
-                    {
-                        "name": {
-                            "nl": "Liedekerke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23044"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wemmel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23102"
-                    },
-                    {
-                        "name": {
-                            "nl": "Merchtem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23052"
-                    },
-                    {
-                        "name": {
-                            "nl": "Affligem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23105"
-                    },
-                    {
-                        "name": {
-                            "nl": "Londerzeel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23045"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herent + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Huldenberg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24045"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oud-Heverlee + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24086"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bertem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortenberg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24055"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tervuren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24104"
-                    },
-                    {
-                        "name": {
-                            "nl": "Overijse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23062"
-                    },
-                    {
-                        "name": {
-                            "nl": "Keerbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24048"
-                    },
-                    {
-                        "name": {
-                            "nl": "Haacht + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24033"
-                    },
-                    {
-                        "name": {
-                            "nl": "Boortmeerbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aarschot + deelgemeenten"
+                            "nl": "Aarschot"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24001"
                     },
                     {
                         "name": {
-                            "nl": "Scherpenheuvel-Zichem + deelgemeenten"
+                            "nl": "Scherpenheuvel-Zichem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24134"
                     },
                     {
                         "name": {
-                            "nl": "Diest + deelgemeenten"
+                            "nl": "Diest"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24020"
                     },
                     {
                         "name": {
-                            "nl": "Tienen + deelgemeenten"
+                            "nl": "Tienen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24107"
                     },
                     {
                         "name": {
-                            "nl": "Hoegaarden + deelgemeenten"
+                            "nl": "Hoegaarden"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24041"
                     },
                     {
                         "name": {
-                            "nl": "Linter + deelgemeenten"
+                            "nl": "Linter"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24133"
                     },
                     {
                         "name": {
-                            "nl": "Glabbeek + deelgemeenten"
+                            "nl": "Glabbeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24137"
                     },
                     {
                         "name": {
-                            "nl": "Tielt-Winge + deelgemeenten"
+                            "nl": "Tielt-Winge"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24135"
                     },
                     {
                         "name": {
-                            "nl": "Zoutleeuw + deelgemeenten"
+                            "nl": "Zoutleeuw"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24130"
                     },
                     {
                         "name": {
-                            "nl": "Geetbets + deelgemeenten"
+                            "nl": "Geetbets"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24028"
                     },
                     {
                         "name": {
-                            "nl": "Bekkevoort + deelgemeenten"
+                            "nl": "Bekkevoort"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24008"
                     },
                     {
                         "name": {
-                            "nl": "Kortenaken + deelgemeenten"
+                            "nl": "Kortenaken"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24054"
                     },
                     {
                         "name": {
-                            "nl": "Rotselaar + deelgemeenten"
+                            "nl": "Rotselaar"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24094"
                     },
                     {
                         "name": {
-                            "nl": "Tremelo + deelgemeenten"
+                            "nl": "Tremelo"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24109"
                     },
                     {
                         "name": {
-                            "nl": "Begijnendijk + deelgemeenten"
+                            "nl": "Begijnendijk"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24007"
                     },
                     {
                         "name": {
-                            "nl": "Lubbeek + deelgemeenten"
+                            "nl": "Lubbeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24066"
                     },
                     {
                         "name": {
-                            "nl": "Holsbeek + deelgemeenten"
+                            "nl": "Holsbeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24043"
                     },
                     {
                         "name": {
-                            "nl": "Bierbeek + deelgemeenten"
+                            "nl": "Bierbeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24011"
                     },
                     {
                         "name": {
-                            "nl": "Boutersem + deelgemeenten"
+                            "nl": "Boutersem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Leuven + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24062"
                     }
                 ]
             },
@@ -2547,377 +959,10 @@
                 "name": {
                     "nl": "Regio Leuven"
                 },
-                "label": "reg-leuven",
                 "children": [
                     {
                         "name": {
-                            "nl": "Vilvoorde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23088"
-                    },
-                    {
-                        "name": {
-                            "nl": "Steenokkerzeel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Machelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23047"
-                    },
-                    {
-                        "name": {
-                            "nl": "Grimbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Meise + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23050"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kapelle-op-den-Bos + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kampenhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zaventem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23094"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kraainem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23099"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wezembeek-Oppem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23103"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zemst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23096"
-                    },
-                    {
-                        "name": {
-                            "nl": "Halle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pajottegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bever + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hoeilaart + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23033"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Pieters-Leeuw + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23077"
-                    },
-                    {
-                        "name": {
-                            "nl": "Drogenbos + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23098"
-                    },
-                    {
-                        "name": {
-                            "nl": "Linkebeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23100"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Genesius-Rode + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23101"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beersel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pepingen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dilbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Asse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ternat + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23086"
-                    },
-                    {
-                        "name": {
-                            "nl": "Opwijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23060"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lennik + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23104"
-                    },
-                    {
-                        "name": {
-                            "nl": "Roosdaal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23097"
-                    },
-                    {
-                        "name": {
-                            "nl": "Liedekerke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23044"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wemmel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23102"
-                    },
-                    {
-                        "name": {
-                            "nl": "Merchtem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23052"
-                    },
-                    {
-                        "name": {
-                            "nl": "Affligem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23105"
-                    },
-                    {
-                        "name": {
-                            "nl": "Londerzeel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23045"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herent + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Huldenberg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24045"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oud-Heverlee + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24086"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bertem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortenberg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24055"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tervuren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24104"
-                    },
-                    {
-                        "name": {
-                            "nl": "Overijse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-23062"
-                    },
-                    {
-                        "name": {
-                            "nl": "Keerbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24048"
-                    },
-                    {
-                        "name": {
-                            "nl": "Haacht + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24033"
-                    },
-                    {
-                        "name": {
-                            "nl": "Boortmeerbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aarschot + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Scherpenheuvel-Zichem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24134"
-                    },
-                    {
-                        "name": {
-                            "nl": "Diest + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tienen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24107"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hoegaarden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Linter + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24133"
-                    },
-                    {
-                        "name": {
-                            "nl": "Glabbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24137"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tielt-Winge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24135"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zoutleeuw + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24130"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geetbets + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bekkevoort + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortenaken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24054"
-                    },
-                    {
-                        "name": {
-                            "nl": "Rotselaar + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24094"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tremelo + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24109"
-                    },
-                    {
-                        "name": {
-                            "nl": "Begijnendijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lubbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24066"
-                    },
-                    {
-                        "name": {
-                            "nl": "Holsbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bierbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Boutersem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Leuven + deelgemeenten"
+                            "nl": "Leuven"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24062"
                     }
@@ -2930,384 +975,18 @@
             "nl": "Provincie West-Vlaanderen"
         },
         "label": "cultuurkuur_werkingsregio_provincie_nis-30000",
+        "extraLabel": "cultuurkuur_werkingsregio_nis-30000",
         "children": [
             {
                 "name": {
                     "nl": "Regio Brugge"
                 },
-                "label": "reg-brugge",
                 "children": [
                     {
                         "name": {
-                            "nl": "Brugge + deelgemeenten"
+                            "nl": "Brugge"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-31005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostkamp + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zedelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Damme + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zuienkerke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ichtegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Jabbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beernem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Torhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31033"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudenburg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gistel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lichtervelde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tielt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pittem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wingene +deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ardooie + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ingelmunster + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Roeselare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36015"
-                    },
-                    {
-                        "name": {
-                            "nl": "Izegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ledegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Moorslede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wielsbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dentergem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostrozebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortrijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kuurne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Harelbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Deerlijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zwevegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wevelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Anzegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Avelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Spiere-Helkijn + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Waregem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lendelede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Menen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Knokke-Heist + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Blankenberge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31004"
-                    },
-                    {
-                        "name": {
-                            "nl": "De Haan + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bredene + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35002"
-                    },
-                    {
-                        "name": {
-                            "nl": "De Panne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostende + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Middelkerke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nieuwpoort + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Koksijde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hooglede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Staden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Veurne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Alveringem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Diksmuide + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortemark + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lo-Reninge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Houthulst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Koekelare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Vleteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ieper + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Langemark-Poelkapelle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heuvelland + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mesen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Poperinge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zonnebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wervik + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33029"
                     }
                 ]
             },
@@ -3315,379 +994,96 @@
                 "name": {
                     "nl": "Regio Brugse Ommeland"
                 },
-                "label": "reg-brugse-ommeland",
                 "children": [
                     {
                         "name": {
-                            "nl": "Brugge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostkamp + deelgemeenten"
+                            "nl": "Oostkamp"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-31022"
                     },
                     {
                         "name": {
-                            "nl": "Zedelgem + deelgemeenten"
+                            "nl": "Zedelgem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-31040"
                     },
                     {
                         "name": {
-                            "nl": "Damme + deelgemeenten"
+                            "nl": "Damme"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-31006"
                     },
                     {
                         "name": {
-                            "nl": "Zuienkerke + deelgemeenten"
+                            "nl": "Zuienkerke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-31042"
                     },
                     {
                         "name": {
-                            "nl": "Ichtegem + deelgemeenten"
+                            "nl": "Ichtegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-35006"
                     },
                     {
                         "name": {
-                            "nl": "Jabbeke + deelgemeenten"
+                            "nl": "Jabbeke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-31012"
                     },
                     {
                         "name": {
-                            "nl": "Beernem + deelgemeenten"
+                            "nl": "Beernem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-31003"
                     },
                     {
                         "name": {
-                            "nl": "Torhout + deelgemeenten"
+                            "nl": "Torhout"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-31033"
                     },
                     {
                         "name": {
-                            "nl": "Oudenburg + deelgemeenten"
+                            "nl": "Oudenburg"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-35014"
                     },
                     {
                         "name": {
-                            "nl": "Gistel + deelgemeenten"
+                            "nl": "Gistel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-35005"
                     },
                     {
                         "name": {
-                            "nl": "Lichtervelde + deelgemeenten"
+                            "nl": "Lichtervelde"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-36011"
                     },
                     {
                         "name": {
-                            "nl": "Tielt + deelgemeenten"
+                            "nl": "Tielt"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21002"
                     },
                     {
                         "name": {
-                            "nl": "Pittem + deelgemeenten"
+                            "nl": "Pittem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-37011"
                     },
                     {
                         "name": {
-                            "nl": "Wingene +deelgemeenten"
+                            "nl": "Wingene"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21003"
                     },
                     {
                         "name": {
-                            "nl": "Ardooie + deelgemeenten"
+                            "nl": "Ardooie"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-37020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ingelmunster + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Roeselare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36015"
-                    },
-                    {
-                        "name": {
-                            "nl": "Izegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ledegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Moorslede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wielsbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dentergem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostrozebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortrijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kuurne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Harelbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Deerlijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zwevegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wevelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Anzegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Avelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Spiere-Helkijn + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Waregem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lendelede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Menen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Knokke-Heist + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Blankenberge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31004"
-                    },
-                    {
-                        "name": {
-                            "nl": "De Haan + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bredene + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35002"
-                    },
-                    {
-                        "name": {
-                            "nl": "De Panne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostende + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Middelkerke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nieuwpoort + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Koksijde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hooglede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Staden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Veurne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Alveringem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Diksmuide + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortemark + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lo-Reninge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Houthulst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Koekelare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Vleteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ieper + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Langemark-Poelkapelle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heuvelland + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mesen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Poperinge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zonnebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wervik + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33029"
                     }
                 ]
             },
@@ -3695,379 +1091,126 @@
                 "name": {
                     "nl": "Regio Leiestreek West-Vlaanderen"
                 },
-                "label": "reg-leiestreek-west-vlaanderen",
                 "children": [
                     {
                         "name": {
-                            "nl": "Brugge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostkamp + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zedelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Damme + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zuienkerke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ichtegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Jabbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beernem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Torhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31033"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudenburg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gistel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lichtervelde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tielt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pittem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wingene +deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ardooie + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ingelmunster + deelgemeenten"
+                            "nl": "Ingelmunster"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-36007"
                     },
                     {
                         "name": {
-                            "nl": "Roeselare + deelgemeenten"
+                            "nl": "Roeselare"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-36015"
                     },
                     {
                         "name": {
-                            "nl": "Izegem + deelgemeenten"
+                            "nl": "Izegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-36008"
                     },
                     {
                         "name": {
-                            "nl": "Ledegem + deelgemeenten"
+                            "nl": "Ledegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-36010"
                     },
                     {
                         "name": {
-                            "nl": "Moorslede + deelgemeenten"
+                            "nl": "Moorslede"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-36012"
                     },
                     {
                         "name": {
-                            "nl": "Wielsbeke + deelgemeenten"
+                            "nl": "Wielsbeke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-37017"
                     },
                     {
                         "name": {
-                            "nl": "Dentergem + deelgemeenten"
+                            "nl": "Dentergem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-37002"
                     },
                     {
                         "name": {
-                            "nl": "Oostrozebeke + deelgemeenten"
+                            "nl": "Oostrozebeke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-37010"
                     },
                     {
                         "name": {
-                            "nl": "Kortrijk + deelgemeenten"
+                            "nl": "Kortrijk"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34022"
                     },
                     {
                         "name": {
-                            "nl": "Kuurne + deelgemeenten"
+                            "nl": "Kuurne"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34023"
                     },
                     {
                         "name": {
-                            "nl": "Harelbeke + deelgemeenten"
+                            "nl": "Harelbeke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34013"
                     },
                     {
                         "name": {
-                            "nl": "Deerlijk + deelgemeenten"
+                            "nl": "Deerlijk"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34009"
                     },
                     {
                         "name": {
-                            "nl": "Zwevegem + deelgemeenten"
+                            "nl": "Zwevegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34042"
                     },
                     {
                         "name": {
-                            "nl": "Wevelgem + deelgemeenten"
+                            "nl": "Wevelgem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34041"
                     },
                     {
                         "name": {
-                            "nl": "Anzegem + deelgemeenten"
+                            "nl": "Anzegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34002"
                     },
                     {
                         "name": {
-                            "nl": "Avelgem + deelgemeenten"
+                            "nl": "Avelgem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34003"
                     },
                     {
                         "name": {
-                            "nl": "Spiere-Helkijn + deelgemeenten"
+                            "nl": "Spiere-Helkijn"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34043"
                     },
                     {
                         "name": {
-                            "nl": "Waregem + deelgemeenten"
+                            "nl": "Waregem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34040"
                     },
                     {
                         "name": {
-                            "nl": "Lendelede + deelgemeenten"
+                            "nl": "Lendelede"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34025"
                     },
                     {
                         "name": {
-                            "nl": "Menen + deelgemeenten"
+                            "nl": "Menen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-34027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Knokke-Heist + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Blankenberge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31004"
-                    },
-                    {
-                        "name": {
-                            "nl": "De Haan + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bredene + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35002"
-                    },
-                    {
-                        "name": {
-                            "nl": "De Panne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostende + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Middelkerke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nieuwpoort + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Koksijde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hooglede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Staden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Veurne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Alveringem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Diksmuide + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortemark + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lo-Reninge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Houthulst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Koekelare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Vleteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ieper + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Langemark-Poelkapelle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heuvelland + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mesen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Poperinge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zonnebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wervik + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33029"
                     }
                 ]
             },
@@ -4075,379 +1218,60 @@
                 "name": {
                     "nl": "Regio Vlaamse Kust"
                 },
-                "label": "reg-vlaamse-kust",
                 "children": [
                     {
                         "name": {
-                            "nl": "Brugge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostkamp + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zedelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Damme + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zuienkerke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ichtegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Jabbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beernem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Torhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31033"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudenburg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gistel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lichtervelde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tielt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pittem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wingene +deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ardooie + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ingelmunster + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Roeselare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36015"
-                    },
-                    {
-                        "name": {
-                            "nl": "Izegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ledegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Moorslede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wielsbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dentergem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostrozebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortrijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kuurne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Harelbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Deerlijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zwevegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wevelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Anzegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Avelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Spiere-Helkijn + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Waregem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lendelede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Menen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Knokke-Heist + deelgemeenten"
+                            "nl": "Knokke-Heist"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-31043"
                     },
                     {
                         "name": {
-                            "nl": "Blankenberge + deelgemeenten"
+                            "nl": "Blankenberge"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-31004"
                     },
                     {
                         "name": {
-                            "nl": "De Haan + deelgemeenten"
+                            "nl": "De Haan"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-35029"
                     },
                     {
                         "name": {
-                            "nl": "Bredene + deelgemeenten"
+                            "nl": "Bredene"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-35002"
                     },
                     {
                         "name": {
-                            "nl": "De Panne + deelgemeenten"
+                            "nl": "De Panne"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-38008"
                     },
                     {
                         "name": {
-                            "nl": "Oostende + deelgemeenten"
+                            "nl": "Oostende"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-35013"
                     },
                     {
                         "name": {
-                            "nl": "Middelkerke + deelgemeenten"
+                            "nl": "Middelkerke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-35011"
                     },
                     {
                         "name": {
-                            "nl": "Nieuwpoort + deelgemeenten"
+                            "nl": "Nieuwpoort"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-38016"
                     },
                     {
                         "name": {
-                            "nl": "Koksijde + deelgemeenten"
+                            "nl": "Koksijde"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-38014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hooglede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Staden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Veurne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Alveringem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Diksmuide + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortemark + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lo-Reninge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Houthulst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Koekelare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-32010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Vleteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ieper + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Langemark-Poelkapelle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heuvelland + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Mesen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Poperinge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zonnebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wervik + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-33029"
                     }
                 ]
             },
@@ -4455,377 +1279,106 @@
                 "name": {
                     "nl": "Regio Westhoek"
                 },
-                "label": "reg-westhoek",
                 "children": [
                     {
                         "name": {
-                            "nl": "Brugge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostkamp + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zedelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Damme + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zuienkerke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ichtegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Jabbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beernem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Torhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31033"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudenburg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gistel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lichtervelde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tielt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pittem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wingene +deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ardooie + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ingelmunster + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Roeselare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36015"
-                    },
-                    {
-                        "name": {
-                            "nl": "Izegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ledegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Moorslede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-36012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wielsbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dentergem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostrozebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-37010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kortrijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kuurne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Harelbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Deerlijk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zwevegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wevelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Anzegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Avelgem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Spiere-Helkijn + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Waregem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34040"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lendelede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Menen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-34027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Knokke-Heist + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Blankenberge + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-31004"
-                    },
-                    {
-                        "name": {
-                            "nl": "De Haan + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35029"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bredene + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35002"
-                    },
-                    {
-                        "name": {
-                            "nl": "De Panne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oostende + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Middelkerke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-35011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nieuwpoort + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38016"
-                    },
-                    {
-                        "name": {
-                            "nl": "Koksijde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-38014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hooglede + deelgemeenten"
+                            "nl": "Hooglede"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-36006"
                     },
                     {
                         "name": {
-                            "nl": "Staden + deelgemeenten"
+                            "nl": "Staden"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-36019"
                     },
                     {
                         "name": {
-                            "nl": "Veurne + deelgemeenten"
+                            "nl": "Veurne"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-38025"
                     },
                     {
                         "name": {
-                            "nl": "Alveringem + deelgemeenten"
+                            "nl": "Alveringem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-38002"
                     },
                     {
                         "name": {
-                            "nl": "Diksmuide + deelgemeenten"
+                            "nl": "Diksmuide"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-32003"
                     },
                     {
                         "name": {
-                            "nl": "Kortemark + deelgemeenten"
+                            "nl": "Kortemark"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-32011"
                     },
                     {
                         "name": {
-                            "nl": "Lo-Reninge + deelgemeenten"
+                            "nl": "Lo-Reninge"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-32030"
                     },
                     {
                         "name": {
-                            "nl": "Houthulst + deelgemeenten"
+                            "nl": "Houthulst"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-32006"
                     },
                     {
                         "name": {
-                            "nl": "Koekelare + deelgemeenten"
+                            "nl": "Koekelare"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-32010"
                     },
                     {
                         "name": {
-                            "nl": "Vleteren + deelgemeenten"
+                            "nl": "Vleteren"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-33041"
                     },
                     {
                         "name": {
-                            "nl": "Ieper + deelgemeenten"
+                            "nl": "Ieper"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-33011"
                     },
                     {
                         "name": {
-                            "nl": "Langemark-Poelkapelle + deelgemeenten"
+                            "nl": "Langemark-Poelkapelle"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-33040"
                     },
                     {
                         "name": {
-                            "nl": "Heuvelland + deelgemeenten"
+                            "nl": "Heuvelland"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-33039"
                     },
                     {
                         "name": {
-                            "nl": "Mesen + deelgemeenten"
+                            "nl": "Mesen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-33016"
                     },
                     {
                         "name": {
-                            "nl": "Poperinge + deelgemeenten"
+                            "nl": "Poperinge"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-33021"
                     },
                     {
                         "name": {
-                            "nl": "Zonnebeke + deelgemeenten"
+                            "nl": "Zonnebeke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-33037"
                     },
                     {
                         "name": {
-                            "nl": "Wervik + deelgemeenten"
+                            "nl": "Wervik"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-33029"
                     }
@@ -4838,342 +1391,18 @@
             "nl": "Provincie Oost-Vlaanderen"
         },
         "label": "cultuurkuur_werkingsregio_provincie_nis-40000",
+        "extraLabel": "cultuurkuur_werkingsregio_nis-40000",
         "children": [
             {
                 "name": {
                     "nl": "Regio Gent"
                 },
-                "label": "reg-gent",
                 "children": [
                     {
                         "name": {
-                            "nl": "Gent + deelgemeenten"
+                            "nl": "Gent"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-44021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nazareth-De Pinte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Martens-Latem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zulte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Deinze + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44083"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zelzate + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Eeklo + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Assenede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kaprijke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Laureins + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maldegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lochristi + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Evergem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalter + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44084"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lievegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44085"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geraardsbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Lievens-Houtem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41063"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herzele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zottegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lierde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45063"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ronse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zwalm + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45065"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brakel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45059"
-                    },
-                    {
-                        "name": {
-                            "nl": "Horebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45062"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maarkedal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kluisbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45060"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudenaarde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wortegem-Petegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45061"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oosterzele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44052"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gavere + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kruisem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45068"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Niklaas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Temse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lokeren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Gillis-Waas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Stekene + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Waasmunster + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41034"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ninove + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41048"
-                    },
-                    {
-                        "name": {
-                            "nl": "Erpe-Mere + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41082"
-                    },
-                    {
-                        "name": {
-                            "nl": "Haaltert + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Denderleeuw + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dendermonde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hamme + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wetteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Buggenhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wichelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42026"
-                    },
-                    {
-                        "name": {
-                            "nl": "Laarne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lebbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Berlare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Destelbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Merelbeke-Melle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21008"
                     }
                 ]
             },
@@ -5181,337 +1410,30 @@
                 "name": {
                     "nl": "Regio Leiestreek Oost-Vlaanderen"
                 },
-                "label": "reg-leiestreek-oost-vlaanderen",
                 "children": [
                     {
                         "name": {
-                            "nl": "Gent + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nazareth-De Pinte + deelgemeenten"
+                            "nl": "Nazareth-De Pinte"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21004"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Martens-Latem + deelgemeenten"
+                            "nl": "Sint-Martens-Latem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-44064"
                     },
                     {
                         "name": {
-                            "nl": "Zulte + deelgemeenten"
+                            "nl": "Zulte"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-44081"
                     },
                     {
                         "name": {
-                            "nl": "Deinze + deelgemeenten"
+                            "nl": "Deinze"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-44083"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zelzate + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Eeklo + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Assenede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kaprijke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Laureins + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maldegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lochristi + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Evergem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalter + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44084"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lievegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44085"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geraardsbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Lievens-Houtem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41063"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herzele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zottegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lierde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45063"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ronse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zwalm + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45065"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brakel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45059"
-                    },
-                    {
-                        "name": {
-                            "nl": "Horebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45062"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maarkedal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kluisbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45060"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudenaarde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wortegem-Petegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45061"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oosterzele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44052"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gavere + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kruisem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45068"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Niklaas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Temse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lokeren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Gillis-Waas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Stekene + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Waasmunster + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41034"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ninove + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41048"
-                    },
-                    {
-                        "name": {
-                            "nl": "Erpe-Mere + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41082"
-                    },
-                    {
-                        "name": {
-                            "nl": "Haaltert + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Denderleeuw + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dendermonde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hamme + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wetteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Buggenhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wichelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42026"
-                    },
-                    {
-                        "name": {
-                            "nl": "Laarne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lebbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Berlare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Destelbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Merelbeke-Melle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21008"
                     }
                 ]
             },
@@ -5519,337 +1441,66 @@
                 "name": {
                     "nl": "Regio Meetjesland"
                 },
-                "label": "reg-meetjesland",
                 "children": [
                     {
                         "name": {
-                            "nl": "Gent + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nazareth-De Pinte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Martens-Latem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zulte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Deinze + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44083"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zelzate + deelgemeenten"
+                            "nl": "Zelzate"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-43018"
                     },
                     {
                         "name": {
-                            "nl": "Eeklo + deelgemeenten"
+                            "nl": "Eeklo"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-43005"
                     },
                     {
                         "name": {
-                            "nl": "Assenede + deelgemeenten"
+                            "nl": "Assenede"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-43002"
                     },
                     {
                         "name": {
-                            "nl": "Kaprijke + deelgemeenten"
+                            "nl": "Kaprijke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-43007"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Laureins + deelgemeenten"
+                            "nl": "Sint-Laureins"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-43014"
                     },
                     {
                         "name": {
-                            "nl": "Maldegem + deelgemeenten"
+                            "nl": "Maldegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-43010"
                     },
                     {
                         "name": {
-                            "nl": "Lochristi + deelgemeenten"
+                            "nl": "Lochristi"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21005"
                     },
                     {
                         "name": {
-                            "nl": "Evergem + deelgemeenten"
+                            "nl": "Evergem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-44019"
                     },
                     {
                         "name": {
-                            "nl": "Aalter + deelgemeenten"
+                            "nl": "Aalter"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-44084"
                     },
                     {
                         "name": {
-                            "nl": "Lievegem + deelgemeenten"
+                            "nl": "Lievegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-44085"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geraardsbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Lievens-Houtem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41063"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herzele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zottegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lierde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45063"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ronse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zwalm + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45065"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brakel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45059"
-                    },
-                    {
-                        "name": {
-                            "nl": "Horebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45062"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maarkedal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kluisbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45060"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudenaarde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wortegem-Petegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45061"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oosterzele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44052"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gavere + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kruisem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45068"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Niklaas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Temse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lokeren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Gillis-Waas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Stekene + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Waasmunster + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41034"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ninove + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41048"
-                    },
-                    {
-                        "name": {
-                            "nl": "Erpe-Mere + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41082"
-                    },
-                    {
-                        "name": {
-                            "nl": "Haaltert + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Denderleeuw + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dendermonde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hamme + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wetteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Buggenhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wichelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42026"
-                    },
-                    {
-                        "name": {
-                            "nl": "Laarne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lebbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Berlare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Destelbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Merelbeke-Melle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21008"
                     }
                 ]
             },
@@ -5857,337 +1508,102 @@
                 "name": {
                     "nl": "Regio Vlaamse Ardennen"
                 },
-                "label": "reg-vlaamse-ardennen",
                 "children": [
                     {
                         "name": {
-                            "nl": "Gent + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nazareth-De Pinte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Martens-Latem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zulte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Deinze + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44083"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zelzate + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Eeklo + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Assenede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kaprijke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Laureins + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maldegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lochristi + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Evergem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalter + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44084"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lievegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44085"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geraardsbergen + deelgemeenten"
+                            "nl": "Geraardsbergen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-41018"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Lievens-Houtem + deelgemeenten"
+                            "nl": "Sint-Lievens-Houtem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-41063"
                     },
                     {
                         "name": {
-                            "nl": "Herzele + deelgemeenten"
+                            "nl": "Herzele"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-41027"
                     },
                     {
                         "name": {
-                            "nl": "Zottegem + deelgemeenten"
+                            "nl": "Zottegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-41081"
                     },
                     {
                         "name": {
-                            "nl": "Lierde + deelgemeenten"
+                            "nl": "Lierde"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-45063"
                     },
                     {
                         "name": {
-                            "nl": "Ronse + deelgemeenten"
+                            "nl": "Ronse"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-45041"
                     },
                     {
                         "name": {
-                            "nl": "Zwalm + deelgemeenten"
+                            "nl": "Zwalm"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-45065"
                     },
                     {
                         "name": {
-                            "nl": "Brakel + deelgemeenten"
+                            "nl": "Brakel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-45059"
                     },
                     {
                         "name": {
-                            "nl": "Horebeke + deelgemeenten"
+                            "nl": "Horebeke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-45062"
                     },
                     {
                         "name": {
-                            "nl": "Maarkedal + deelgemeenten"
+                            "nl": "Maarkedal"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-45064"
                     },
                     {
                         "name": {
-                            "nl": "Kluisbergen + deelgemeenten"
+                            "nl": "Kluisbergen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-45060"
                     },
                     {
                         "name": {
-                            "nl": "Oudenaarde + deelgemeenten"
+                            "nl": "Oudenaarde"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-45035"
                     },
                     {
                         "name": {
-                            "nl": "Wortegem-Petegem + deelgemeenten"
+                            "nl": "Wortegem-Petegem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-45061"
                     },
                     {
                         "name": {
-                            "nl": "Oosterzele + deelgemeenten"
+                            "nl": "Oosterzele"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-44052"
                     },
                     {
                         "name": {
-                            "nl": "Gavere + deelgemeenten"
+                            "nl": "Gavere"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-44020"
                     },
                     {
                         "name": {
-                            "nl": "Kruisem + deelgemeenten"
+                            "nl": "Kruisem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-45068"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Niklaas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Temse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lokeren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Gillis-Waas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Stekene + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Waasmunster + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41034"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ninove + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41048"
-                    },
-                    {
-                        "name": {
-                            "nl": "Erpe-Mere + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41082"
-                    },
-                    {
-                        "name": {
-                            "nl": "Haaltert + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Denderleeuw + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dendermonde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hamme + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wetteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Buggenhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wichelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42026"
-                    },
-                    {
-                        "name": {
-                            "nl": "Laarne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lebbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Berlare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Destelbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Merelbeke-Melle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21008"
                     }
                 ]
             },
@@ -6195,337 +1611,48 @@
                 "name": {
                     "nl": "Regio Waasland"
                 },
-                "label": "reg-waasland",
                 "children": [
                     {
                         "name": {
-                            "nl": "Gent + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nazareth-De Pinte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Martens-Latem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zulte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Deinze + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44083"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zelzate + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Eeklo + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Assenede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kaprijke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Laureins + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maldegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lochristi + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Evergem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalter + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44084"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lievegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44085"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geraardsbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Lievens-Houtem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41063"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herzele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zottegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lierde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45063"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ronse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zwalm + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45065"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brakel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45059"
-                    },
-                    {
-                        "name": {
-                            "nl": "Horebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45062"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maarkedal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kluisbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45060"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudenaarde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wortegem-Petegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45061"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oosterzele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44052"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gavere + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kruisem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45068"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Niklaas + deelgemeenten"
+                            "nl": "Sint-Niklaas"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-46021"
                     },
                     {
                         "name": {
-                            "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
+                            "nl": "Beveren-Kruibeke-Zwijndrecht"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21006"
                     },
                     {
                         "name": {
-                            "nl": "Temse + deelgemeenten"
+                            "nl": "Temse"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-46025"
                     },
                     {
                         "name": {
-                            "nl": "Lokeren + deelgemeenten"
+                            "nl": "Lokeren"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21007"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Gillis-Waas + deelgemeenten"
+                            "nl": "Sint-Gillis-Waas"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-46020"
                     },
                     {
                         "name": {
-                            "nl": "Stekene + deelgemeenten"
+                            "nl": "Stekene"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-46024"
                     },
                     {
                         "name": {
-                            "nl": "Waasmunster + deelgemeenten"
+                            "nl": "Waasmunster"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-42023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41034"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ninove + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41048"
-                    },
-                    {
-                        "name": {
-                            "nl": "Erpe-Mere + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41082"
-                    },
-                    {
-                        "name": {
-                            "nl": "Haaltert + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Denderleeuw + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dendermonde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hamme + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42008"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wetteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Buggenhout + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wichelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42026"
-                    },
-                    {
-                        "name": {
-                            "nl": "Laarne + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lebbeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Berlare + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Destelbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44013"
-                    },
-                    {
-                        "name": {
-                            "nl": "Merelbeke-Melle + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21008"
                     }
                 ]
             },
@@ -6533,335 +1660,106 @@
                 "name": {
                     "nl": "Regio Scheldeland Oost-Vlaanderen"
                 },
-                "label": "reg-scheldeland-oost-vlaanderen",
                 "children": [
                     {
                         "name": {
-                            "nl": "Gent + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nazareth-De Pinte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Martens-Latem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zulte + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Deinze + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44083"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zelzate + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Eeklo + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Assenede + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kaprijke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Laureins + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43014"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maldegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-43010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lochristi + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21005"
-                    },
-                    {
-                        "name": {
-                            "nl": "Evergem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44019"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalter + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44084"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lievegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44085"
-                    },
-                    {
-                        "name": {
-                            "nl": "Geraardsbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Lievens-Houtem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41063"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herzele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41027"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zottegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-41081"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lierde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45063"
-                    },
-                    {
-                        "name": {
-                            "nl": "Ronse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zwalm + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45065"
-                    },
-                    {
-                        "name": {
-                            "nl": "Brakel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45059"
-                    },
-                    {
-                        "name": {
-                            "nl": "Horebeke + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45062"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maarkedal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45064"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kluisbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45060"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudenaarde + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45035"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wortegem-Petegem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45061"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oosterzele + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44052"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gavere + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-44020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kruisem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-45068"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Niklaas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21006"
-                    },
-                    {
-                        "name": {
-                            "nl": "Temse + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46025"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lokeren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21007"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Gillis-Waas + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Stekene + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-46024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Waasmunster + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-42023"
-                    },
-                    {
-                        "name": {
-                            "nl": "Aalst + deelgemeenten"
+                            "nl": "Aalst"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-41002"
                     },
                     {
                         "name": {
-                            "nl": "Lede + deelgemeenten"
+                            "nl": "Lede"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-41034"
                     },
                     {
                         "name": {
-                            "nl": "Ninove + deelgemeenten"
+                            "nl": "Ninove"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-41048"
                     },
                     {
                         "name": {
-                            "nl": "Erpe-Mere + deelgemeenten"
+                            "nl": "Erpe-Mere"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-41082"
                     },
                     {
                         "name": {
-                            "nl": "Haaltert + deelgemeenten"
+                            "nl": "Haaltert"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-41024"
                     },
                     {
                         "name": {
-                            "nl": "Denderleeuw + deelgemeenten"
+                            "nl": "Denderleeuw"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-41011"
                     },
                     {
                         "name": {
-                            "nl": "Dendermonde + deelgemeenten"
+                            "nl": "Dendermonde"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-42006"
                     },
                     {
                         "name": {
-                            "nl": "Hamme + deelgemeenten"
+                            "nl": "Hamme"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-42008"
                     },
                     {
                         "name": {
-                            "nl": "Wetteren + deelgemeenten"
+                            "nl": "Wetteren"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-42025"
                     },
                     {
                         "name": {
-                            "nl": "Zele + deelgemeenten"
+                            "nl": "Zele"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-42028"
                     },
                     {
                         "name": {
-                            "nl": "Buggenhout + deelgemeenten"
+                            "nl": "Buggenhout"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-42004"
                     },
                     {
                         "name": {
-                            "nl": "Wichelen + deelgemeenten"
+                            "nl": "Wichelen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-42026"
                     },
                     {
                         "name": {
-                            "nl": "Laarne + deelgemeenten"
+                            "nl": "Laarne"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-42010"
                     },
                     {
                         "name": {
-                            "nl": "Lebbeke + deelgemeenten"
+                            "nl": "Lebbeke"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-42011"
                     },
                     {
                         "name": {
-                            "nl": "Berlare + deelgemeenten"
+                            "nl": "Berlare"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-42003"
                     },
                     {
                         "name": {
-                            "nl": "Destelbergen + deelgemeenten"
+                            "nl": "Destelbergen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-44013"
                     },
                     {
                         "name": {
-                            "nl": "Merelbeke-Melle + deelgemeenten"
+                            "nl": "Merelbeke-Melle"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21008"
                     }
@@ -6874,246 +1772,90 @@
             "nl": "Provincie Limburg"
         },
         "label": "cultuurkuur_werkingsregio_provincie_nis-70000",
+        "extraLabel": "cultuurkuur_werkingsregio_nis-70000",
         "children": [
             {
                 "name": {
                     "nl": "Regio Haspengouw"
                 },
-                "label": "reg-haspengouw",
                 "children": [
                     {
                         "name": {
-                            "nl": "Alken + deelgemeenten"
+                            "nl": "Alken"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-73001"
                     },
                     {
                         "name": {
-                            "nl": "Tongeren-Borgloon + deelgemeenten"
+                            "nl": "Tongeren-Borgloon"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21009"
                     },
                     {
                         "name": {
-                            "nl": "Herstappe + deelgemeenten"
+                            "nl": "Herstappe"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-73028"
                     },
                     {
                         "name": {
-                            "nl": "Bilzen-Hoeselt + deelgemeenten"
+                            "nl": "Bilzen-Hoeselt"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21010"
                     },
                     {
                         "name": {
-                            "nl": "Riemst + deelgemeenten"
+                            "nl": "Riemst"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-73066"
                     },
                     {
                         "name": {
-                            "nl": "Sint-Truiden + deelgemeenten"
+                            "nl": "Sint-Truiden"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71053"
                     },
                     {
                         "name": {
-                            "nl": "Wellen + deelgemeenten"
+                            "nl": "Wellen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-73098"
                     },
                     {
                         "name": {
-                            "nl": "Heers + deelgemeenten"
+                            "nl": "Heers"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-73022"
                     },
                     {
                         "name": {
-                            "nl": "Gingelom + deelgemeenten"
+                            "nl": "Gingelom"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71017"
                     },
                     {
                         "name": {
-                            "nl": "Herk-de-Stad + deelgemeenten"
+                            "nl": "Herk-de-Stad"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71024"
                     },
                     {
                         "name": {
-                            "nl": "Halen + deelgemeenten"
+                            "nl": "Halen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71020"
                     },
                     {
                         "name": {
-                            "nl": "Nieuwerkerken + deelgemeenten"
+                            "nl": "Nieuwerkerken"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71045"
                     },
                     {
                         "name": {
-                            "nl": "Landen + deelgemeenten"
+                            "nl": "Landen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-24059"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hasselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Houthalen-Helchteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lommel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hamont-Achel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hechtel-Eksel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bocholt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bree + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Peer + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zonhoven + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71066"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heusden-Zolder + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71070"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lummen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beringen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Diepenbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Genk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71016"
-                    },
-                    {
-                        "name": {
-                            "nl": "As + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zutendaal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71067"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tessenderlo-Ham + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Leopoldsburg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71034"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pelt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudsbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kinrooi + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dilsen-Stokkem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maaseik + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lanaken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maasmechelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73107"
-                    },
-                    {
-                        "name": {
-                            "nl": "Voeren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73109"
                     }
                 ]
             },
@@ -7121,241 +1863,12 @@
                 "name": {
                     "nl": "Regio Hasselt"
                 },
-                "label": "reg-hasselt",
                 "children": [
                     {
                         "name": {
-                            "nl": "Alken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tongeren-Borgloon + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herstappe + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bilzen-Hoeselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Riemst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73066"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Truiden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71053"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wellen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73098"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heers + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gingelom + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herk-de-Stad + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Halen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nieuwerkerken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71045"
-                    },
-                    {
-                        "name": {
-                            "nl": "Landen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24059"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hasselt + deelgemeenten"
+                            "nl": "Hasselt"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Houthalen-Helchteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lommel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hamont-Achel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hechtel-Eksel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bocholt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bree + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Peer + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zonhoven + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71066"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heusden-Zolder + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71070"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lummen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beringen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Diepenbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Genk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71016"
-                    },
-                    {
-                        "name": {
-                            "nl": "As + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zutendaal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71067"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tessenderlo-Ham + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Leopoldsburg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71034"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pelt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudsbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kinrooi + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dilsen-Stokkem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maaseik + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lanaken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maasmechelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73107"
-                    },
-                    {
-                        "name": {
-                            "nl": "Voeren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73109"
                     }
                 ]
             },
@@ -7363,241 +1876,120 @@
                 "name": {
                     "nl": "Regio Limburgse Kempen"
                 },
-                "label": "reg-limburgse-kempen",
                 "children": [
                     {
                         "name": {
-                            "nl": "Alken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tongeren-Borgloon + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herstappe + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bilzen-Hoeselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Riemst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73066"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Truiden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71053"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wellen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73098"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heers + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gingelom + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herk-de-Stad + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Halen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nieuwerkerken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71045"
-                    },
-                    {
-                        "name": {
-                            "nl": "Landen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24059"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hasselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Houthalen-Helchteren + deelgemeenten"
+                            "nl": "Houthalen-Helchteren"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72039"
                     },
                     {
                         "name": {
-                            "nl": "Lommel + deelgemeenten"
+                            "nl": "Lommel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72020"
                     },
                     {
                         "name": {
-                            "nl": "Hamont-Achel + deelgemeenten"
+                            "nl": "Hamont-Achel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72037"
                     },
                     {
                         "name": {
-                            "nl": "Hechtel-Eksel + deelgemeenten"
+                            "nl": "Hechtel-Eksel"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72038"
                     },
                     {
                         "name": {
-                            "nl": "Bocholt + deelgemeenten"
+                            "nl": "Bocholt"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72003"
                     },
                     {
                         "name": {
-                            "nl": "Bree + deelgemeenten"
+                            "nl": "Bree"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72004"
                     },
                     {
                         "name": {
-                            "nl": "Peer + deelgemeenten"
+                            "nl": "Peer"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72030"
                     },
                     {
                         "name": {
-                            "nl": "Zonhoven + deelgemeenten"
+                            "nl": "Zonhoven"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71066"
                     },
                     {
                         "name": {
-                            "nl": "Heusden-Zolder + deelgemeenten"
+                            "nl": "Heusden-Zolder"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71070"
                     },
                     {
                         "name": {
-                            "nl": "Lummen + deelgemeenten"
+                            "nl": "Lummen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71037"
                     },
                     {
                         "name": {
-                            "nl": "Beringen + deelgemeenten"
+                            "nl": "Beringen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71004"
                     },
                     {
                         "name": {
-                            "nl": "Diepenbeek + deelgemeenten"
+                            "nl": "Diepenbeek"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71011"
                     },
                     {
                         "name": {
-                            "nl": "Genk + deelgemeenten"
+                            "nl": "Genk"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71016"
                     },
                     {
                         "name": {
-                            "nl": "As + deelgemeenten"
+                            "nl": "As"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71002"
                     },
                     {
                         "name": {
-                            "nl": "Zutendaal + deelgemeenten"
+                            "nl": "Zutendaal"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71067"
                     },
                     {
                         "name": {
-                            "nl": "Tessenderlo-Ham + deelgemeenten"
+                            "nl": "Tessenderlo-Ham"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-21012"
                     },
                     {
                         "name": {
-                            "nl": "Leopoldsburg + deelgemeenten"
+                            "nl": "Leopoldsburg"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-71034"
                     },
                     {
                         "name": {
-                            "nl": "Pelt + deelgemeenten"
+                            "nl": "Pelt"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72043"
                     },
                     {
                         "name": {
-                            "nl": "Oudsbergen + deelgemeenten"
+                            "nl": "Oudsbergen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kinrooi + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dilsen-Stokkem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maaseik + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lanaken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maasmechelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73107"
-                    },
-                    {
-                        "name": {
-                            "nl": "Voeren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73109"
                     }
                 ]
             },
@@ -7605,241 +1997,36 @@
                 "name": {
                     "nl": "Regio Maasland"
                 },
-                "label": "reg-maasland",
                 "children": [
                     {
                         "name": {
-                            "nl": "Alken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tongeren-Borgloon + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herstappe + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bilzen-Hoeselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Riemst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73066"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Truiden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71053"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wellen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73098"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heers + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gingelom + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herk-de-Stad + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Halen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nieuwerkerken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71045"
-                    },
-                    {
-                        "name": {
-                            "nl": "Landen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24059"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hasselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Houthalen-Helchteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lommel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hamont-Achel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hechtel-Eksel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bocholt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bree + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Peer + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zonhoven + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71066"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heusden-Zolder + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71070"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lummen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beringen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Diepenbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Genk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71016"
-                    },
-                    {
-                        "name": {
-                            "nl": "As + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zutendaal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71067"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tessenderlo-Ham + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Leopoldsburg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71034"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pelt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudsbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kinrooi + deelgemeenten"
+                            "nl": "Kinrooi"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72018"
                     },
                     {
                         "name": {
-                            "nl": "Dilsen-Stokkem + deelgemeenten"
+                            "nl": "Dilsen-Stokkem"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72041"
                     },
                     {
                         "name": {
-                            "nl": "Maaseik + deelgemeenten"
+                            "nl": "Maaseik"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-72021"
                     },
                     {
                         "name": {
-                            "nl": "Lanaken + deelgemeenten"
+                            "nl": "Lanaken"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-73042"
                     },
                     {
                         "name": {
-                            "nl": "Maasmechelen + deelgemeenten"
+                            "nl": "Maasmechelen"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-73107"
-                    },
-                    {
-                        "name": {
-                            "nl": "Voeren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73109"
                     }
                 ]
             },
@@ -7847,239 +2034,10 @@
                 "name": {
                     "nl": "Regio Voerstreek"
                 },
-                "label": "reg-voerstreek",
                 "children": [
                     {
                         "name": {
-                            "nl": "Alken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73001"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tongeren-Borgloon + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21009"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herstappe + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73028"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bilzen-Hoeselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21010"
-                    },
-                    {
-                        "name": {
-                            "nl": "Riemst + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73066"
-                    },
-                    {
-                        "name": {
-                            "nl": "Sint-Truiden + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71053"
-                    },
-                    {
-                        "name": {
-                            "nl": "Wellen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73098"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heers + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73022"
-                    },
-                    {
-                        "name": {
-                            "nl": "Gingelom + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71017"
-                    },
-                    {
-                        "name": {
-                            "nl": "Herk-de-Stad + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71024"
-                    },
-                    {
-                        "name": {
-                            "nl": "Halen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Nieuwerkerken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71045"
-                    },
-                    {
-                        "name": {
-                            "nl": "Landen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-24059"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hasselt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Houthalen-Helchteren + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72039"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lommel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72020"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hamont-Achel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Hechtel-Eksel + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72038"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bocholt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72003"
-                    },
-                    {
-                        "name": {
-                            "nl": "Bree + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Peer + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72030"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zonhoven + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71066"
-                    },
-                    {
-                        "name": {
-                            "nl": "Heusden-Zolder + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71070"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lummen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71037"
-                    },
-                    {
-                        "name": {
-                            "nl": "Beringen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71004"
-                    },
-                    {
-                        "name": {
-                            "nl": "Diepenbeek + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71011"
-                    },
-                    {
-                        "name": {
-                            "nl": "Genk + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71016"
-                    },
-                    {
-                        "name": {
-                            "nl": "As + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71002"
-                    },
-                    {
-                        "name": {
-                            "nl": "Zutendaal + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71067"
-                    },
-                    {
-                        "name": {
-                            "nl": "Tessenderlo-Ham + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-21012"
-                    },
-                    {
-                        "name": {
-                            "nl": "Leopoldsburg + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-71034"
-                    },
-                    {
-                        "name": {
-                            "nl": "Pelt + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72043"
-                    },
-                    {
-                        "name": {
-                            "nl": "Oudsbergen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Kinrooi + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72018"
-                    },
-                    {
-                        "name": {
-                            "nl": "Dilsen-Stokkem + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72041"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maaseik + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-72021"
-                    },
-                    {
-                        "name": {
-                            "nl": "Lanaken + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73042"
-                    },
-                    {
-                        "name": {
-                            "nl": "Maasmechelen + deelgemeenten"
-                        },
-                        "label": "cultuurkuur_werkingsregio_nis-73107"
-                    },
-                    {
-                        "name": {
-                            "nl": "Voeren + deelgemeenten"
+                            "nl": "Voeren"
                         },
                         "label": "cultuurkuur_werkingsregio_nis-73109"
                     }

--- a/tests/Cultuurkuur/GetEducationLevelsRequestHandlerTest.php
+++ b/tests/Cultuurkuur/GetEducationLevelsRequestHandlerTest.php
@@ -28,8 +28,8 @@ class GetEducationLevelsRequestHandlerTest extends TestCase
         $this->assertArrayHasKey('nl', $json[0]['name']);
         $this->assertArrayHasKey('label', $json[0]);
         $this->assertArrayHasKey('children', $json[0]);
-        $this->assertEquals('Basisonderwijs', $json[0]['name']['nl']);
-        $this->assertEquals('cultuurkuur_basisonderwijs', $json[0]['label']);
+        $this->assertEquals('Gewoon basisonderwijs (kleuter- en basis)', $json[0]['name']['nl']);
+        $this->assertEquals('cultuurkuur_Gewoon-basisonderwijs', $json[0]['label']);
         $this->assertIsArray($json[0]['children']);
     }
 }


### PR DESCRIPTION
### Changes
- Make sure the right municipalities are shown in the regions (now som regions have the same municipalities ex: Antwerpen)
- Add the province label for the municipalities, on province level. So this is the second province label in the excel
- Remove region label (ex. ‘reg-brussel’) because it is never used
- Remove ‘+ deelgemeenten’ on all labels
- For educationlevels: lowest level labels (level 3) are changed. Check if this is the case (see excelscheet with changes).


---

Ticket: https://jira.uitdatabank.be/browse/III-6579 
