### PR TITLE
[minor] Fix typo readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Xdebug is configured to run with trigger mode, meaning you have to modify the re
 - *CLI*: (useful with unit tests):
 ```
 make bash-xdebug
-source ./start-xdebug.sh
+source ./bin/start-xdebug.sh
 ```
 
 ## Logs


### PR DESCRIPTION
### Fixed
- Fix typo (wrong location) in readme.md