### PR TITLE
III-6772 fix for v2 JWT Provider tokens in DomainMessage

### DIFF
--- a/features/Steps/AuthorizationSteps.php
+++ b/features/Steps/AuthorizationSteps.php
@@ -83,8 +83,8 @@ trait AuthorizationSteps
         );
         $this->responseState->setResponse($response);
 
-        $accessToken = $this->responseState->getJsonContent()['id_token'];
-        $this->requestState->setJwt($accessToken);
+        $idToken = $this->responseState->getJsonContent()['id_token'];
+        $this->requestState->setJwt($idToken);
 
         $this->iAmUsingTheUDB3BaseURL();
     }

--- a/features/Steps/AuthorizationSteps.php
+++ b/features/Steps/AuthorizationSteps.php
@@ -83,7 +83,7 @@ trait AuthorizationSteps
         );
         $this->responseState->setResponse($response);
 
-        $accessToken = $this->responseState->getJsonContent()['access_token'];
+        $accessToken = $this->responseState->getJsonContent()['id_token'];
         $this->requestState->setJwt($accessToken);
 
         $this->iAmUsingTheUDB3BaseURL();

--- a/features/search/auth.feature
+++ b/features/search/auth.feature
@@ -51,9 +51,3 @@ Feature: Test the Search API v3 authentication
     And I am using the Search API v3 base URL
     When I send a GET request to "/events"
     Then the response status should be "403"
-
-  Scenario: Search with a JWT provider v2 token
-    Given I am authorized as JWT provider v2 user "invoerder"
-    And I am using the Search API v3 base URL
-    When I send a GET request to "/events"
-    Then the response status should be "200"

--- a/src/Http/Auth/Jwt/JsonWebToken.php
+++ b/src/Http/Auth/Jwt/JsonWebToken.php
@@ -58,7 +58,7 @@ final class JsonWebToken
             return self::UIT_ID_V1_JWT_PROVIDER_TOKEN;
         }
 
-        // Because ID tokens from Keycloak always have a `azp` claim the `typ` claim can be used to verify if a Keycloak ID token is passed. Note: this `typ` field is missing for Auth0, so we need to a check for Auth0 and a check for Keycloak.
+        // Because ID tokens from Keycloak always have a `azp` claim the `typ` claim can be used to verify if a Keycloak ID token is passed.
         if ($this->token->claims()->get('typ', '') === 'ID') {
             return self::UIT_ID_V2_JWT_PROVIDER_TOKEN;
         }

--- a/src/Http/Auth/Jwt/JsonWebToken.php
+++ b/src/Http/Auth/Jwt/JsonWebToken.php
@@ -58,11 +58,6 @@ final class JsonWebToken
             return self::UIT_ID_V1_JWT_PROVIDER_TOKEN;
         }
 
