### PR TITLE
III-6730 Add implicit Ownership for the creator of an Organizer

### DIFF
--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -72,6 +72,7 @@ use CultuurNet\UDB3\Search\EventsSapi3SearchService;
 use CultuurNet\UDB3\Search\OffersSapi3SearchService;
 use CultuurNet\UDB3\Search\OrganizersSapi3SearchService;
 use CultuurNet\UDB3\Search\PlacesSapi3SearchService;
+use CultuurNet\UDB3\Security\OfferSecurityServiceProvider;
 use CultuurNet\UDB3\User\Keycloak\CachedUserIdentityResolver;
 use Google_Client;
 use Google_Service_YouTube;
@@ -363,7 +364,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
             'console.offer:change-owner-bulk',
             fn () => new ChangeOfferOwnerInBulk(
                 $container->get('event_command_bus'),
-                $container->get('offer_creator_query')
+                $container->get(OfferSecurityServiceProvider::OFFER_CREATOR_QUERY)
             )
         );
 

--- a/app/Console/ConsoleServiceProvider.php
+++ b/app/Console/ConsoleServiceProvider.php
@@ -363,7 +363,7 @@ final class ConsoleServiceProvider extends AbstractServiceProvider
             'console.offer:change-owner-bulk',
             fn () => new ChangeOfferOwnerInBulk(
                 $container->get('event_command_bus'),
-                $container->get('offer_owner_query')
+                $container->get('offer_creator_query')
             )
         );
 

--- a/app/Event/EventPermissionServiceProvider.php
+++ b/app/Event/EventPermissionServiceProvider.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Event\ReadModel\Permission\Projector;
 use CultuurNet\UDB3\Security\ResourceOwner\Doctrine\DBALResourceOwnerRepository;
+use CultuurNet\UDB3\Security\ResourceOwner\Doctrine\DBALResourceRelatedOwnerRepository;
 
 final class EventPermissionServiceProvider extends AbstractServiceProvider
 {
@@ -14,6 +15,7 @@ final class EventPermissionServiceProvider extends AbstractServiceProvider
     {
         return [
             'event_owner.repository',
+            'event_organizer_owner.repository',
             'event_permission.projector',
         ];
     }
@@ -29,6 +31,18 @@ final class EventPermissionServiceProvider extends AbstractServiceProvider
                     'event_permission_readmodel',
                     $container->get('dbal_connection'),
                     'event_id'
+                );
+            }
+        );
+
+        $container->addShared(
+            'event_organizer_owner.repository',
+            function () use ($container): DBALResourceRelatedOwnerRepository {
+                return new DBALResourceRelatedOwnerRepository(
+                    'organizer_permission_readmodel',
+                    'event_relations',
+                    $container->get('dbal_connection'),
+                    'event'
                 );
             }
         );

