### PR TITLE
III-6726 decorate saved queries

### DIFF
--- a/app/SavedSearches/SavedSearchesServiceProvider.php
+++ b/app/SavedSearches/SavedSearchesServiceProvider.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Http\SavedSearches\CreateSavedSearchRequestHandler;
 use CultuurNet\UDB3\Http\SavedSearches\DeleteSavedSearchRequestHandler;
 use CultuurNet\UDB3\Http\SavedSearches\ReadSavedSearchesRequestHandler;
 use CultuurNet\UDB3\Http\SavedSearches\UpdateSavedSearchRequestHandler;
+use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchesOwnedByCurrentUser;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchReadRepository;
 use CultuurNet\UDB3\SavedSearches\ValueObject\CreatedByQueryMode;
@@ -53,6 +54,11 @@ final class SavedSearchesServiceProvider extends AbstractServiceProvider
             SavedSearchesOwnedByCurrentUser::class,
             function () use ($container) {
                 return new CombinedSavedSearchRepository(
+                    new OwnershipSavedSearchRepository(
+                        $container->get(JsonWebToken::class),
+                        $container->get('organizer_jsonld_repository'),
+                        $container->get(OwnershipSearchRepository::class)
+                    ),
                     new Sapi3FixedSavedSearchRepository(
                         $container->get(JsonWebToken::class),
                         $container->get(UserIdentityResolver::class),

--- a/features/saved_searches/ownerships.feature
+++ b/features/saved_searches/ownerships.feature
@@ -1,0 +1,49 @@
+Feature: Test the UDB3 ownerships saved searches API
+  
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider user "centraal_beheerder"
+    And I send and accept "application/json"
+    And I create a minimal organizer and save the "id" as "organizerId"
+    And I am authorized as JWT provider user "invoerder_ownerships"
+    And I request ownership for "auth0|64089494e980aedd96740212" on the organizer with organizerId "%{organizerId}" and save the "id" as "ownershipId"
+
+  Scenario: Requested ownerships should show not up in saved searches
+    Given I am authorized as JWT provider user "invoerder_ownerships"
+    When I send a GET request to "/saved-searches/v3"
+    Then the response status should be "200"
+    And the JSON response should not include:
+    """
+    Aanbod %{name}
+    """
+
+  Scenario: Approved ownerships should show up in saved searches
+    Given I am authorized as JWT provider user "centraal_beheerder"
+    And I approve the ownership with ownershipId "%{ownershipId}"
+    And I am authorized as JWT provider user "invoerder_ownerships"
+    When I send a GET request to "/saved-searches/v3"
+    Then the response status should be "200"
+    And the JSON response at "/" should include "Aanbod %{name}"
+
+  Scenario: Rejected ownerships should show not up in saved searches
+    Given I am authorized as JWT provider user "centraal_beheerder"
+    And I reject the ownership with ownershipId "%{ownershipId}"
+    Given I am authorized as JWT provider user "invoerder_ownerships"
+    When I send a GET request to "/saved-searches/v3"
+    Then the response status should be "200"
+    And the JSON response should not include:
+    """
+    Aanbod %{name}
+    """
+
+  Scenario: Deleted ownerships should show up in saved searches
+    Given I am authorized as JWT provider user "centraal_beheerder"
+    And I delete the ownership with ownershipId "%{ownershipId}"
+    Given I am authorized as JWT provider user "invoerder_ownerships"
+    When I send a GET request to "/saved-searches/v3"
+    Then the response status should be "200"
+    And the JSON response should not include:
+    """
+    Aanbod %{name}
+    """

--- a/features/saved_searches/ownerships.feature
+++ b/features/saved_searches/ownerships.feature
@@ -15,7 +15,7 @@ Feature: Test the UDB3 ownerships saved searches API
     Then the response status should be "200"
     And the JSON response should not include:
     """
-    {"name":"Aanbod %{name}","query":"organizer.id:%{organizerId}"}"
+    "query":"organizer.id:%{organizerId}"
     """
 
   Scenario: Approved ownerships should show up in saved searches
@@ -24,10 +24,9 @@ Feature: Test the UDB3 ownerships saved searches API
     And I am authorized as JWT provider user "invoerder_ownerships"
     When I send a GET request to "/saved-searches/v3"
     Then the response status should be "200"
-    And show me the unparsed response
-    And the JSON response at "/" should include:
+    And the JSON response should include:
     """
-    {"name":"Aanbod %{name}","query":"organizer.id:%{organizerId}"}"
+    "query":"organizer.id:%{organizerId}"
     """
 
   Scenario: Rejected ownerships should show not up in saved searches
@@ -38,7 +37,7 @@ Feature: Test the UDB3 ownerships saved searches API
     Then the response status should be "200"
     And the JSON response should not include:
     """
-    Aanbod %{name}
+    "query":"organizer.id:%{organizerId}"
     """
 
   Scenario: Deleted ownerships should show up in saved searches
@@ -49,5 +48,5 @@ Feature: Test the UDB3 ownerships saved searches API
     Then the response status should be "200"
     And the JSON response should not include:
     """
-    Aanbod %{name}
+    "query":"organizer.id:%{organizerId}"
     """

--- a/features/saved_searches/ownerships.feature
+++ b/features/saved_searches/ownerships.feature
@@ -15,7 +15,7 @@ Feature: Test the UDB3 ownerships saved searches API
     Then the response status should be "200"
     And the JSON response should not include:
     """
-    Aanbod %{name}
+    {"name":"Aanbod %{name}","query":"organizer.id:%{organizerId}"}"
     """
 
   Scenario: Approved ownerships should show up in saved searches
@@ -24,7 +24,11 @@ Feature: Test the UDB3 ownerships saved searches API
     And I am authorized as JWT provider user "invoerder_ownerships"
     When I send a GET request to "/saved-searches/v3"
     Then the response status should be "200"
-    And the JSON response at "/" should include "Aanbod %{name}"
+    And show me the unparsed response
+    And the JSON response at "/" should include:
+    """
+    {"name":"Aanbod %{name}","query":"organizer.id:%{organizerId}"}"
+    """
 
   Scenario: Rejected ownerships should show not up in saved searches
     Given I am authorized as JWT provider user "centraal_beheerder"

--- a/src/SavedSearches/OwnershipSavedSearchRepository.php
+++ b/src/SavedSearches/OwnershipSavedSearchRepository.php
@@ -40,8 +40,8 @@ class OwnershipSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
         $ownershipQueryStrings = $this->getOwnershipQueryStrings();
 
         $savedSearches = [];
-        foreach ($ownershipQueryStrings as $ownershipName => $ownershipQueryString) {
-            $savedSearches[] = new SavedSearch('Aanbod ' . $ownershipName, $ownershipQueryString);
+        foreach ($ownershipQueryStrings as $organizerName => $ownershipQueryString) {
+            $savedSearches[] = new SavedSearch('Aanbod ' . $organizerName, $ownershipQueryString);
         }
         return $savedSearches;
     }

--- a/src/SavedSearches/OwnershipSavedSearchRepository.php
+++ b/src/SavedSearches/OwnershipSavedSearchRepository.php
@@ -67,23 +67,15 @@ class OwnershipSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
             $organizerId = $ownershipItem->getItemId();
             $organizerAsJson = $this->organizerDocumentRepository->fetch($organizerId);
             $body = $organizerAsJson->getAssocBody();
-            $organizerName = $this->getName($body);
+            $organizerName = $this->getNameInMainLanguage($body);
             $ownershipQueries[$organizerName] = new QueryString('organizer.id:' . $organizerId);
         }
         return $ownershipQueries;
     }
 
-    private function getName(array $body): string
+    private function getNameInMainLanguage(array $body): string
     {
-        $preferredLanguages = ['nl', 'fr', 'de', 'en'];
-
-        foreach ($preferredLanguages as $lang) {
-            if (!empty($body['name'][$lang])) {
-                return $body['name'][$lang];
-            }
-        }
-
-        // fallback if no language match is found
-        return '';
+        $mainLanguage = $body['mainLanguage'];
+        return $body['name'][$mainLanguage];
     }
 }