-        // V2 tokens from the JWT provider are Auth0 ID tokens and do not have an azp claim
-        if (!$this->token->claims()->has('azp')) {
-            return self::UIT_ID_V2_JWT_PROVIDER_TOKEN;
-        }
-
         // Because ID tokens from Keycloak always have a `azp` claim the `typ` claim can be used to verify if a Keycloak ID token is passed. Note: this `typ` field is missing for Auth0, so we need to a check for Auth0 and a check for Keycloak.
         if ($this->token->claims()->get('typ', '') === 'ID') {
             return self::UIT_ID_V2_JWT_PROVIDER_TOKEN;

--- a/src/Http/Auth/RequestAuthenticatorMiddleware.php
+++ b/src/Http/Auth/RequestAuthenticatorMiddleware.php
@@ -88,9 +88,7 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
         $this->authenticateToken($request);
 
         // Requests that use a token from the JWT provider (v1 or v2) require an API key from UiTID v1.
-        // Requests that use a token that they got directly from Auth0 do not require an API key.
-        // The difference can be checked by checking if the token has a client id, which is always missing in tokens
-        // from the JWT providers.
+        // Requests that use a token that they got from a clientId do not require an API key.
         if ($this->token->getType() === JsonWebToken::UIT_ID_V1_JWT_PROVIDER_TOKEN || $this->token->getType() === JsonWebToken::UIT_ID_V2_JWT_PROVIDER_TOKEN) {
             $this->authenticateApiKey($request);
         }

--- a/src/Http/Auth/RequestAuthenticatorMiddleware.php
+++ b/src/Http/Auth/RequestAuthenticatorMiddleware.php
@@ -91,7 +91,7 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
         // Requests that use a token that they got directly from Auth0 do not require an API key.
         // The difference can be checked by checking if the token has a client id, which is always missing in tokens
         // from the JWT providers.
-        if ($this->token->getClientId() === null) {
+        if ($this->token->getClientId() === null || $this->token->getType() === JsonWebToken::UIT_ID_V2_JWT_PROVIDER_TOKEN) {
             $this->authenticateApiKey($request);
         }
 

--- a/src/Http/Auth/RequestAuthenticatorMiddleware.php
+++ b/src/Http/Auth/RequestAuthenticatorMiddleware.php
@@ -91,7 +91,7 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
         // Requests that use a token that they got directly from Auth0 do not require an API key.
         // The difference can be checked by checking if the token has a client id, which is always missing in tokens
         // from the JWT providers.
-        if ($this->token->getClientId() === null || $this->token->getType() === JsonWebToken::UIT_ID_V2_JWT_PROVIDER_TOKEN) {
+        if ($this->token->getType() === JsonWebToken::UIT_ID_V1_JWT_PROVIDER_TOKEN || $this->token->getType() === JsonWebToken::UIT_ID_V2_JWT_PROVIDER_TOKEN) {
             $this->authenticateApiKey($request);
         }
 

--- a/tests/Http/Auth/Jwt/JsonWebTokenTest.php
+++ b/tests/Http/Auth/Jwt/JsonWebTokenTest.php
@@ -125,15 +125,6 @@ class JsonWebTokenTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_v2_jwt_provider_token_type_if_an_azp_claim_is_missing(): void
-    {
-        $jwt = JsonWebTokenFactory::createWithClaims(['sub' => 'auth0|mock-user-id']);
-        $this->assertEquals(JsonWebToken::UIT_ID_V2_JWT_PROVIDER_TOKEN, $jwt->getType());
-    }
-
-    /**
-     * @test
-     */
     public function it_returns_v2_jwt_provider_token_type_when_typ_is_id(): void
     {
         $jwt = JsonWebTokenFactory::createWithClaims([

--- a/tests/Http/Auth/Jwt/UitIdV2JwtValidatorTest.php
+++ b/tests/Http/Auth/Jwt/UitIdV2JwtValidatorTest.php
@@ -70,31 +70,4 @@ class UitIdV2JwtValidatorTest extends TestCase
         $this->expectException(ApiProblem::class);
         $this->v2Validator->validateClaims($tokenWithoutPermission);
     }
-
-    /**
-     * @test
-     */
-    public function it_verifies_that_the_aud_is_the_v2_jwt_provider_if_no_azp_is_present(): void
-    {
-        $tokenFromV2JwtProvider = JsonWebTokenFactory::createWithClaims(
-            [
-                'iss' => 'mock-issuer',
-                'sub' => 'mock',
-                'aud' => 'vsCe0hXlLaR255wOrW56Fau7vYO5qvqD',
-            ]
-        );
-        $tokenWithUnknownAud = JsonWebTokenFactory::createWithClaims(
-            [
-                'iss' => 'mock-issuer',
-                'sub' => 'mock',
-                'aud' => 'foobar',
-            ]
-        );
-
-        $this->v2Validator->validateClaims($tokenFromV2JwtProvider);
-        $this->addToAssertionCount(1);
-
-        $this->expectException(ApiProblem::class);
-        $this->v2Validator->validateClaims($tokenWithUnknownAud);
-    }
 }


### PR DESCRIPTION
### Changed

- `AuthorizationSteps`: use `id_token` instead of `access_token` in `iAmAuthorizedAsJwtProviderV2User()`
- `auth.feature`:  Remove faulty test.
- `RequestAuthenticatorMiddleware`: Add check for `typ` of `token` when deciding to `authenticateApiKey()`
- `JsonWebToken`: Remove check for `auth0`-tokens without `azp`
- `JsonWebTokenTest` & `UitIdV2JwtValidatorTest`: Remove tests for `auth0`-tokens without `azp`

### Fixed

- `DomainMessages` should now contain an `apiKey`, when using a `JWT Provider v2-token`.

---

Ticket: https://jira.publiq.be/browse/III-6772
