### PR TITLE
III-6777 Change calculation canonical place protect uitpas place

### DIFF
--- a/app/Place/PlaceServiceProvider.php
+++ b/app/Place/PlaceServiceProvider.php
@@ -99,6 +99,7 @@ final class PlaceServiceProvider extends AbstractServiceProvider
             'canonical_service',
             fn () => new CanonicalService(
                 $container->get('config')['museumpas']['label'],
+                $container->get('config')['uitpas']['labels'],
                 $container->get(DuplicatePlaceRepository::class),
                 $container->get(EventRelationsRepository::class),
                 new DBALReadRepository(

--- a/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
@@ -29,20 +29,20 @@ class DBALReadRepository extends AbstractDBALRepository implements ReadRepositor
         }
     }
 
-    public function getLabelRelationsForTypes(array $labelNames, RelationType $relationType): array
+    public function getLabelsRelationsForType(array $labelNames, RelationType $relationType): array
     {
-        if (empty($labelNames)) {
+       if (empty($labelNames)) {
             return [];
         }
 
-        $placeholders = implode(',', array_fill(0, count($labelNames), '?'));
-        $whereLabelNames = ColumnNames::LABEL_NAME . " IN ($placeholders)";
-
         return $this->createQueryBuilder()->select(ColumnNames::RELATION_ID)
             ->from($this->getTableName())
-            ->where($whereLabelNames)
-            ->andWhere(ColumnNames::RELATION_TYPE . ' = ?')
-            ->setParameters(array_merge($labelNames, [$relationType->toString()]))
+            ->where($this->createQueryBuilder()->expr()->in(ColumnNames::LABEL_NAME, ':labelNames'))
+            ->andWhere(ColumnNames::RELATION_TYPE . ' = :relationType')
+            ->setParameters([
+                'labelNames' => $labelNames,
+                'relationType' => $relationType->toString()
+            ])
             ->execute()
             ->fetchFirstColumn();
     }

--- a/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
@@ -29,6 +29,24 @@ class DBALReadRepository extends AbstractDBALRepository implements ReadRepositor
         }
     }
 