--- a/src/SavedSearches/OwnershipSavedSearchRepository.php
+++ b/src/SavedSearches/OwnershipSavedSearchRepository.php
@@ -51,12 +51,12 @@ class OwnershipSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
      */
     private function getOwnershipQueryStrings(): array
     {
-        $token = $this->token->getUserId();
+        $userId = $this->token->getUserId();
 
         $ownershipItemCollection = $this->ownershipSearchRepository->search(
             new SearchQuery([
                 new SearchParameter('state', OwnershipState::approved()->toString()),
-                new SearchParameter('ownerId', $token),
+                new SearchParameter('ownerId', $userId),
             ])
         );
 

--- a/src/SavedSearches/OwnershipSavedSearchRepository.php
+++ b/src/SavedSearches/OwnershipSavedSearchRepository.php
@@ -65,9 +65,9 @@ class OwnershipSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
 
         foreach ($ownershipItemCollection as $ownershipItem) {
             $organizerId = $ownershipItem->getItemId();
-            $organizerAsJson = $this->organizerDocumentRepository->fetch($organizerId);
-            $body = $organizerAsJson->getAssocBody();
-            $organizerName = $this->getNameInMainLanguage($body);
+            $organizerName = $this->getNameInMainLanguage(
+                $this->organizerDocumentRepository->fetch($organizerId)->getAssocBody()
+            );
             $ownershipQueries[$organizerName] = new QueryString('organizer.id:' . $organizerId);
         }
         return $ownershipQueries;

--- a/src/SavedSearches/OwnershipSavedSearchRepository.php
+++ b/src/SavedSearches/OwnershipSavedSearchRepository.php
@@ -56,6 +56,7 @@ class OwnershipSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
         $ownershipItemCollection = $this->ownershipSearchRepository->search(
             new SearchQuery([
                 new SearchParameter('state', OwnershipState::approved()->toString()),
+                new SearchParameter('itemType', 'organizer'),
                 new SearchParameter('ownerId', $userId),
             ])
         );
@@ -63,13 +64,11 @@ class OwnershipSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
         $ownershipQueries = [];
 
         foreach ($ownershipItemCollection as $ownershipItem) {
-            if ($ownershipItem->getItemType() === 'organizer') {
-                $organizerId = $ownershipItem->getItemId();
-                $organizerAsJson = $this->organizerDocumentRepository->fetch($organizerId);
-                $body = $organizerAsJson->getAssocBody();
-                $organizerName = $this->getName($body);
-                $ownershipQueries[$organizerName] = new QueryString('organizer.id:' . $organizerId);
-            }
+            $organizerId = $ownershipItem->getItemId();
+            $organizerAsJson = $this->organizerDocumentRepository->fetch($organizerId);
+            $body = $organizerAsJson->getAssocBody();
+            $organizerName = $this->getName($body);
+            $ownershipQueries[$organizerName] = new QueryString('organizer.id:' . $organizerId);
         }
         return $ownershipQueries;
     }

