### PR TITLE
III-6795 Missing creator fallback

### DIFF
--- a/src/Http/Organizer/GetCreatorRequestHandler.php
+++ b/src/Http/Organizer/GetCreatorRequestHandler.php
@@ -50,6 +50,10 @@ final class GetCreatorRequestHandler implements RequestHandlerInterface
 
             $organizer = $this->organizerRepository->fetch($organizerId);
 
+            if (!property_exists($organizer->getBody(), 'creator')) {
+                throw ApiProblem::resourceNotFound('Creator', 'unknown');
+            }
+
             $creatorId = $organizer->getBody()->creator;
             $creator = $this->userIdentityResolver->getUserById($creatorId);
 


### PR DESCRIPTION
### Fixed
- When an old organizer does not have a creator, the organizer-id/creator call fails. This PR sends a clean 404 HTTP error instead of a crash.

### Next steps
- This is not the final fix, because we need to see how the frontend handles this endpoint, and they will need to handle this new 404 error. See ticket https://jira.publiq.be/browse/III-6801

---

Ticket: https://jira.uitdatabank.be/browse/III-6795 