+    public function getLabelRelationsForTypes(array $labelNames, RelationType $relationType): array
+    {
+        if (empty($labelNames)) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($labelNames), '?'));
+        $whereLabelNames = ColumnNames::LABEL_NAME . " IN ($placeholders)";
+
+        return $this->createQueryBuilder()->select(ColumnNames::RELATION_ID)
+            ->from($this->getTableName())
+            ->where($whereLabelNames)
+            ->andWhere(ColumnNames::RELATION_TYPE . ' = ?')
+            ->setParameters(array_merge($labelNames, [$relationType->toString()]))
+            ->execute()
+            ->fetchFirstColumn();
+    }
+
     public function getLabelRelationsForType(string $labelName, RelationType $relationType): array
     {
         $whereLabelName = ColumnNames::LABEL_NAME . ' = ?';

--- a/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\LabelRelation;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
+use Doctrine\DBAL\Connection;
 
 class DBALReadRepository extends AbstractDBALRepository implements ReadRepositoryInterface
 {
@@ -31,33 +32,30 @@ class DBALReadRepository extends AbstractDBALRepository implements ReadRepositor
 
     public function getLabelsRelationsForType(array $labelNames, RelationType $relationType): array
     {
-       if (empty($labelNames)) {
+        if (empty($labelNames)) {
             return [];
         }
 
-        return $this->createQueryBuilder()->select(ColumnNames::RELATION_ID)
+        $qb = $this->createQueryBuilder();
+
+        return $qb->select(ColumnNames::RELATION_ID)
             ->from($this->getTableName())
-            ->where($this->createQueryBuilder()->expr()->in(ColumnNames::LABEL_NAME, ':labelNames'))
-            ->andWhere(ColumnNames::RELATION_TYPE . ' = :relationType')
-            ->setParameters([
-                'labelNames' => $labelNames,
-                'relationType' => $relationType->toString()
-            ])
+            ->where(
+                $qb->expr()->in(
+                    ColumnNames::LABEL_NAME,
+                    $qb->createNamedParameter($labelNames, Connection::PARAM_STR_ARRAY)
+                )
+            )
+            ->andWhere($qb->expr()->eq(ColumnNames::RELATION_TYPE, ':relationType'))
+            ->setParameter('relationType', $relationType->toString())
             ->execute()
             ->fetchFirstColumn();
     }
 
+    // Alias for single label lookup
     public function getLabelRelationsForType(string $labelName, RelationType $relationType): array
     {
-        $whereLabelName = ColumnNames::LABEL_NAME . ' = ?';
-
-        return $this->createQueryBuilder()->select(ColumnNames::RELATION_ID)
-            ->from($this->getTableName())
-            ->where($whereLabelName)
-            ->andWhere(ColumnNames::RELATION_TYPE . ' = ?')
-            ->setParameters([$labelName, $relationType->toString()])
-            ->execute()
-            ->fetchFirstColumn();
+        return $this->getLabelsRelationsForType([$labelName], $relationType);
     }
 
     public function getLabelRelationsForItem(string $relationId): array

--- a/src/Label/ReadModels/Relations/Repository/ReadRepositoryInterface.php
+++ b/src/Label/ReadModels/Relations/Repository/ReadRepositoryInterface.php
@@ -17,7 +17,7 @@ interface ReadRepositoryInterface
      * @return string[]
      */
     public function getLabelRelationsForType(string $labelName, RelationType $relationType): array;
-    public function getLabelRelationsForTypes(array $labelNames, RelationType $relationType): array;
+    public function getLabelsRelationsForType(array $labelNames, RelationType $relationType): array;
 
 
     /**

--- a/src/Label/ReadModels/Relations/Repository/ReadRepositoryInterface.php
+++ b/src/Label/ReadModels/Relations/Repository/ReadRepositoryInterface.php
@@ -17,6 +17,8 @@ interface ReadRepositoryInterface
      * @return string[]
      */
     public function getLabelRelationsForType(string $labelName, RelationType $relationType): array;
+    public function getLabelRelationsForTypes(array $labelNames, RelationType $relationType): array;
+
 
     /**
      * @return LabelRelation[]

--- a/src/Place/Canonical/CanonicalService.php
+++ b/src/Place/Canonical/CanonicalService.php
@@ -86,7 +86,7 @@ class CanonicalService
 
     private function getPlacesWithUiTPasInCluster(array $placeIds): array
     {
-        $result = $this->labelRelationsRepository->getLabelRelationsForTypes(
+        $result = $this->labelRelationsRepository->getLabelsRelationsForType(
             $this->uitpasLabels,
             RelationType::place()
         );

--- a/src/Place/Canonical/CanonicalService.php
+++ b/src/Place/Canonical/CanonicalService.php
@@ -7,12 +7,17 @@ namespace CultuurNet\UDB3\Place\Canonical;
 use CultuurNet\UDB3\Event\ReadModel\Relations\EventRelationsRepository;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
+use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
+use CultuurNet\UDB3\Place\Canonical\Exception\MuseumPassAndUiTPassInSameCluster;
 use CultuurNet\UDB3\Place\Canonical\Exception\MuseumPassNotUniqueInCluster;
+use CultuurNet\UDB3\Place\Canonical\Exception\UiTPassNotUniqueInCluster;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 
 class CanonicalService
 {
     private string $museumpasLabel;
+    private array $uitpasLabels;
 
     private DuplicatePlaceRepository $duplicatePlaceRepository;
 
@@ -24,26 +29,31 @@ class CanonicalService
 
     public function __construct(
         string $museumpasLabel,
+        array $uitpasLabels,
         DuplicatePlaceRepository $duplicatePlaceRepository,
         EventRelationsRepository $eventRelationsRepository,
         ReadRepositoryInterface $labelRelationsRepository,
         DocumentRepository $placeRepository
     ) {
         $this->museumpasLabel = $museumpasLabel;
+        $this->uitpasLabels = $uitpasLabels;
         $this->duplicatePlaceRepository = $duplicatePlaceRepository;
         $this->eventRelationsRepository = $eventRelationsRepository;
         $this->labelRelationsRepository = $labelRelationsRepository;
         $this->placeRepository = $placeRepository;
     }
 
-    /**
-     * @throws MuseumPassNotUniqueInCluster
-     */
     public function getCanonical(string $clusterId): string
     {
         $placeIds = $this->duplicatePlaceRepository->getPlacesInCluster($clusterId);
 
         $placesWithMuseumpas = $this->getPlacesWithMuseumPasInCluster($placeIds);
+        $placesWithUiTPas = $this->getPlacesWithUiTPasInCluster($placeIds);
+
+        if (count($placesWithMuseumpas) > 0 && count($placesWithUiTPas) > 0) {
+            throw new MuseumPassAndUiTPassInSameCluster($clusterId, count($placesWithMuseumpas), count($placesWithUiTPas));
+        }
+
         if (count($placesWithMuseumpas) === 1) {
             return $placesWithMuseumpas[array_key_first($placesWithMuseumpas)];
         }
@@ -51,6 +61,13 @@ class CanonicalService
             throw new MuseumPassNotUniqueInCluster($clusterId, count($placesWithMuseumpas));
         }
 
+        if (count($placesWithUiTPas) === 1) {
+            return $placesWithUiTPas[array_key_first($placesWithUiTPas)];
+        }
+        if (count($placesWithUiTPas) > 1) {
+            throw new UiTPassNotUniqueInCluster($clusterId, count($placesWithUiTPas));
+        }
+        
         $placesWithMostEvents = $this->getPlacesWithMostEvents($placeIds);
         if (count($placesWithMostEvents) === 1) {
             return $placesWithMostEvents[array_key_first($placesWithMostEvents)];
@@ -63,6 +80,16 @@ class CanonicalService
     {
         $result = $this->labelRelationsRepository->getLabelRelationsForType(
             $this->museumpasLabel,
+            RelationType::place()
+        );
+
+        return array_intersect($placeIds, $result);
+    }
+
+    private function getPlacesWithUiTPasInCluster(array $placeIds): array
+    {
+        $result = $this->labelRelationsRepository->getLabelRelationsForTypes(
+            $this->uitpasLabels,
             RelationType::place()
         );
 

--- a/src/Place/Canonical/CanonicalService.php
+++ b/src/Place/Canonical/CanonicalService.php
@@ -7,11 +7,9 @@ namespace CultuurNet\UDB3\Place\Canonical;
 use CultuurNet\UDB3\Event\ReadModel\Relations\EventRelationsRepository;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
-use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\Place\Canonical\Exception\MuseumPassAndUiTPassInSameCluster;
 use CultuurNet\UDB3\Place\Canonical\Exception\MuseumPassNotUniqueInCluster;
 use CultuurNet\UDB3\Place\Canonical\Exception\UiTPassNotUniqueInCluster;
-use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 
 class CanonicalService
@@ -67,7 +65,7 @@ class CanonicalService
         if (count($placesWithUiTPas) > 1) {
             throw new UiTPassNotUniqueInCluster($clusterId, count($placesWithUiTPas));
         }
-        
+
         $placesWithMostEvents = $this->getPlacesWithMostEvents($placeIds);
         if (count($placesWithMostEvents) === 1) {
             return $placesWithMostEvents[array_key_first($placesWithMostEvents)];

--- a/src/Place/Canonical/Exception/MuseumPassAndUiTPassInSameCluster.php
+++ b/src/Place/Canonical/Exception/MuseumPassAndUiTPassInSameCluster.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Place\Canonical\Exception;
+
+class MuseumPassAndUiTPassInSameCluster extends \Exception
+{
+    public function __construct(string $clusterId, int $amountMuseumpass, int $amountUiTPass)
+    {
+        parent::__construct(sprintf('Cluster %s contains %d MuseumPass places and %d UiTPAS places', $clusterId, $amountMuseumpass, $amountUiTPass));
+    }
+}

--- a/src/Place/Canonical/Exception/UiTPassNotUniqueInCluster.php
+++ b/src/Place/Canonical/Exception/UiTPassNotUniqueInCluster.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Place\Canonical\Exception;
 
-class MuseumPassNotUniqueInCluster extends \Exception
+class UiTPassNotUniqueInCluster extends \Exception
 {
     public function __construct(string $clusterId, int $amountMuseumpass)
     {
-        parent::__construct(sprintf('Cluster %s contains %d MuseumPass places', $clusterId, $amountMuseumpass));
+        parent::__construct(sprintf('Cluster %s contains %d UiTPAS places', $clusterId, $amountMuseumpass));
     }
 }

--- a/tests/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepositoryTest.php
+++ b/tests/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepositoryTest.php
@@ -105,6 +105,27 @@ class DBALReadRepositoryTest extends BaseDBALRepositoryTest
         );
     }
 
+    /**
+     * @test
+     */
+    public function it_should_return_offers_by_multiple_labels_for_type(): void
+    {
+        $labelRelationsForType = $this->readRepository->getLabelsRelationsForType(
+            ['cultuurnet', '2dotstwice'],
+            RelationType::place()
+        );
+
+        $this->assertEquals(
+            [
+                '99A78F44-A45B-40E2-A1E3-7632D2F3B1C6',
+                'A9B3FA7B-9AF5-49F4-8BB5-2B169CE83107',
+                '298A39A1-8D1E-4F5D-B05E-811B6459EA36',
+                '99A78F44-A45B-40E2-A1E3-7632D2F3B1C6',
+            ],
+            $labelRelationsForType
+        );
+    }
+
     private function saveOfferLabelRelations(): void
     {
         $labelName = '2dotstwice';


### PR DESCRIPTION
### Changed
Change the canonical place algoritme in the following way:

Check if there is an UiTPAS location, in which case, pick it as the canonical place.
If there are more then 1 UiTPAS location, throw an error (like we already do for Museumpass)
If there is an UiTPAS location AND an Museumpass location (and they are not the same place), also throw an error.

---

Ticket: https://jira.uitdatabank.be/browse/III-6777