--- a/src/SavedSearches/OwnershipSavedSearchRepository.php
+++ b/src/SavedSearches/OwnershipSavedSearchRepository.php
@@ -67,10 +67,24 @@ class OwnershipSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
                 $organizerId = $ownershipItem->getItemId();
                 $organizerAsJson = $this->organizerDocumentRepository->fetch($organizerId);
                 $body = $organizerAsJson->getAssocBody();
-                $organizerName = $body['name']['nl'];
+                $organizerName = $this->getName($body);
                 $ownershipQueries[$organizerName] = new QueryString('organizer.id:' . $organizerId);
             }
         }
         return $ownershipQueries;
+    }
+
+    private function getName(array $body): string
+    {
+        $preferredLanguages = ['nl', 'fr', 'de', 'en'];
+
+        foreach ($preferredLanguages as $lang) {
+            if (!empty($body['name'][$lang])) {
+                return $body['name'][$lang];
+            }
+        }
+
+        // fallback if no language match is found
+        return '';
     }
 }

--- a/src/SavedSearches/OwnershipSavedSearchRepository.php
+++ b/src/SavedSearches/OwnershipSavedSearchRepository.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\SavedSearches;
+
+use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
+use CultuurNet\UDB3\Http\Ownership\Search\SearchParameter;
+use CultuurNet\UDB3\Http\Ownership\Search\SearchQuery;
+use CultuurNet\UDB3\Ownership\OwnershipState;
+use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchesOwnedByCurrentUser;
+
+class OwnershipSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
+{
+    private JsonWebToken $token;
+
+    private DocumentRepository $organizerDocumentRepository;
+
+    private OwnershipSearchRepository $ownershipSearchRepository;
+
+    public function __construct(
+        JsonWebToken $token,
+        DocumentRepository $organizerDocumentRepository,
+        OwnershipSearchRepository $ownershipSearchRepository
+    ) {
+        $this->token = $token;
+        $this->organizerDocumentRepository = $organizerDocumentRepository;
+        $this->ownershipSearchRepository = $ownershipSearchRepository;
+    }
+
+    /**
+     * @return SavedSearch[]
+     */
+    public function ownedByCurrentUser(): array
+    {
+        $ownershipQueryStrings = $this->getOwnershipQueryStrings();
+
+        $savedSearches = [];
+        foreach ($ownershipQueryStrings as $ownershipName => $ownershipQueryString) {
+            $savedSearches[] = new SavedSearch('Aanbod ' . $ownershipName, $ownershipQueryString);
+        }
+        return $savedSearches;
+    }
+
+    /**
+     * @return QueryString[]
+     */
+    private function getOwnershipQueryStrings(): array
+    {
+        $token = $this->token->getUserId();
+
+        $ownershipItemCollection = $this->ownershipSearchRepository->search(
+            new SearchQuery([
+                new SearchParameter('state', OwnershipState::approved()->toString()),
+                new SearchParameter('ownerId', $token),
+            ])
+        );
+
+        $ownershipQueries = [];
+
+        foreach ($ownershipItemCollection as $ownershipItem) {
+            if ($ownershipItem->getItemType() === 'organizer') {
+                $organizerId = $ownershipItem->getItemId();
+                $organizerAsJson = $this->organizerDocumentRepository->fetch($organizerId);
+                $body = $organizerAsJson->getAssocBody();
+                $organizerName = $body['name']['nl'];
+                $ownershipQueries[$organizerName] = new QueryString('organizer.id:' . $organizerId);
+            }
+        }
+        return $ownershipQueries;
+    }
+}