--- a/app/Event/EventPermissionServiceProvider.php
+++ b/app/Event/EventPermissionServiceProvider.php
@@ -11,12 +11,16 @@ use CultuurNet\UDB3\Security\ResourceOwner\Doctrine\DBALResourceRelatedOwnerRepo
 
 final class EventPermissionServiceProvider extends AbstractServiceProvider
 {
+    public const EVENT_OWNER_REPOSITORY = 'event_owner.repository';
+    public const EVENT_ORGANIZER_OWNER_REPOSITORY = 'event_organizer_owner.repository';
+    public const EVENT_PERMISSION_PROJECTOR = 'event_permission.projector';
+
     protected function getProvidedServiceNames(): array
     {
         return [
-            'event_owner.repository',
-            'event_organizer_owner.repository',
-            'event_permission.projector',
+            self::EVENT_OWNER_REPOSITORY,
+            self::EVENT_ORGANIZER_OWNER_REPOSITORY,
+            self::EVENT_PERMISSION_PROJECTOR,
         ];
     }
 
@@ -25,7 +29,7 @@ final class EventPermissionServiceProvider extends AbstractServiceProvider
         $container = $this->getContainer();
 
         $container->addShared(
-            'event_owner.repository',
+            self::EVENT_OWNER_REPOSITORY,
             function () use ($container): DBALResourceOwnerRepository {
                 return new DBALResourceOwnerRepository(
                     'event_permission_readmodel',
@@ -36,7 +40,7 @@ final class EventPermissionServiceProvider extends AbstractServiceProvider
         );
 
         $container->addShared(
-            'event_organizer_owner.repository',
+            self::EVENT_ORGANIZER_OWNER_REPOSITORY,
             function () use ($container): DBALResourceRelatedOwnerRepository {
                 return new DBALResourceRelatedOwnerRepository(
                     'organizer_permission_readmodel',
@@ -48,10 +52,10 @@ final class EventPermissionServiceProvider extends AbstractServiceProvider
         );
 
         $container->addShared(
-            'event_permission.projector',
+            self::EVENT_PERMISSION_PROJECTOR,
             function () use ($container): Projector {
                 return new Projector(
-                    $container->get('event_owner.repository'),
+                    $container->get(EventPermissionServiceProvider::EVENT_OWNER_REPOSITORY),
                     $container->get('cdbxml_created_by_resolver'),
                 );
             }

--- a/app/EventBus/EventBusServiceProvider.php
+++ b/app/EventBus/EventBusServiceProvider.php
@@ -8,6 +8,7 @@ use Broadway\EventHandling\EventBus;
 use CultuurNet\UDB3\Broadway\AMQP\AMQPPublisher;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Event\EventJSONLDServiceProvider;
+use CultuurNet\UDB3\Event\EventPermissionServiceProvider;
 use CultuurNet\UDB3\Event\ReadModel\History\EventPlaceHistoryProjector;
 use CultuurNet\UDB3\Event\ReadModel\History\HistoryProjector as EventHistoryProjector;
 use CultuurNet\UDB3\Event\ReadModel\Relations\EventRelationsProjector;
@@ -64,7 +65,7 @@ final class EventBusServiceProvider extends AbstractServiceProvider
                             OrganizerJSONLDServiceProvider::PROJECTOR,
                             RelatedDocumentProjectedToJSONLDDispatcher::class,
                             'event_calendar_projector',
-                            'event_permission.projector',
+                            EventPermissionServiceProvider::EVENT_PERMISSION_PROJECTOR,
                             'place_permission.projector',
                             OrganizerPermissionServiceProvider::PERMISSION_PROJECTOR,
                             AMQPPublisher::class,

--- a/app/Offer/OfferServiceProvider.php
+++ b/app/Offer/OfferServiceProvider.php
@@ -91,6 +91,7 @@ use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataRepository;
 use CultuurNet\UDB3\Place\ReadModel\RDF\PlaceJsonToTurtleConverter;
 use CultuurNet\UDB3\Place\ReadModel\Relations\PlaceRelationsRepository;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\OfferSecurityServiceProvider;
 use CultuurNet\UDB3\Security\Permission\DeleteUiTPASPlaceVoter;
 use CultuurNet\UDB3\UiTPAS\Validation\EventHasTicketSalesGuard;
 use CultuurNet\UDB3\User\CurrentUser;
@@ -294,7 +295,7 @@ final class OfferServiceProvider extends AbstractServiceProvider
             ChangeOwnerHandler::class,
             fn () => new ChangeOwnerHandler(
                 $container->get(OfferRepository::class),
-                $container->get('offer_creator_query')
+                $container->get(OfferSecurityServiceProvider::OFFER_CREATOR_QUERY)
             )
         );
 

--- a/app/Offer/OfferServiceProvider.php
+++ b/app/Offer/OfferServiceProvider.php
@@ -294,7 +294,7 @@ final class OfferServiceProvider extends AbstractServiceProvider
             ChangeOwnerHandler::class,
             fn () => new ChangeOwnerHandler(
                 $container->get(OfferRepository::class),
-                $container->get('offer_owner_query')
+                $container->get('offer_creator_query')
             )
         );
 

--- a/app/Security/OfferSecurityServiceProvider.php
+++ b/app/Security/OfferSecurityServiceProvider.php
@@ -19,10 +19,12 @@ use Http\Adapter\Guzzle7\Client;
 
 final class OfferSecurityServiceProvider extends AbstractServiceProvider
 {
+    public const OFFER_CREATOR_QUERY = 'offer_creator_query';
+
     protected function getProvidedServiceNames(): array
     {
         return [
-            'offer_creator_query',
+            self::OFFER_CREATOR_QUERY,
             'offer_permission_voter',
             DeleteUiTPASPlaceVoter::class,
         ];
@@ -33,7 +35,7 @@ final class OfferSecurityServiceProvider extends AbstractServiceProvider
         $container = $this->getContainer();
 
         $container->addShared(
-            'offer_creator_query',
+            self::OFFER_CREATOR_QUERY,
             fn () => new CombinedResourceOwnerQuery([
                 $container->get(EventPermissionServiceProvider::EVENT_OWNER_REPOSITORY),
                 $container->get(EventPermissionServiceProvider::EVENT_ORGANIZER_OWNER_REPOSITORY),
@@ -46,7 +48,7 @@ final class OfferSecurityServiceProvider extends AbstractServiceProvider
             fn () => new AnyOfVoter(
                 $container->get('god_user_voter'),
                 new ResourceOwnerVoter(
-                    $container->get('offer_owner_query'),
+                    $container->get(self::OFFER_CREATOR_QUERY),
                     $container->get(ApiName::class) !== ApiName::CLI
                 ),
                 new ContributorVoter(

--- a/app/Security/OfferSecurityServiceProvider.php
+++ b/app/Security/OfferSecurityServiceProvider.php
@@ -40,7 +40,6 @@ final class OfferSecurityServiceProvider extends AbstractServiceProvider
             self::OFFER_CREATOR_QUERY,
             fn () => new CombinedResourceOwnerQuery([
                 $container->get(EventPermissionServiceProvider::EVENT_OWNER_REPOSITORY),
-                $container->get(EventPermissionServiceProvider::EVENT_ORGANIZER_OWNER_REPOSITORY),
                 $container->get('place_owner.repository'),
             ])
         );

--- a/app/Security/OfferSecurityServiceProvider.php
+++ b/app/Security/OfferSecurityServiceProvider.php
@@ -22,7 +22,7 @@ final class OfferSecurityServiceProvider extends AbstractServiceProvider
     protected function getProvidedServiceNames(): array
     {
         return [
-            'offer_owner_query',
+            'offer_creator_query',
             'offer_permission_voter',
             DeleteUiTPASPlaceVoter::class,
         ];
@@ -33,7 +33,7 @@ final class OfferSecurityServiceProvider extends AbstractServiceProvider
         $container = $this->getContainer();
 
         $container->addShared(
-            'offer_owner_query',
+            'offer_creator_query',
             fn () => new CombinedResourceOwnerQuery([
                 $container->get(EventPermissionServiceProvider::EVENT_OWNER_REPOSITORY),
                 $container->get(EventPermissionServiceProvider::EVENT_ORGANIZER_OWNER_REPOSITORY),

--- a/app/Security/OfferSecurityServiceProvider.php
+++ b/app/Security/OfferSecurityServiceProvider.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Security;
 use CultuurNet\UDB3\ApiName;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Contributor\ContributorRepository;
+use CultuurNet\UDB3\Event\EventPermissionServiceProvider;
 use CultuurNet\UDB3\Security\Permission\AnyOfVoter;
 use CultuurNet\UDB3\Security\Permission\ContributorVoter;
 use CultuurNet\UDB3\Security\Permission\DeleteUiTPASPlaceVoter;
@@ -34,8 +35,8 @@ final class OfferSecurityServiceProvider extends AbstractServiceProvider
         $container->addShared(
             'offer_owner_query',
             fn () => new CombinedResourceOwnerQuery([
-                $container->get('event_owner.repository'),
-                $container->get('event_organizer_owner.repository'),
+                $container->get(EventPermissionServiceProvider::EVENT_OWNER_REPOSITORY),
+                $container->get(EventPermissionServiceProvider::EVENT_ORGANIZER_OWNER_REPOSITORY),
                 $container->get('place_owner.repository'),
             ])
         );

--- a/app/Security/OfferSecurityServiceProvider.php
+++ b/app/Security/OfferSecurityServiceProvider.php
@@ -20,12 +20,13 @@ use Http\Adapter\Guzzle7\Client;
 final class OfferSecurityServiceProvider extends AbstractServiceProvider
 {
     public const OFFER_CREATOR_QUERY = 'offer_creator_query';
-    public const OFFER_CREATOR_WITH_ORGANIZERS_QUERY = 'offer_creator_with_organizers_query';
+    private const OFFER_CREATOR_WITH_ORGANIZERS_QUERY = 'offer_creator_with_organizers_query';
 
     protected function getProvidedServiceNames(): array
     {
         return [
             self::OFFER_CREATOR_QUERY,
+            self::OFFER_CREATOR_WITH_ORGANIZERS_QUERY,
             'offer_permission_voter',
             DeleteUiTPASPlaceVoter::class,
         ];

--- a/app/Security/OfferSecurityServiceProvider.php
+++ b/app/Security/OfferSecurityServiceProvider.php
@@ -35,6 +35,7 @@ final class OfferSecurityServiceProvider extends AbstractServiceProvider
             'offer_owner_query',
             fn () => new CombinedResourceOwnerQuery([
                 $container->get('event_owner.repository'),
+                $container->get('event_organizer_owner.repository'),
                 $container->get('place_owner.repository'),
             ])
         );

--- a/features/data/events/event-minimal-permanent-with-organizer-updated.json
+++ b/features/data/events/event-minimal-permanent-with-organizer-updated.json
@@ -1,0 +1,20 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Permanent event UPDATED"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{placeUrl}"
+  },
+  "calendarType": "permanent",
+  "organizer": {
+    "@id": "%{organizerUrl}"
+  }
+}

--- a/features/event/implicit-ownership.feature
+++ b/features/event/implicit-ownership.feature
@@ -1,0 +1,18 @@
+Feature: Test the UDB3 implicit ownership for the creator of an organizer
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider user "invoerder"
+    And I send and accept "application/json"
+    And I create a minimal organizer and save the "url" as "organizerUrl"
+    And I create a minimal place and save the "url" as "placeUrl"
+
+  Scenario: Get implicit ownership for the creator of an event with an organizer
+    When I am authorized as JWT provider user "invoerder_1"
+    And I create an event from "events/event-minimal-permanent-with-organizer.json" and save the "url" as "eventUrl"
+    And I am authorized as JWT provider user "invoerder"
+    And I update the event at "%{eventUrl}" from "events/event-minimal-permanent-with-organizer-updated.json"
+    Then the response status should be "200"
+    And I get the event at "%{eventUrl}"
+    Then the JSON response at "name/nl" should be "Permanent event UPDATED"

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceRelatedOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceRelatedOwnerRepository.php
@@ -47,7 +47,7 @@ final class DBALResourceRelatedOwnerRepository implements ResourceOwnerQuery
 
         $events = [];
         while ($id = $results->fetchColumn(0)) {
-            $events[] =$id;
+            $events[] = $id;
         }
 
         return $events;

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceRelatedOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceRelatedOwnerRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Security\ResourceOwner\Doctrine;
+
+use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
+use Doctrine\DBAL\Connection;
+
+final class DBALResourceRelatedOwnerRepository implements ResourceOwnerQuery
+{
+    private Connection $connection;
+
+    private string $idField;
+
+    private string $organizersTable;
+
+    private string $relationsTable;
+
+    public function __construct(
+        string $organizersTable,
+        string $relationsTable,
+        Connection $connection,
+        string $idField
+    ) {
+        $this->organizersTable = $organizersTable;
+        $this->relationsTable = $relationsTable;
+        $this->connection = $connection;
+        $this->idField = $idField;
+    }
+
+    public function getEditableResourceIds(string $userId): array
+    {
+        $q = $this->connection->createQueryBuilder();
+        $q->select($this->idField)
+            ->from($this->relationsTable, 'r')
+            ->innerJoin(
+                'r',
+                $this->organizersTable,
+                'o',
+                'r.organizer = o.organizer_id'
+            )
+            ->where('o.user_id = :userId')
+            ->setParameter(':userId', $userId);
+
+        $results = $q->execute();
+
+        $events = [];
+        while ($id = $results->fetchColumn(0)) {
+            $events[] =$id;
+        }
+
+        return $events;
+    }
+}

--- a/tests/Security/ResourceOwner/Doctrine/DBALResourceRelatedOwnerRepositoryTest.php
+++ b/tests/Security/ResourceOwner/Doctrine/DBALResourceRelatedOwnerRepositoryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Security\ResourceOwner\Doctrine;
+
+use CultuurNet\UDB3\DBALTestConnectionTrait;
+use CultuurNet\UDB3\Model\ValueObject\Identity\Uuid;
+use PHPUnit\Framework\TestCase;
+
+final class DBALResourceRelatedOwnerRepositoryTest extends TestCase
+{
+    use DBALTestConnectionTrait;
+
+    private DBALResourceRelatedOwnerRepository $repository;
+
+    private string $organizersTable;
+
+    private string $relationsTable;
+
+    private string $organizerCreator;
+
+    public function setUp(): void
+    {
+        $this->setUpDatabase();
+
+        $this->organizerCreator = Uuid::uuid4()->toString();
+
+        $this->organizersTable = 'organizer_permission_readmodel';
+        $this->relationsTable = 'event_relations';
+
+        $idField = 'event';
+
+        $this->repository = new DBALResourceRelatedOwnerRepository(
+            $this->organizersTable,
+            $this->relationsTable,
+            $this->getConnection(),
+            $idField
+        );
+
+        $this->seedOrganizers();
+        $this->seedRelations();
+    }
+
+    /**
+     * @test
+     */
+    public function testGetEditableResourceIds(): void
+    {
+        $this->assertEquals(
+            ['event1', 'event3'],
+            $this->repository->getEditableResourceIds($this->organizerCreator)
+        );
+    }
+
+    private function seedOrganizers(): void
+    {
+        $this->insertOrganizer('organizer1', $this->organizerCreator);
+        $this->insertOrganizer('organizer2', Uuid::uuid4()->toString());
+        $this->insertOrganizer('organizer3', $this->organizerCreator);
+    }
+
+    private function seedRelations(): void
+    {
+        $this->insertRelation('event1', 'organizer1');
+        $this->insertRelation('event2', 'organizer2');
+        $this->insertRelation('event3', 'organizer3');
+        $this->insertRelation('event4', null, 'place1');
+    }
+
+    private function insertOrganizer(string $organizerId, string $userId): void
+    {
+        $this->getConnection()->insert(
+            $this->organizersTable,
+            [
+                'organizer_id' => $organizerId,
+                'user_id' => $userId,
+            ]
+        );
+    }
+
+    private function insertRelation(string $eventId, string $organizerId = null, string $placeId = null): void
+    {
+        $this->getConnection()->insert(
+            $this->relationsTable,
+            [
+                'event' => $eventId,
+                'organizer' => $organizerId,
+                'place' => $placeId,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
### Added

- `DBALResourceRelatedOwnerRepository`: new `Repository` to find events that have an `Organizer` with a certain `creator`
- `DBALResourceRelatedOwnerRepositoryTest`: `UnitTest` for new `Repository`
- `event-minimal-permanent-with-organizer-updated.json`: new data file for use in `acceptance tests`
- `event/implicit-ownership.feature`: Add acceptance test for new implicit `Ownership`.

### Changed

- `EventPermissionServiceProvider`: Register new `Repository`
- `OfferSecurityServiceProvider`: Add new `Repository` to `CombinedResourceOwnerQuery`

### Fixed

- `Creators` of an `Organizer` now have implicit `Ownership` of the `events` that are organized by the `Organizer`

---

Ticket: https://jira.publiq.be/browse/III-6730