--- a/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
@@ -52,7 +52,7 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
      * @test
      * @dataProvider SavedSearchDataprovider
      */
-    public function it_returns_an_empty_ownership_collection_if_no_were_found(array $jsonDocuments, OwnershipItemCollection $ownershipItemCollection, array $savedSearches): void
+    public function it_returns_ownerships(array $jsonDocuments, OwnershipItemCollection $ownershipItemCollection, array $savedSearches): void
     {
         foreach ($jsonDocuments as $jsonDocument) {
             $this->organizerDocumentRepository->save($jsonDocument);

--- a/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
@@ -62,6 +62,7 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
         ->method('search')
             ->with(new SearchQuery([
                 new SearchParameter('state', OwnershipState::approved()->toString()),
+                new SearchParameter('itemType', 'organizer'),
                 new SearchParameter('ownerId', self::USER_ID),
             ]))
             ->willReturn($ownershipItemCollection);
@@ -176,49 +177,6 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
                     new SavedSearch('Aanbod Foobar EN', new QueryString('organizer.id:' . $itemId1)),
                     new SavedSearch('Aanbod Bar Foo FR', new QueryString('organizer.id:' . $itemId2)),
                 ],
-            ],
-            'no_organizers' => [
-                [
-                    new JsonDocument(
-                        $itemId1,
-                        Json::encode(
-                            [
-                                '@type' => 'event',
-                                'name' => [
-                                    'nl' => 'Foobar EN',
-                                ],
-                            ]
-                        )
-                    ),
-                    new JsonDocument(
-                        $itemId2,
-                        Json::encode(
-                            [
-                                '@type' => 'place',
-                                'name' => [
-                                    'nl' => 'Bar Foo FR',
-                                ],
-                            ]
-                        )
-                    ),
-                ],
-                new OwnershipItemCollection(
-                    new OwnershipItem(
-                        $ownershipItemId1,
-                        $itemId1,
-                        'event',
-                        self::USER_ID,
-                        OwnershipState::approved()->toString()
-                    ),
-                    new OwnershipItem(
-                        $ownershipItem2,
-                        $itemId2,
-                        'place',
-                        self::USER_ID,
-                        OwnershipState::approved()->toString()
-                    )
-                ),
-                [],
             ],
         ];
     }

--- a/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
@@ -52,220 +52,179 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
             $this->ownershipSearchRepository
         );
     }
+
     /**
      * @test
+     * @dataProvider SavedSearchDataprovider
      */
-    public function it_returns_an_empty_ownership_collection_if_no_were_found(): void
+    public function it_returns_an_empty_ownership_collection_if_no_were_found(array $jsonDocuments, OwnershipItemCollection $ownershipItemCollection, array $savedSearches): void
     {
+        foreach ($jsonDocuments as $jsonDocument) {
+            $this->organizerDocumentRepository->save($jsonDocument);
+        }
+
         $this->ownershipSearchRepository->expects($this->once())
         ->method('search')
             ->with(new SearchQuery([
                 new SearchParameter('state', OwnershipState::approved()->toString()),
                 new SearchParameter('ownerId', self::USER_ID),
             ]))
-            ->willReturn(new OwnershipItemCollection());
+            ->willReturn($ownershipItemCollection);
 
         $this->assertEquals(
-            [],
+            $savedSearches,
             $this->ownershipSavedSearchRepository->ownedByCurrentUser()
         );
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_ownership_collections_if_some_were_found(): void
+    public function SavedSearchDataprovider(): array
     {
         $itemId1 = 'c84d6167-5e71-4f2c-aedf-ad346e569e03';
-        $jsonLd = new JsonDocument(
-            $itemId1,
-            Json::encode(
-                [
-                    '@type' => 'organizer',
-                    'name' => [
-                        'nl' => 'Foobar NL',
-                    ],
-                ]
-            )
-        );
-        $this->organizerDocumentRepository->save($jsonLd);
-
         $itemId2 = '24bc3c50-5c9e-4e34-8bc7-1c9826352775';
-        $jsonLd2 = new JsonDocument(
-            $itemId2,
-            Json::encode(
-                [
-                    '@type' => 'organizer',
-                    'name' => [
-                        'nl' => 'Bar Foo NL',
-                    ],
-                ]
-            )
-        );
-        $this->organizerDocumentRepository->save($jsonLd2);
+        $ownershipItemId1 = 'a700c463-1401-4d91-a85c-fa289b6d8d8e';
+        $ownershipItem2 = '8ba5ee51-8e0c-4179-8516-3942ac4ab6d2';
 
-        $this->ownershipSearchRepository->expects($this->once())
-            ->method('search')
-            ->with(new SearchQuery([
-                new SearchParameter('state', OwnershipState::approved()->toString()),
-                new SearchParameter('ownerId', self::USER_ID),
-            ]))
-            ->willReturn(
+        return [
+            'no_approved_ownerships' => [
+                [],
+                new OwnershipItemCollection(),
+                [],
+            ],
+            'approved_ownership_were_found' => [
+                [
+                    new JsonDocument(
+                        $itemId1,
+                        Json::encode(
+                            [
+                                '@type' => 'organizer',
+                                'name' => [
+                                    'nl' => 'Foobar NL',
+                                ],
+                            ]
+                        )
+                    ),
+                    new JsonDocument(
+                        $itemId2,
+                        Json::encode(
+                            [
+                                '@type' => 'organizer',
+                                'name' => [
+                                    'nl' => 'Bar Foo NL',
+                                ],
+                            ]
+                        )
+                    ),
+                ],
                 new OwnershipItemCollection(
                     new OwnershipItem(
-                        'a700c463-1401-4d91-a85c-fa289b6d8d8e',
+                        $ownershipItemId1,
                         $itemId1,
                         'organizer',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     ),
                     new OwnershipItem(
-                        '8ba5ee51-8e0c-4179-8516-3942ac4ab6d2',
+                        $ownershipItem2,
                         $itemId2,
                         'organizer',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     )
-                )
-            );
-
-        $this->assertEquals(
-            [
-                new SavedSearch('Aanbod Foobar NL', new QueryString('organizer.id:' . $itemId1)),
-                new SavedSearch('Aanbod Bar Foo NL', new QueryString('organizer.id:' . $itemId2)),
+                ),
+                [
+                    new SavedSearch('Aanbod Foobar NL', new QueryString('organizer.id:' . $itemId1)),
+                    new SavedSearch('Aanbod Bar Foo NL', new QueryString('organizer.id:' . $itemId2)),
+                ],
             ],
-            $this->ownershipSavedSearchRepository->ownedByCurrentUser()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_fallback_to_other_languages_if_dutch_is_not_present(): void
-    {
-        $itemId1 = 'c84d6167-5e71-4f2c-aedf-ad346e569e03';
-        $jsonLd = new JsonDocument(
-            $itemId1,
-            Json::encode(
+            'fallback_if_dutch_is_not_present' => [
                 [
-                    '@type' => 'organizer',
-                    'name' => [
-                        'en' => 'Foobar EN',
-                    ],
-                ]
-            )
-        );
-        $this->organizerDocumentRepository->save($jsonLd);
-
-        $itemId2 = '24bc3c50-5c9e-4e34-8bc7-1c9826352775';
-        $jsonLd2 = new JsonDocument(
-            $itemId2,
-            Json::encode(
-                [
-                    '@type' => 'organizer',
-                    'name' => [
-                        'fr' => 'Bar Foo FR',
-                    ],
-                ]
-            )
-        );
-        $this->organizerDocumentRepository->save($jsonLd2);
-
-        $this->ownershipSearchRepository->expects($this->once())
-            ->method('search')
-            ->with(new SearchQuery([
-                new SearchParameter('state', OwnershipState::approved()->toString()),
-                new SearchParameter('ownerId', self::USER_ID),
-            ]))
-            ->willReturn(
+                    new JsonDocument(
+                        $itemId1,
+                        Json::encode(
+                            [
+                                '@type' => 'organizer',
+                                'name' => [
+                                    'en' => 'Foobar EN',
+                                ],
+                            ]
+                        )
+                    ),
+                    new JsonDocument(
+                        $itemId2,
+                        Json::encode(
+                            [
+                                '@type' => 'organizer',
+                                'name' => [
+                                    'fr' => 'Bar Foo FR',
+                                ],
+                            ]
+                        )
+                    ),
+                ],
                 new OwnershipItemCollection(
                     new OwnershipItem(
-                        'a700c463-1401-4d91-a85c-fa289b6d8d8e',
+                        $ownershipItemId1,
                         $itemId1,
                         'organizer',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     ),
                     new OwnershipItem(
-                        '8ba5ee51-8e0c-4179-8516-3942ac4ab6d2',
+                        $ownershipItem2,
                         $itemId2,
                         'organizer',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     )
-                )
-            );
-
-        $this->assertEquals(
-            [
-                new SavedSearch('Aanbod Foobar EN', new QueryString('organizer.id:' . $itemId1)),
-                new SavedSearch('Aanbod Bar Foo FR', new QueryString('organizer.id:' . $itemId2)),
+                ),
+                [
+                    new SavedSearch('Aanbod Foobar EN', new QueryString('organizer.id:' . $itemId1)),
+                    new SavedSearch('Aanbod Bar Foo FR', new QueryString('organizer.id:' . $itemId2)),
+                ],
             ],
-            $this->ownershipSavedSearchRepository->ownedByCurrentUser()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_only_support_organizers(): void
-    {
-        $itemId1 = 'c84d6167-5e71-4f2c-aedf-ad346e569e03';
-        $jsonLd = new JsonDocument(
-            $itemId1,
-            Json::encode(
+            'no_organizers' => [
                 [
-                    '@type' => 'organizer',
-                    'name' => [
-                        'en' => 'Foobar EN',
-                    ],
-                ]
-            )
-        );
-        $this->organizerDocumentRepository->save($jsonLd);
-
-        $itemId2 = '24bc3c50-5c9e-4e34-8bc7-1c9826352775';
-        $jsonLd2 = new JsonDocument(
-            $itemId2,
-            Json::encode(
-                [
-                    '@type' => 'organizer',
-                    'name' => [
-                        'fr' => 'Bar Foo FR',
-                    ],
-                ]
-            )
-        );
-        $this->organizerDocumentRepository->save($jsonLd2);
-
-        $this->ownershipSearchRepository->expects($this->once())
-            ->method('search')
-            ->with(new SearchQuery([
-                new SearchParameter('state', OwnershipState::approved()->toString()),
-                new SearchParameter('ownerId', self::USER_ID),
-            ]))
-            ->willReturn(
+                    new JsonDocument(
+                        $itemId1,
+                        Json::encode(
+                            [
+                                '@type' => 'event',
+                                'name' => [
+                                    'nl' => 'Foobar EN',
+                                ],
+                            ]
+                        )
+                    ),
+                    new JsonDocument(
+                        $itemId2,
+                        Json::encode(
+                            [
+                                '@type' => 'place',
+                                'name' => [
+                                    'nl' => 'Bar Foo FR',
+                                ],
+                            ]
+                        )
+                    ),
+                ],
                 new OwnershipItemCollection(
                     new OwnershipItem(
-                        'a700c463-1401-4d91-a85c-fa289b6d8d8e',
+                        $ownershipItemId1,
                         $itemId1,
                         'event',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     ),
                     new OwnershipItem(
-                        '8ba5ee51-8e0c-4179-8516-3942ac4ab6d2',
+                        $ownershipItem2,
                         $itemId2,
                         'place',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     )
-                )
-            );
-
-        $this->assertEquals(
-            [],
-            $this->ownershipSavedSearchRepository->ownedByCurrentUser()
-        );
+                ),
+                [],
+            ],
+        ];
     }
 }

--- a/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
@@ -93,8 +93,10 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
                         Json::encode(
                             [
                                 '@type' => 'organizer',
+                                'mainLanguage' => 'nl',
                                 'name' => [
                                     'nl' => 'Foobar NL',
+                                    'fr' => 'Foobar FR',
                                 ],
                             ]
                         )
@@ -104,53 +106,9 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
                         Json::encode(
                             [
                                 '@type' => 'organizer',
+                                'mainLanguage' => 'fr',
                                 'name' => [
                                     'nl' => 'Bar Foo NL',
-                                ],
-                            ]
-                        )
-                    ),
-                ],
-                new OwnershipItemCollection(
-                    new OwnershipItem(
-                        $ownershipItemId1,
-                        $itemId1,
-                        'organizer',
-                        self::USER_ID,
-                        OwnershipState::approved()->toString()
-                    ),
-                    new OwnershipItem(
-                        $ownershipItem2,
-                        $itemId2,
-                        'organizer',
-                        self::USER_ID,
-                        OwnershipState::approved()->toString()
-                    )
-                ),
-                [
-                    new SavedSearch('Aanbod Foobar NL', new QueryString('organizer.id:' . $itemId1)),
-                    new SavedSearch('Aanbod Bar Foo NL', new QueryString('organizer.id:' . $itemId2)),
-                ],
-            ],
-            'fallback_if_dutch_is_not_present' => [
-                [
-                    new JsonDocument(
-                        $itemId1,
-                        Json::encode(
-                            [
-                                '@type' => 'organizer',
-                                'name' => [
-                                    'en' => 'Foobar EN',
-                                ],
-                            ]
-                        )
-                    ),
-                    new JsonDocument(
-                        $itemId2,
-                        Json::encode(
-                            [
-                                '@type' => 'organizer',
-                                'name' => [
                                     'fr' => 'Bar Foo FR',
                                 ],
                             ]
@@ -174,7 +132,7 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
                     )
                 ),
                 [
-                    new SavedSearch('Aanbod Foobar EN', new QueryString('organizer.id:' . $itemId1)),
+                    new SavedSearch('Aanbod Foobar NL', new QueryString('organizer.id:' . $itemId1)),
                     new SavedSearch('Aanbod Bar Foo FR', new QueryString('organizer.id:' . $itemId2)),
                 ],
             ],

--- a/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\SavedSearches;
+
+use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
+use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebTokenFactory;
+use CultuurNet\UDB3\Http\Ownership\Search\SearchParameter;
+use CultuurNet\UDB3\Http\Ownership\Search\SearchQuery;
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\Ownership\OwnershipState;
+use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
+use CultuurNet\UDB3\Ownership\Repositories\OwnershipItemCollection;
+use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
+use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class OwnershipSavedSearchRepositoryTest extends TestCase
+{
+    private const USER_ID = 'e2a78b6e-6eba-42a4-a366-248c5a8df792';
+
+    private JsonWebToken $token;
+
+    private DocumentRepository $organizerDocumentRepository;
+
+    /**
+     * @var OwnershipSearchRepository&MockObject
+     */
+    private $ownershipSearchRepository;
+    private OwnershipSavedSearchRepository $ownershipSavedSearchRepository;
+
+    protected function setUp(): void
+    {
+        $this->token = JsonWebTokenFactory::createWithClaims(
+            [
+                'sub' => self::USER_ID,
+            ]
+        );
+
+        $this->organizerDocumentRepository = new InMemoryDocumentRepository();
+        $this->ownershipSearchRepository = $this->createMock(OwnershipSearchRepository::class);
+
+        $this->ownershipSavedSearchRepository = new OwnershipSavedSearchRepository(
+            $this->token,
+            $this->organizerDocumentRepository,
+            $this->ownershipSearchRepository
+        );
+    }
+    /**
+     * @test
+     */
+    public function it_returns_an_empty_ownership_collection_if_no_were_found(): void
+    {
+        $this->ownershipSearchRepository->expects($this->once())
+        ->method('search')
+            ->with(new SearchQuery([
+                new SearchParameter('state', OwnershipState::approved()->toString()),
+                new SearchParameter('ownerId', self::USER_ID),
+            ]))
+            ->willReturn(new OwnershipItemCollection());
+
+        $this->assertEquals(
+            [],
+            $this->ownershipSavedSearchRepository->ownedByCurrentUser()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_ownership_collections_if_some_were_found(): void
+    {
+        $itemId1 = 'c84d6167-5e71-4f2c-aedf-ad346e569e03';
+        $jsonLd = new JsonDocument(
+            $itemId1,
+            Json::encode(
+                [
+                    '@type' => 'organizer',
+                    'name' => [
+                        'nl' => 'Foobar NL',
+                    ],
+                ]
+            )
+        );
+        $this->organizerDocumentRepository->save($jsonLd);
+
+        $itemId2 = '24bc3c50-5c9e-4e34-8bc7-1c9826352775';
+        $jsonLd2 = new JsonDocument(
+            $itemId2,
+            Json::encode(
+                [
+                    '@type' => 'organizer',
+                    'name' => [
+                        'nl' => 'Bar Foo NL',
+                    ],
+                ]
+            )
+        );
+        $this->organizerDocumentRepository->save($jsonLd2);
+
+        $this->ownershipSearchRepository->expects($this->once())
+            ->method('search')
+            ->with(new SearchQuery([
+                new SearchParameter('state', OwnershipState::approved()->toString()),
+                new SearchParameter('ownerId', self::USER_ID),
+            ]))
+            ->willReturn(
+                new OwnershipItemCollection(
+                    new OwnershipItem(
+                        'a700c463-1401-4d91-a85c-fa289b6d8d8e',
+                        $itemId1,
+                        'organizer',
+                        self::USER_ID,
+                        OwnershipState::approved()->toString()
+                    ),
+                    new OwnershipItem(
+                        '8ba5ee51-8e0c-4179-8516-3942ac4ab6d2',
+                        $itemId2,
+                        'organizer',
+                        self::USER_ID,
+                        OwnershipState::approved()->toString()
+                    )
+                )
+            );
+
+        $this->assertEquals(
+            [
+                new SavedSearch('Aanbod Foobar NL', new QueryString('organizer.id:' . $itemId1)),
+                new SavedSearch('Aanbod Bar Foo NL', new QueryString('organizer.id:' . $itemId2)),
+            ],
+            $this->ownershipSavedSearchRepository->ownedByCurrentUser()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_fallback_to_other_languages_if_dutch_is_not_present(): void
+    {
+        $itemId1 = 'c84d6167-5e71-4f2c-aedf-ad346e569e03';
+        $jsonLd = new JsonDocument(
+            $itemId1,
+            Json::encode(
+                [
+                    '@type' => 'organizer',
+                    'name' => [
+                        'en' => 'Foobar EN',
+                    ],
+                ]
+            )
+        );
+        $this->organizerDocumentRepository->save($jsonLd);
+
+        $itemId2 = '24bc3c50-5c9e-4e34-8bc7-1c9826352775';
+        $jsonLd2 = new JsonDocument(
+            $itemId2,
+            Json::encode(
+                [
+                    '@type' => 'organizer',
+                    'name' => [
+                        'fr' => 'Bar Foo FR',
+                    ],
+                ]
+            )
+        );
+        $this->organizerDocumentRepository->save($jsonLd2);
+
+        $this->ownershipSearchRepository->expects($this->once())
+            ->method('search')
+            ->with(new SearchQuery([
+                new SearchParameter('state', OwnershipState::approved()->toString()),
+                new SearchParameter('ownerId', self::USER_ID),
+            ]))
+            ->willReturn(
+                new OwnershipItemCollection(
+                    new OwnershipItem(
+                        'a700c463-1401-4d91-a85c-fa289b6d8d8e',
+                        $itemId1,
+                        'organizer',
+                        self::USER_ID,
+                        OwnershipState::approved()->toString()
+                    ),
+                    new OwnershipItem(
+                        '8ba5ee51-8e0c-4179-8516-3942ac4ab6d2',
+                        $itemId2,
+                        'organizer',
+                        self::USER_ID,
+                        OwnershipState::approved()->toString()
+                    )
+                )
+            );
+
+        $this->assertEquals(
+            [
+                new SavedSearch('Aanbod Foobar EN', new QueryString('organizer.id:' . $itemId1)),
+                new SavedSearch('Aanbod Bar Foo FR', new QueryString('organizer.id:' . $itemId2)),
+            ],
+            $this->ownershipSavedSearchRepository->ownedByCurrentUser()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_only_support_organizers(): void
+    {
+        $itemId1 = 'c84d6167-5e71-4f2c-aedf-ad346e569e03';
+        $jsonLd = new JsonDocument(
+            $itemId1,
+            Json::encode(
+                [
+                    '@type' => 'organizer',
+                    'name' => [
+                        'en' => 'Foobar EN',
+                    ],
+                ]
+            )
+        );
+        $this->organizerDocumentRepository->save($jsonLd);
+
+        $itemId2 = '24bc3c50-5c9e-4e34-8bc7-1c9826352775';
+        $jsonLd2 = new JsonDocument(
+            $itemId2,
+            Json::encode(
+                [
+                    '@type' => 'organizer',
+                    'name' => [
+                        'fr' => 'Bar Foo FR',
+                    ],
+                ]
+            )
+        );
+        $this->organizerDocumentRepository->save($jsonLd2);
+
+        $this->ownershipSearchRepository->expects($this->once())
+            ->method('search')
+            ->with(new SearchQuery([
+                new SearchParameter('state', OwnershipState::approved()->toString()),
+                new SearchParameter('ownerId', self::USER_ID),
+            ]))
+            ->willReturn(
+                new OwnershipItemCollection(
+                    new OwnershipItem(
+                        'a700c463-1401-4d91-a85c-fa289b6d8d8e',
+                        $itemId1,
+                        'event',
+                        self::USER_ID,
+                        OwnershipState::approved()->toString()
+                    ),
+                    new OwnershipItem(
+                        '8ba5ee51-8e0c-4179-8516-3942ac4ab6d2',
+                        $itemId2,
+                        'place',
+                        self::USER_ID,
+                        OwnershipState::approved()->toString()
+                    )
+                )
+            );
+
+        $this->assertEquals(
+            [],
+            $this->ownershipSavedSearchRepository->ownedByCurrentUser()
+        );
+    }
+}

--- a/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SavedSearches;
 
-use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
 use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebTokenFactory;
 use CultuurNet\UDB3\Http\Ownership\Search\SearchParameter;
 use CultuurNet\UDB3\Http\Ownership\Search\SearchQuery;
@@ -25,8 +24,6 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
 {
     private const USER_ID = 'e2a78b6e-6eba-42a4-a366-248c5a8df792';
 
-    private JsonWebToken $token;
-
     private DocumentRepository $organizerDocumentRepository;
 
     /**
@@ -37,17 +34,15 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->token = JsonWebTokenFactory::createWithClaims(
-            [
-                'sub' => self::USER_ID,
-            ]
-        );
-
         $this->organizerDocumentRepository = new InMemoryDocumentRepository();
         $this->ownershipSearchRepository = $this->createMock(OwnershipSearchRepository::class);
 
         $this->ownershipSavedSearchRepository = new OwnershipSavedSearchRepository(
-            $this->token,
+            JsonWebTokenFactory::createWithClaims(
+                [
+                    'sub' => self::USER_ID,
+                ]
+            ),
             $this->organizerDocumentRepository,
             $this->ownershipSearchRepository
         );


### PR DESCRIPTION
### Added

- `OwnershipSavedSearchRepository`: Add Search Repo for `APPROVED` Ownerships.
- `OwnershipSavedSearchRepositoryTest`: Unit test for `OwnershipSavedSearchRepository`
- `ownerships.feature`: Acceptance test

### Changed

- `SavedSearchesServiceProvider`: register `OwnershipSavedSearchRepository`

---

Ticket: https://jira.publiq.be/browse/III-6726
